### PR TITLE
Gives Tribals roundstart Hard Yards (Trekking)

### DIFF
--- a/code/modules/jobs/job_types/tribal.dm
+++ b/code/modules/jobs/job_types/tribal.dm
@@ -24,6 +24,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	ADD_TRAIT(H, TRAIT_TRAPPER,  REF(src))
 	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS,  REF(src))
 	ADD_TRAIT(H, TRAIT_AUTO_DRAW,  REF(src))
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, REF(src))
 	H.grant_language(/datum/language/tribal)
 	var/list/recipes = list(
 		/datum/crafting_recipe/tribal_pa,


### PR DESCRIPTION
Tribals should be able to move off-road the same speed they do on asphalt since they're a faction that's deeply in tune with all things natural.