### PR TITLE
Rewards the destruction of FEV

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -28,8 +28,11 @@ SUBSYSTEM_DEF(research)
 	var/list/techweb_nodes_experimental = list()	//Node ids that are exclusive to the BEPIS.
 
 	var/list/techweb_point_items = list(		//path = list(point type = value)
-	/obj/item/blueprint/research                   = list(TECHWEB_POINT_TYPE_GENERIC = 10000),
-	/obj/item/scrap/research                       = list(TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/reagent_containers/glass/bottle/FEV_solution                  = list(TECHWEB_POINT_TYPE_GENERIC = 100000),
+	/obj/item/reagent_containers/glass/bottle/FEV_solution/two              = list(TECHWEB_POINT_TYPE_GENERIC = 100000),
+	/obj/item/reagent_containers/glass/bottle/FEV_solution/curling          = list(TECHWEB_POINT_TYPE_GENERIC = 100000),
+	/obj/item/blueprint/research                   							= list(TECHWEB_POINT_TYPE_GENERIC = 10000),
+	/obj/item/scrap/research                       							= list(TECHWEB_POINT_TYPE_GENERIC = 1000),
 
 	/obj/item/assembly/signaler/anomaly            = list(TECHWEB_POINT_TYPE_GENERIC = 10000),
 	//   -   Slime Extracts!   - Basics


### PR DESCRIPTION
## About The Pull Request

This PR gives Followers/Enclave/BoS research points if they destroy FEV. This should (mechanically) incentivize the trading and removal of FEV to prevent "incidents" of Curling or chem bombing from other factions by giving them worth so the bottles are out of circulation.

## Why It's Good For The Game

FEV being out of circulation or even Curling-13 being used is just, not fun, at all, to engage with. The alternative was mutating people if they didn't wear a radioactive suit to prevent people from soft core griefing.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog

:cl:
add: Adds research points to FEV bottles.
/:cl:
