### PR TITLE
Fixes the rising desert

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -11,7 +11,7 @@
 	name = "plating"
 	icon_state = "plating"
 	intact = FALSE
-	baseturfs = /turf/open/indestructible/ground/outside/desert
+	baseturfs = /turf/open/indestructible/ground/outside/ruins
 	footstep = FOOTSTEP_PLATING
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -316,7 +316,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 //	step_sounds = list("human" = "erikafootsteps")
 
-/turf/open/indestructible/ground/outside/ruins/ex_act(severity, target)
+/*/turf/open/indestructible/ground/outside/ruins/ex_act(severity, target)
 	contents_explosion(severity, target)
 	switch(severity)
 		if(4)
@@ -329,7 +329,7 @@
 			if(prob(50))
 				ChangeTurf(baseturfs)
 		if(1)
-			ChangeTurf(baseturfs)
+			ChangeTurf(baseturfs)*/
 
 /turf/open/indestructible/ground/outside/wood
 	name = "\proper wood planks"


### PR DESCRIPTION
## About The Pull Request

The baseturf (turf under the turf) for premade plating is desert floor. This has often resulted in the desert appearing in odd places (i.e. upstairs!) when plating is destroyed. Replacing the baseturf with ruin floor looks a lot more appropriate in any circumstance.

(As part of this I did have to comment out some code that rarely turns ruin floor into desert floor, but it's worth it.)

![news](https://github.com/f13babylon/f13babylon/assets/132588088/1b9ca6d5-da81-4d1f-b94e-27ef43266028)

![new](https://github.com/f13babylon/f13babylon/assets/132588088/e684e4b9-f30f-4175-bce1-25125ccfc219)

## Why It's Good For The Game

It's a lot better visually.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
fix: Fixed desert flooring appearing in odd places because of blown up tiles.
/:cl:
