### PR TITLE
Enables Podpeople as a Roundstart Species (May need to be enabled on the box)

### DIFF
--- a/code/datums/elements/photosynthesis.dm
+++ b/code/datums/elements/photosynthesis.dm
@@ -64,6 +64,8 @@
 				L.adjust_nutrition(light_amount * light_nutrition_gain * attached_atoms[AM], NUTRITION_LEVEL_WELL_FED)
 			if(light_amount > bonus_lum || light_amount < malus_lum)
 				var/mult = ((light_amount > bonus_lum) ? 1 : -1) * attached_atoms[AM]
+				if(mult < 0 && prob(10))
+					to_chat(A, "<span class ='danger'>You feel yourself growing weaker without light.</span>")
 				if(light_bruteheal)
 					L.adjustBruteLoss(light_bruteheal * mult)
 				if(light_burnheal)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -70,10 +70,11 @@
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,MUTCOLORS,CAN_SCAR,HAS_FLESH,HAS_BONE)
 	mutant_bodyparts = list("mcolor" = "FFFFFF","mcolor2" = "FFFFFF","mcolor3" = "FFFFFF", "mam_snouts" = "Husky", "mam_tail" = "Husky", "mam_ears" = "Husky", "mam_body_markings" = list(), "taur" = "None", "legs" = "Normal Legs")
 	limbs_id = "pod"
-	light_nutrition_gain_factor = 3
+	light_nutrition_gain_factor = 2	//New Babylon change: from 3 to 2
 	light_bruteheal = -0.2
 	light_burnheal = -0.2
-	light_toxheal = -0.7
+	light_toxheal = -0.1	//New Babylon change: from 0.7 to 0.1
+	light_oxyheal = 0	//New Babylon change: from 1 to 0
 
 	tail_type = "mam_tail"
 	wagging_type = "mam_waggingtail"

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -7,6 +7,8 @@
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
+	exotic_blood = /datum/reagent/plantnutriment/eznutriment
+	exotic_blood_color = "#376400"
 	burnmod = 1.25
 	heatmod = 1.5
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
@@ -21,7 +23,7 @@
 
 	species_type = "plant"
 
-	allowed_limb_ids = list("pod","mush")
+	allowed_limb_ids = list("pod")
 
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -72,8 +74,8 @@
 	limbs_id = "pod"
 	brutemod = 1.25	//New Babylon change: from 1 to 1.25
 	light_nutrition_gain_factor = 2	//New Babylon change: from 3 to 2
-	light_bruteheal = -0.2
-	light_burnheal = -0.2
+	light_bruteheal = -0.1	//New Babylon change: from 0.2 to 0.1
+	light_burnheal = -0.1	//New Babylon change: from 0.2 to 0.1
 	light_toxheal = -0.1	//New Babylon change: from 0.7 to 0.1
 	light_oxyheal = 0	//New Babylon change: from 1 to 0
 

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -70,6 +70,7 @@
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,MUTCOLORS,CAN_SCAR,HAS_FLESH,HAS_BONE)
 	mutant_bodyparts = list("mcolor" = "FFFFFF","mcolor2" = "FFFFFF","mcolor3" = "FFFFFF", "mam_snouts" = "Husky", "mam_tail" = "Husky", "mam_ears" = "Husky", "mam_body_markings" = list(), "taur" = "None", "legs" = "Normal Legs")
 	limbs_id = "pod"
+	brutemod = 1.25	//New Babylon change: from 1 to 1.25
 	light_nutrition_gain_factor = 2	//New Babylon change: from 3 to 2
 	light_bruteheal = -0.2
 	light_burnheal = -0.2

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1869,7 +1869,7 @@
 	ghoulfriendly = TRUE
 
 /datum/reagent/plantnutriment/on_mob_life(mob/living/carbon/M)
-	if(prob(tox_prob))
+	if(prob(tox_prob) && M.dna.species.species_type != "plant")	//New Babylon change: Podpeople do not get poisoned from plant nutrients
 		M.adjustToxLoss(1*REM, updating_health = FALSE)
 		. = 1
 	..()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -470,6 +470,7 @@ ROUNDSTART_RACES dwarf
 #ROUNDSTART_RACES uranium
 #ROUNDSTART_RACES abductor
 ROUNDSTART_RACES synth
+ROUNDSTART_RACES podweak
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes a WEAKENED version of Podpeople selectable as a roundstart species. Their maluses and bonuses are as follows:
- 1.25 damage modifiers for Brute/Burn
- Restore 2 hunger and heal 0.2 Brute, 0.2 Burn, 0.1 Toxin when in light.
- Reverse effects in darkness.
## Why It's Good For The Game
This lets people play as anthropomorphic Broc flowers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: enabled podpeople as a roundstart species
balance: rebalanced weak podpeople healing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
