### PR TITLE
Makes Priestess Clothing Gender Neutral

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -623,7 +623,7 @@
 		H.update_sight()
 
 /obj/item/clothing/glasses/sunglasses/fakeblindfold
-	name = "priestess blindfold"
+	name = "priest blindfold"
 	desc = "The coverings used to restrict the sight of the world, but see with the Sight of Mars."
 	icon_state = "legpriestess"
 	item_state = "legpriestess"
@@ -640,4 +640,3 @@
 			user.Knockdown(100)
 			user.blind_eyes(30)
 		return
-

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -307,7 +307,7 @@
 	AddComponent(/datum/component/armor_plate)
 
 /obj/item/clothing/head/helmet/f13/legion/marsheaddress
-	name = "priestess' headdress"
+	name = "garments of mars headdress"
 	desc = "A headdress made of feathers and decorated with two golden tassles."
 	icon_state = "legion-priestess"
 	item_state = "legion-priestess"

--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -386,8 +386,8 @@
 	can_adjust = TRUE
 
 /obj/item/clothing/under/f13/priestess
-	name = "priestess robes"
-	desc = "The robes worn by a Priestess of Mars."
+	name = "garments of mars"
+	desc = "The robes worn by a priest of Mars."
 	icon_state = "priestess"
 	item_state = "priestess"
 	item_color = "priestess"
@@ -395,8 +395,8 @@
 	can_adjust = FALSE
 
 /obj/item/clothing/under/f13/pmarsrobe
-	name = "priestess of mars robe"
-	desc = "A red robe decorated with bird feathers for the Priestess of Mars."
+	name = "garments of mars robe"
+	desc = "A red robe decorated with bird feathers for the priest of Mars."
 	icon_state = "pmars_robe"
 	item_state = "pmars_robe"
 	armor = list(melee = 0, bullet = 0, laser = 20, energy = 20, bomb = 5, bio = 0, rad = 0, fire = 100, acid = 0)

--- a/code/modules/fallout/obj/cards_ids.dm
+++ b/code/modules/fallout/obj/cards_ids.dm
@@ -256,7 +256,7 @@
 	assignment = "explorer medallion"
 
 /obj/item/card/id/dogtag/legpriest
-	name = "priestess medallion"
+	name = "priest medallion"
 	desc = "A golden disc awarded to the trusted spiritual guide to the nearby Legion."
 	icon_state = "legionmedallioncent"
 	item_state = "card-id_leg2"
@@ -463,4 +463,3 @@ end of
 	item_state = "card-id_leg"
 	assignment = "US dogtags"
 	access = list(ACCESS_ENCLAVE)
-

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -189,7 +189,7 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 		)
 
 /datum/outfit/loadout/oratorf
-	name = "Priestess of Mars"
+	name = "Priest of Mars"
 	uniform = /obj/item/clothing/under/f13/pmarsrobe
 	head = /obj/item/clothing/head/helmet/f13/legion/orator
 	shoes = /obj/item/clothing/shoes/roman


### PR DESCRIPTION
## About The Pull Request

This PR makes it so people playing Priest/Priestess have gender-neutral clothing. Made out of request by wotz.

## Why It's Good For The Game

Character diversity is good.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog


:cl:
tweak: gender neutral priest(ess) clothing.
/:cl: