### PR TITLE
Rubber ammo dupe fix

### DIFF
--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -359,13 +359,6 @@
 	build_path = /obj/item/ammo_box/c45/rubber
 	category = list("initial", "Basic Ammo")
 
-/datum/design/ammolathe/a10mmrubber
-	name = "10mm rubber ammo box"
-	id = "a10mmrubber"
-	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
-	build_path = /obj/item/ammo_box/c10mm/rubber
-	category = list("initial", "Basic Ammo")
-
 /datum/design/ammolathe/a22rubber
 	name = ".22 rubber ammo box"
 	id = "m22rubber"


### PR DESCRIPTION
## About The Pull Request

This PR gets rid of the extra 10mm rubber ammo box in the reloading bench menu.

## Why It's Good For The Game

Bloat up the ammo lathe menu. Weird change.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog


:cl:
del: gets rid of an extra printable set of 10mm rubber ammo?
/:cl: