### PR TITLE
Removes syndicate nanite injectors and removes strongsludge's permeant stamina crit

### DIFF
--- a/code/modules/fallout/f13lootdrop.dm
+++ b/code/modules/fallout/f13lootdrop.dm
@@ -531,8 +531,8 @@
 
 	loot = list(
 				/obj/item/defibrillator/compact/combat/loaded,
-				/obj/item/reagent_containers/hypospray/combat,
-				/obj/item/clothing/glasses/hud/health/night,
+				/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+				/obj/item/clothing/glasses/hud/health,
 				///obj/item/disk/surgery/revival
 				)
 

--- a/code/modules/fallout/reagents/alcohol.dm
+++ b/code/modules/fallout/reagents/alcohol.dm
@@ -891,8 +891,7 @@
 	else
 		if(ishuman(M))
 			if(prob(98))
-				M.vomit(50)
-				M.adjustToxLoss(10*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
+				M.adjustToxLoss(0.5*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 		..()
 	return TRUE // update health at end of tick
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

There was previously seven spawns on the map that included NVGs and syndicate nanite injectors. These have been adjusted for superstims and a normal health HUD. Strong sludge has been adjusted so that it will not permanently cause a person to vomit and thereby be stamcrit forever after it's application.

## Why It's Good For The Game

Powergame mechanics begone. Also requested by headmins.
