### PR TITLE
Removes Observer Blindening

### DIFF
--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -81,10 +81,10 @@
 	HandlePlanes()
 
 /datum/hud/ghost/proc/HandlePlanes()
-	if(check_rights(R_ADMIN))
+	/*if(check_rights(R_ADMIN))              //Babylon Edit - restores ghost vision.
 		return
 	plane_masters["[OBJITEM_PLANE]"].Hide()
-	mymob.client.show_popup_menus = 0
+	mymob.client.show_popup_menus = 0*/
 
 /datum/hud/ghost/show_hud(version = 0, mob/viewmob)
 	// don't show this HUD if observing; show the HUD of the observee

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -709,11 +709,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	..()
 
 /mob/dead/observer/proc/HandlePlanes()
-	if(check_rights(R_ADMIN))
+	/*if(check_rights(R_ADMIN))     //babylon edit - restores ghost vision.
 		return
 	hud_used.plane_masters["[OBJITEM_PLANE]"].Hide()
 	if(client)
-		client.show_popup_menus = 0
+		client.show_popup_menus = 0*/
 
 /proc/updateallghostimages()
 	listclearnulls(GLOB.ghost_images_default)

--- a/modular_citadel/code/modules/client/client_procs.dm
+++ b/modular_citadel/code/modules/client/client_procs.dm
@@ -55,6 +55,5 @@
 	set name = "Toggle Rightclick"
 	set desc = "Did the context menu get stuck on or off? Press this button."
 
-	if(check_rights(R_ADMIN))
-		show_popup_menus = !show_popup_menus
-		to_chat(src, "<span class='notice'>The right-click context menu is now [show_popup_menus ? "enabled" : "disabled"].</span>")
+	show_popup_menus = !show_popup_menus
+	to_chat(src, "<span class='notice'>The right-click context menu is now [show_popup_menus ? "enabled" : "disabled"].</span>")


### PR DESCRIPTION
## About The Pull Request
![filterbefore](https://github.com/f13babylon/f13babylon/assets/132588088/9a929c60-5788-4fe3-ac68-752b75ee52ab)
![after](https://github.com/f13babylon/f13babylon/assets/132588088/a1d34602-e290-4649-80d4-586ee2f2221c)

Removes the observer blindening system and allows ghosts/observers to see items on the map. A proc that was restricted to admins as part of this (as it was a way to cheese around it) was also restored.

## Why It's Good For The Game
This is a really interesting system inherited from Sunset, but is widely disliked by many (including myself) and a suggestion to remove it received unanimous praise.

![discord](https://github.com/f13babylon/f13babylon/assets/132588088/d39658bd-b5bb-4761-b93f-28c5406b6c7c)

I agree with this.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
del: Removes the observer blindening system.
/:cl: