### PR TITLE
hydro ''qol'' changes (straight buffs)

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -110,8 +110,8 @@
 
 
 	if(harvest)
-		cycledelay = initial(cycledelay) + 2 MINUTES
-	else if(cycledelay > 2 MINUTES)
+		cycledelay = initial(cycledelay) + 5 MINUTES
+	else if(cycledelay > 5 MINUTES)
 		cycledelay = initial(cycledelay)
 
 	if(world.time > (lastcycle + cycledelay))
@@ -454,7 +454,7 @@
 	age = 0
 	plant_health = myseed.endurance
 	lastcycle = world.time
-	if(cycledelay > 2 MINUTES)
+	if(cycledelay > 5 MINUTES)
 		cycledelay = initial(cycledelay)
 	harvest = 0
 	weedlevel = 0 // Reset
@@ -493,7 +493,7 @@
 	age = 0
 	plant_health = myseed.endurance
 	lastcycle = world.time
-	if(cycledelay > 2 MINUTES)
+	if(cycledelay > 5 MINUTES)
 		cycledelay = initial(cycledelay)
 	harvest = 0
 	weedlevel = 0 // Reset
@@ -515,7 +515,7 @@
 		age = 0
 		plant_health = myseed.endurance
 		lastcycle = world.time
-		if(cycledelay > 2 MINUTES)
+		if(cycledelay > 5 MINUTES)
 			cycledelay = initial(cycledelay)
 		harvest = 0
 		weedlevel = 0 // Reset
@@ -535,7 +535,7 @@
 /obj/machinery/hydroponics/proc/plantdies()
 	plant_health = 0
 	harvest = FALSE
-	if(cycledelay > 2 MINUTES)
+	if(cycledelay > 5 MINUTES)
 		cycledelay = initial(cycledelay)
 	pestlevel = 0 // Pests die
 	lastproduce = 0
@@ -698,7 +698,7 @@
 				plant_health = 0
 				if(harvest)
 					harvest = FALSE //To make sure they can't just put in another seed and insta-harvest it
-				if(cycledelay > 2 MINUTES)
+				if(cycledelay > 5 MINUTES)
 					cycledelay = initial(cycledelay)
 				qdel(myseed)
 				myseed = null
@@ -765,7 +765,7 @@
 
 /obj/machinery/hydroponics/proc/update_tray(mob/user)
 	harvest = FALSE
-	if(cycledelay > 2 MINUTES)
+	if(cycledelay > 5 MINUTES)
 		cycledelay = initial(cycledelay)
 	lastproduce = age
 	if(myseed.getYield() <= 0)
@@ -803,11 +803,9 @@
 	weedlevel = clamp(weedlevel + adjustamt, 0, 10)
 
 /obj/machinery/hydroponics/proc/adjustSelfSuff(adjustamt)
-	if(self_sustainingprog>19)
+	self_sustainingprog += adjustamt
+	if(self_sustainingprog>19 && !self_sustaining)
 		become_self_sufficient()
-	else
-		self_sustainingprog += adjustamt
-
 /obj/machinery/hydroponics/proc/spawnplant() // why would you put strange reagent in a hydro tray you monster I bet you also feed them blood
 	var/list/livingplants = list(/mob/living/simple_animal/hostile/tree, /mob/living/simple_animal/hostile/killertomato)
 	var/chosen = pick(livingplants)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -9,7 +9,7 @@
 	idle_power_usage = 0
 	var/waterlevel = 100	//The amount of water in the tray (max 100)
 	var/maxwater = 100		//The maximum amount of water in the tray
-	var/nutridrain = 0.3      // How many units of nutrient will be drained in the tray //test //lowering it even further
+	var/nutridrain = 0.075      // How many units of nutrient will be drained in the tray //test //lowering it even further
 	var/maxnutri = 10		//The maximum nutrient of water in the tray
 	var/pestlevel = 0		//The amount of pests in the tray (max 10)
 	var/weedlevel = 0		//The amount of weeds in the tray (max 10)
@@ -21,7 +21,7 @@
 	var/plant_health		//Its health
 	var/lastproduce = 0		//Last time it was harvested
 	var/lastcycle = 0		//Used for timing of cycles.
-	var/cycledelay = 200	//About 10 seconds / cycle
+	var/cycledelay = 10 SECONDS	// 10 seconds / cycle
 	var/harvest = FALSE			//Ready to harvest?
 	var/obj/item/seeds/myseed = null	//The currently planted seed
 	var/rating = 1
@@ -104,9 +104,15 @@
 		myseed.forceMove(src)
 
 	else if(self_sustaining)
-		adjustWater(5)
+		adjustWater(10)
 		adjustWeeds(-5)
 		adjustPests(-5)
+
+
+	if(harvest)
+		cycledelay = initial(cycledelay) + 2 MINUTES
+	else if(cycledelay > 2 MINUTES)
+		cycledelay = initial(cycledelay)
 
 	if(world.time > (lastcycle + cycledelay))
 		lastcycle = world.time
@@ -127,6 +133,7 @@
 			else
 				reagents.remove_any(nutridrain)
 
+
 			// Lack of nutrients hurts non-weeds
 			if(reagents.total_volume <= 0 && !myseed.get_gene(/datum/plant_gene/trait/plant_type/weed_hardy))
 				adjustHealth(-rand(1,3))
@@ -145,7 +152,7 @@
 
 //Water//////////////////////////////////////////////////////////////////
 			// Drink random amount of water
-			adjustWater(-rand(1,3) / rating)//6
+			adjustWater(-rand(1,2) / rating)//6
 
 			// If the plant is dry, it loses health pretty fast, unless mushroom
 			if(waterlevel <= 10 && !myseed.get_gene(/datum/plant_gene/trait/plant_type/fungal_metabolism))
@@ -158,7 +165,7 @@
 				adjustHealth(rand(1,2) / rating)
 				if(myseed && prob(myseed.weed_chance))
 					adjustWeeds(myseed.weed_rate)
-				else if(prob(2))  //5 percent chance the weed population will increase
+				else if(prob(2))  //2 percent chance the weed population will increase
 					adjustWeeds(1 / rating)
 
 //Toxins/////////////////////////////////////////////////////////////////
@@ -223,7 +230,7 @@
 
 			// If the plant is too old, lose health fast
 			if(age > myseed.lifespan)
-				adjustHealth(-rand(1,5) / rating)
+				adjustHealth(-1 / rating)
 
 			// Harvest code
 			if(age > myseed.production && (age - lastproduce) > myseed.production && (!harvest && !dead))
@@ -447,6 +454,8 @@
 	age = 0
 	plant_health = myseed.endurance
 	lastcycle = world.time
+	if(cycledelay > 2 MINUTES)
+		cycledelay = initial(cycledelay)
 	harvest = 0
 	weedlevel = 0 // Reset
 	pestlevel = 0 // Reset
@@ -484,6 +493,8 @@
 	age = 0
 	plant_health = myseed.endurance
 	lastcycle = world.time
+	if(cycledelay > 2 MINUTES)
+		cycledelay = initial(cycledelay)
 	harvest = 0
 	weedlevel = 0 // Reset
 
@@ -504,6 +515,8 @@
 		age = 0
 		plant_health = myseed.endurance
 		lastcycle = world.time
+		if(cycledelay > 2 MINUTES)
+			cycledelay = initial(cycledelay)
 		harvest = 0
 		weedlevel = 0 // Reset
 
@@ -522,6 +535,8 @@
 /obj/machinery/hydroponics/proc/plantdies()
 	plant_health = 0
 	harvest = FALSE
+	if(cycledelay > 2 MINUTES)
+		cycledelay = initial(cycledelay)
 	pestlevel = 0 // Pests die
 	lastproduce = 0
 	STOP_PROCESSING(SSplants, src)
@@ -540,15 +555,7 @@
 		to_chat(user, "<span class='warning'>The pests seem to behave oddly, but quickly settle down...</span>")
 
 /obj/machinery/hydroponics/attackby(obj/item/O, mob/user, params)
-	//Called when mob user "attacks" it with object O
-	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia))
-		if(!self_sustaining)
-			adjustSelfSuff(1)
-			to_chat(user, "You spread the gaia through the soil. ([self_sustainingprog] out of 7)")
-			qdel(O)
-			return
-		else
-			. = ..()
+
 	if(istype(O, /obj/item/reagent_containers) )  // Syringe stuff (and other reagent containers now too)
 		var/obj/item/reagent_containers/reagent_source = O
 
@@ -600,6 +607,8 @@
 			var/water_amt = temp_reagents.get_amount_of_type(/datum/reagent/water)
 			adjustWater(water_amt)
 			temp_reagents.del_reagents_of_subtypes(/datum/reagent/water) // We know we only have the amount used anyway.
+		for(var/datum/reagent/R in temp_reagents.reagent_list)
+			R.on_hydroponics_add(myseed, temp_reagents.get_amount_of_type(R), src, user)
 		// Move the rest to our actual holder and clean up.
 		temp_reagents.trans_to(reagents, transfer_amount)
 		qdel(temp_reagents)
@@ -689,6 +698,8 @@
 				plant_health = 0
 				if(harvest)
 					harvest = FALSE //To make sure they can't just put in another seed and insta-harvest it
+				if(cycledelay > 2 MINUTES)
+					cycledelay = initial(cycledelay)
 				qdel(myseed)
 				myseed = null
 				name = initial(name)
@@ -754,6 +765,8 @@
 
 /obj/machinery/hydroponics/proc/update_tray(mob/user)
 	harvest = FALSE
+	if(cycledelay > 2 MINUTES)
+		cycledelay = initial(cycledelay)
 	lastproduce = age
 	if(myseed.getYield() <= 0)
 		to_chat(user, "<span class='warning'>You fail to harvest anything useful!</span>")
@@ -790,7 +803,7 @@
 	weedlevel = clamp(weedlevel + adjustamt, 0, 10)
 
 /obj/machinery/hydroponics/proc/adjustSelfSuff(adjustamt)
-	if(self_sustainingprog>=6)
+	if(self_sustainingprog>19)
 		become_self_sufficient()
 	else
 		self_sustainingprog += adjustamt

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -246,6 +246,12 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 		return
 	return
 
+/datum/reagent/proc/on_hydroponics_add(obj/item/seeds/myseed, add_amount, obj/machinery/hydroponics/mytray, mob/user)
+	if(!mytray || !add_amount)
+		return
+	return
+
+
 /proc/pretty_string_from_reagent_list(list/reagent_list)
 	//Convert reagent list to a printable string for logging etc
 	var/list/rs = list()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1352,6 +1352,10 @@
 	pH = 11
 	value = REAGENT_VALUE_COMMON //not any higher. Ambrosia is a milestone for hydroponics already.
 
+/datum/reagent/medicine/earthsblood/on_hydroponics_add(obj/item/seeds/myseed, add_amount, obj/machinery/hydroponics/mytray, mob/user)
+	. = ..()
+	mytray.adjustSelfSuff(add_amount)
+
 
 //Earthsblood is still a wonderdrug. Just... don't expect to be able to mutate something that makes plants so healthy.
 /datum/reagent/medicine/earthsblood/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)


### PR DESCRIPTION
## About The Pull Request

hydroponics trays:
consume less nutrient (50% less)
tick faster (100% faster)

making a tray self-sufficient now only needs 20u of earthsblood reagent, as coders intended. on average, with 50-quality gaia branches, you only need 5 instead of 7. makes high potency useful for earthsblood as well as high yield

trays that are ready to harvest now tick 60x slower. this means that you can actually leave your setup (if everything's grown) and not come back to a dead field in 2 minutes, in case you actually wanted to rp with people or whatever. tray stasis no longer exists and this option is open to legion as well

## Why It's Good For The Game

hydro is cbt and keeps you from rping/doing ANYything else since u have to babysit plants. this makes it less so.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog


:cl:
balance: hydro trays/soil plots consume less nutrient (50% less), tick faster (100% faster)
tweak: ready to harvest crops in a hydro tray/soil plot tick 60x slower, meaning you can actually leave your farm alone and it wont die in 30 seconds
tweak: self sufficient trays/plots now take 20 earthsblood reagent to make instead, meaning that on average you need 2 less branches. you can also grind and use chemistry tables to be super efficient, if you want
/:cl:


