### PR TITLE
buffs Dead Horses loadouts

### DIFF
--- a/code/modules/jobs/job_types/tribal.dm
+++ b/code/modules/jobs/job_types/tribal.dm
@@ -397,7 +397,7 @@ Below are the original loadouts and the temporarily used Tribal. Pending rework 
 		/obj/item/storage/bag/plants=1,
 		/obj/item/cultivator=1,
 		/obj/item/reagent_containers/glass/bucket/wood=1,
-		/obj/item/melee/onehanded/knife/ritualdagger/baghead = 1,
+		/obj/item/melee/onehanded/club/warclub = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/book/granter/crafting_recipe/tribal/deadhorses = 1
 	)

--- a/code/modules/jobs/job_types/tribal.dm
+++ b/code/modules/jobs/job_types/tribal.dm
@@ -373,7 +373,7 @@ Below are the original loadouts and the temporarily used Tribal. Pending rework 
 	backpack_contents = list(
 		/obj/item/clothing/under/f13/deadhorses = 1,
 		/obj/item/clothing/under/f13/female/deadhorses = 1,
-		/obj/item/melee/onehanded/club/warclub = 1,
+		/obj/item/twohanded/sledgehammer/warmace = 1,
 		/obj/item/storage/backpack/spearquiver = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 2
 	)
@@ -397,6 +397,7 @@ Below are the original loadouts and the temporarily used Tribal. Pending rework 
 		/obj/item/storage/bag/plants=1,
 		/obj/item/cultivator=1,
 		/obj/item/reagent_containers/glass/bucket/wood=1,
+		/obj/item/melee/onehanded/knife/ritualdagger/baghead = 1,
 		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
 		/obj/item/book/granter/crafting_recipe/tribal/deadhorses = 1
 	)


### PR DESCRIPTION

## About The Pull Request

atm they're a little meh. gives the shaman an actual weapon, like other support loadouts (warclub is pretty decent, 30 melee damage + stamina vs people). gives the stalker the twohanded warclub, which is comparable to the bumper sword found in other tribal loadouts


## Why It's Good For The Game

buff dead horses 
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog
:cl:
balance: dead horses shaman now gets a warclub, dead horses stalker gets a 2h warclub
/:cl:
