### PR TITLE
fullupgrade dispenser changes

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -727,6 +727,7 @@
 		/obj/item/stock_parts/cell = 1)
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
 	needs_anchored = FALSE
+
 /obj/item/circuitboard/machine/chem_dispenser/apothecary
 	name = "Apotechary Chem Dispenser (Machine Board)"
 	build_path = /obj/machinery/chem_dispenser/apothecary
@@ -738,13 +739,40 @@
 		/obj/item/stock_parts/cell = 1)
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/upgraded/plus)
 
+/obj/item/circuitboard/machine/chem_dispenser/fullupgrade
+	name = "Advanced Chem Dispenser (Machine Board)"
+	build_path = /obj/machinery/chem_dispenser/fullupgrade
+	req_components = list(
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/cell = 1)
+	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/hyper)
+	needs_anchored = FALSE
+
 /obj/item/circuitboard/machine/chem_dispenser/drinks
 	name = "Soda Dispenser (Machine Board)"
 	build_path = /obj/machinery/chem_dispenser/drinks
 
+/obj/item/circuitboard/machine/chem_dispenser/drinks/fullupgrade
+	name = "Advanced Soda Dispenser (Machine Board)"
+	build_path = /obj/machinery/chem_dispenser/drinks/fullupgrade
+	req_components = list(
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/cell = 1)
+	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/hyper)
+	needs_anchored = FALSE
+
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer
 	name = "Booze Dispenser (Machine Board)"
 	build_path = /obj/machinery/chem_dispenser/drinks/beer
+
+/obj/item/circuitboard/machine/chem_dispenser/drinks/beer/fullupgrade
+	name = "Advanced Booze Dispenser (Machine Board)"
+	build_path = /obj/machinery/chem_dispenser/drinks/beer/fullupgrade
+	req_components = list(
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/cell = 1)
+	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/hyper)
+	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/chem_dispenser/abductor
 	name = "Reagent Synthetizer (Abductor Machine Board)"
@@ -1212,4 +1240,3 @@
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stack/cable_coil = 1,
 		/obj/item/stack/sheet/glass = 2)
-

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -603,6 +603,7 @@
 	)
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade //equivalent to fully ugpraded stock parts, emagged
 	desc = "An advanced self-contained dispenser for various kinds of hard drinks. This one is capable of producing some more esoteric concoctions."
+	circuit = /obj/item/circuitboard/machine/chem_dispenser/drinks/beer/fullupgrade
 	obj_flags = CAN_BE_HIT | EMAGGED
 
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade/RefreshParts()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -540,23 +540,22 @@
 		/datum/reagent/iron,
 	)
 
-/obj/machinery/chem_dispenser/drinks/fullupgrade //fully ugpraded stock parts, emagged
-	desc = "Contains a large reservoir of soft drinks. This model has had its safeties shorted out."
+/obj/machinery/chem_dispenser/drinks/fullupgrade //equivalent to fully ugpraded stock parts, emagged
+	desc = "An advanced self-contained dispenser for various kinds of soft drinks. This one is capable of producing some more esoteric selections."
+	circuit = /obj/item/circuitboard/machine/chem_dispenser/drinks/fullupgrade
+	powerefficiency = 0.2
+	recharge_amount = 40
 	obj_flags = CAN_BE_HIT | EMAGGED
-	flags_1 = NODECONSTRUCT_1
 
-/obj/machinery/chem_dispenser/drinks/fullupgrade/Initialize(mapload)
-	. = ..()
+/obj/machinery/chem_dispenser/drinks/fullupgrade/RefreshParts()
+	recharge_amount = initial(recharge_amount)
+	for(var/obj/item/stock_parts/cell/P in component_parts)
+		cell = P
+	dispensable_reagents |= upgrade_reagents
+	dispensable_reagents |= upgrade_reagents2
+	dispensable_reagents |= upgrade_reagents3
 	dispensable_reagents |= emagged_reagents //adds emagged reagents
-	component_parts = list()
-	component_parts += new /obj/item/circuitboard/machine/chem_dispenser/drinks(null)
-	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
-	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
-	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
-	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
-	component_parts += new /obj/item/stack/sheet/glass(null)
-	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
-	RefreshParts()
+	powerefficiency = round(initial(powerefficiency), 0.01)
 
 /obj/machinery/chem_dispenser/drinks/beer
 	name = "booze dispenser"
@@ -602,23 +601,20 @@
 		/datum/reagent/consumable/ethanol/alexander,
 		/datum/reagent/toxin/minttoxin,
 	)
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade //fully ugpraded stock parts, emagged
-	desc = "Contains a large reservoir of the good stuff. This model has had its safeties shorted out."
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade //equivalent to fully ugpraded stock parts, emagged
+	desc = "An advanced self-contained dispenser for various kinds of hard drinks. This one is capable of producing some more esoteric concoctions."
 	obj_flags = CAN_BE_HIT | EMAGGED
-	flags_1 = NODECONSTRUCT_1
 
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade/Initialize(mapload)
-	. = ..()
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade/RefreshParts()
+	recharge_amount = initial(recharge_amount)
+	for(var/obj/item/stock_parts/cell/P in component_parts)
+		cell = P
+	dispensable_reagents |= upgrade_reagents
+	dispensable_reagents |= upgrade_reagents2
+	dispensable_reagents |= upgrade_reagents3
 	dispensable_reagents |= emagged_reagents //adds emagged reagents
-	component_parts = list()
-	component_parts += new /obj/item/circuitboard/machine/chem_dispenser/drinks/beer(null)
-	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
-	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
-	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
-	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
-	component_parts += new /obj/item/stack/sheet/glass(null)
-	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
-	RefreshParts()
+	powerefficiency = round(initial(powerefficiency), 0.01)
+
 
 /obj/machinery/chem_dispenser/mutagen
 	name = "mutagen dispenser"
@@ -664,23 +660,20 @@
 	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
 	RefreshParts()
 
-/obj/machinery/chem_dispenser/fullupgrade //fully ugpraded stock parts, emagged
-	desc = "Creates and dispenses chemicals. This model has had its safeties shorted out."
+/obj/machinery/chem_dispenser/fullupgrade //equivalent to t4 stock parts, emagged
+	desc = "An advanced self-contained dispenser for various kinds of chemicals. This one is capable of producing some more esoteric types."
+	circuit = /obj/item/circuitboard/machine/chem_dispenser/fullupgrade
 	obj_flags = CAN_BE_HIT | EMAGGED
-	flags_1 = NODECONSTRUCT_1
 
-/obj/machinery/chem_dispenser/fullupgrade/Initialize(mapload)
-	. = ..()
+/obj/machinery/chem_dispenser/fullupgrade/RefreshParts()
+	recharge_amount = initial(recharge_amount)
+	for(var/obj/item/stock_parts/cell/P in component_parts)
+		cell = P
+	dispensable_reagents |= upgrade_reagents
+	dispensable_reagents |= upgrade_reagents2
+	dispensable_reagents |= upgrade_reagents3
 	dispensable_reagents |= emagged_reagents //adds emagged reagents
-	component_parts = list()
-	component_parts += new /obj/item/circuitboard/machine/chem_dispenser(null)
-	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
-	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
-	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
-	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
-	component_parts += new /obj/item/stack/sheet/glass(null)
-	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
-	RefreshParts()
+	powerefficiency = round(initial(powerefficiency), 0.01)
 
 /obj/machinery/chem_dispenser/abductor
 	name = "reagent synthesizer"


### PR DESCRIPTION

## About The Pull Request

fullupgrade dispensers can no longer be beaten to a pulp for free t4 stock parts
fullupgrade dispensers can now be deconstructed and moved and all that stuff
fullupgrade dispensers have a slightly weaker cell by default, but this shouldn't matter for 100% of usecases since energy regenerates super fast anyways

## Why It's Good For The Game

magic undeconnable machines bad, free t4 parts bad, nerfs good

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog

:cl:
tweak: fullupgrade dispensers can now be deconstructed and moved and all that stuff
balance: fullupgrade dispensers can no longer be beaten to a pulp for free t4 stock parts
balance: fullupgrade dispenser cell t4 >> t3
/:cl:


