### PR TITLE
Standardizes RnD Access 

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -377,6 +377,7 @@ Senior Paladin
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_PA_WEAR,  REF(src))
+	ADD_TRAIT(H, TRAIT_RESEARCHER,  REF(src))
 	H.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
 
 /datum/outfit/job/bos/f13seniorpaladin
@@ -465,6 +466,7 @@ Paladin
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_PA_WEAR,  REF(src))
+	ADD_TRAIT(H, TRAIT_RESEARCHER,  REF(src))
 
 /datum/outfit/job/bos/f13paladin
 	name =	"Paladin"
@@ -728,6 +730,7 @@ Scribe
 	..()
 	if(visualsOnly)
 		return
+	ADD_TRAIT(H, TRAIT_RESEARCHER,  REF(src))
 
 /datum/outfit/job/bos/f13seniorknight
 	name = "Senior Knight"


### PR DESCRIPTION
## About The Pull Request
After discussion, because Follower Doctor and Gunny Sgt+ get RnD access, this PR standardizes an "NCO" rank in tech factions getting RnD access, so Bos Senior Knights/Paladins/Senior Paladins get access. You can now play the role you want without gimping the faction now!

## Why It's Good For The Game

Because we had it fine on Fortune/Fortuna/Lonestar/Wasteland, etc. It only serves to punish people who wanna play a character in the BoS that isn't a scribe. More things to play around with is GOOD, especially because BoS self policies its shitters religiously.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog

:cl:
balance: Gives RnD access to SK/PL/SP
/:cl:
