### PR TITLE
trainshot buff + ultradense readded + trainshot nerf

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -327,6 +327,19 @@
 	subcategory = CAT_AMMO
 	always_available = FALSE
 
+/datum/crafting_recipe/c4570boxheavy
+	name = ".45-70 Gv'mt ultradense ammo box"
+	result = /obj/item/ammo_box/c4570box/knockback
+	reqs = list(/obj/item/stack/crafting/metalparts = 2,
+	/obj/item/stack/sheet/mineral/titanium = 1,
+	/obj/item/stack/sheet/prewar = 2,
+	/obj/item/stack/ore/blackpowder = 1
+	)
+	tools = list(TOOL_AWORKBENCH)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
 /////////////////
 ///GUN CRAFTING//
 /////////////////

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -165,6 +165,8 @@
 	sharpness = SHARP_NONE //crunch
 	tile_dropoff = 0
 	tile_dropoff_s = 0
+	supereffective_damage = 15 //same damage vs mobs as regular slugs, epic
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/pellet/trainshot/on_hit(atom/target)
 	. = ..()

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -320,7 +320,7 @@
 	id = "trainshot"
 	materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 1800)
 	build_path = /obj/item/ammo_box/shotgun/trainshot
-	category = list("initial", "Intermediate Ammo")
+	category = list("initial", "Advanced Ammo")
 
 /datum/design/ammolathe/a762
 	name = "7.62 FMJ ammo box"


### PR DESCRIPTION
## About The Pull Request

45-70 ultradense is now craftable again woohoo

trainshot now has the same damage vs mobs as slugs

trainshot is now t3 in the lathe
## Why It's Good For The Game

i exclusively do pve and need a reason to carry trainshot because it's funny

no but really it was like 0.5x the damage against mobs

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog


:cl:
add: ultradense ammo now craftable
balance: trainshot perpellet 15 >> 30 vs simplemobs
/:cl:

