### PR TITLE
removes acidic buffer from celugel recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -864,7 +864,7 @@
 	id = /datum/reagent/celugel
 	required_catalysts = list(/datum/reagent/lithium = 5, /datum/reagent/chlorine = 5)
 	results = list(/datum/reagent/celugel = 4)
-	required_reagents = list(/datum/reagent/cellulose = 1, /datum/reagent/diethylamine = 1, /datum/reagent/fermi/acidic_buffer = 0.5, /datum/reagent/acetone = 1, /datum/reagent/carbondioxide = 1) //not a super easy recipe as it replaces a hard-to-get chemical
+	required_reagents = list(/datum/reagent/cellulose = 1, /datum/reagent/diethylamine = 1, /datum/reagent/acetone = 1, /datum/reagent/carbondioxide = 1) //not a super easy recipe as it replaces a hard-to-get chemical
 	OptimalTempMin 		= 430
 	OptimalTempMax		= 520
 	ExplodeTemp			= 9999


### PR DESCRIPTION
removes acidic buffer from celugel recipe
it turns out that having acidic buffer in the beaker causes adding more to instead just fill the beaker instead of evaporating and reducing pH, meaning that this recipe is way harder to get than intended

it's still pretty hard to get though

:cl:
tweak: removes acidic buffer from celugel recipe
/:cl:


