### PR TITLE
removes chainsaw from the t5 melee pool, removes infil carbine from the unique gun pool

### DIFF
--- a/code/modules/fallout/f13lootdrop.dm
+++ b/code/modules/fallout/f13lootdrop.dm
@@ -723,7 +723,6 @@
 	lootcount = 1
 
 	loot = list(/obj/item/twohanded/thermic_lance,
-				/obj/item/twohanded/chainsaw,
 				/obj/item/twohanded/sledgehammer/rockethammer,
 				/obj/item/melee/powered/ripper,
 				/obj/item/melee/powerfist/f13,

--- a/code/modules/fallout/f13lootdrop.dm
+++ b/code/modules/fallout/f13lootdrop.dm
@@ -910,7 +910,6 @@
 				/obj/item/gun/ballistic/automatic/pistol/ninemil/maria,
 				/obj/item/gun/ballistic/rifle/hunting/paciencia,
 				/obj/item/gun/ballistic/automatic/varmint/ratslayer,
-				/obj/item/gun/ballistic/automatic/assault_rifle/infiltrator,
 				/obj/item/gun/ballistic/revolver/colt357/lucky,
 				/obj/item/gun/ballistic/automatic/m1garand/oldglory,
 				/obj/item/gun/ballistic/automatic/marksman/sniper/gold,


### PR DESCRIPTION
what was bro thinking? it's a relatively cheap craftable item (5 plasteel 1 circular saw)
infil is also in the highmid pool so

:cl:
del: removes chainsaw from t5 loot pool, infil is no longer in both the highmid and unique pools
/:cl:

