### PR TITLE
Removes AP from Plasma Rifle

### DIFF
--- a/code/modules/projectiles/guns/energy/plasmaf13.dm
+++ b/code/modules/projectiles/guns/energy/plasmaf13.dm
@@ -78,7 +78,6 @@
 	name ="plasma rifle"
 	item_state = "plasma"
 	icon_state = "plasma"
-	armour_penetration = 0.1
 	slowdown = 0.65 //this is one of the worst slowdowns in the game
 	fire_delay = 5.2
 	desc = "A miniaturized plasma caster that fires bolts of magnetically accelerated toroidal plasma towards an unlucky target."

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -493,7 +493,7 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 20 //fucc you normies
+	damage = 22 //fucc you normies
 	armour_penetration = 0 //no AP, armor shouldnt have more than 20 resist against plasma unless its specialized
 	flag = "energy" //checks vs. energy protection
 	wound_bonus = 45 //being hit with plasma is horrific

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -493,7 +493,7 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 25 //fucc you normies
+	damage = 20 //fucc you normies
 	armour_penetration = 0 //no AP, armor shouldnt have more than 20 resist against plasma unless its specialized
 	flag = "energy" //checks vs. energy protection
 	wound_bonus = 45 //being hit with plasma is horrific


### PR DESCRIPTION
Plasma is not meant to have AP. Almost no armor already has energy prot as a design decision. Dunno why it had it in the first place. Also their damage was a little too high for my liking.