### PR TITLE
Fixes epinephrine mix value

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -212,7 +212,7 @@
 /datum/chemical_reaction/epinephrine
 	name = "Epinephrine"
 	id = /datum/reagent/medicine/epinephrine
-	results = list(/datum/reagent/medicine/epinephrine = 3)
+	results = list(/datum/reagent/medicine/epinephrine = 6)
 	required_reagents = list(/datum/reagent/acetone = 1, /datum/reagent/diethylamine = 1, /datum/reagent/phenol = 1, /datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 1, /datum/reagent/chlorine = 1)
 
 /datum/chemical_reaction/strange_reagent


### PR DESCRIPTION
## About The Pull Request

This PR changes the value of epinephrine mix from 3 to 6 (like it was before)

## Why It's Good For The Game

Epinephrine is fuel. Fuel for many things, chemical stimpaks included.

Before it's value was changed from 6 to 3, epinephrine production was hard but bearable (since the reagents - product ratio were 1:1). With a change, personally I don't know when, the reagents produce 3 epi per 6 reagents.

Mass-produced chemical stimpaks were an alternative to traditional stimpaks because you could make a crap ton of them at a similar, if not few minutes quicker than via traditional farming at the cost of them not being upgrade-able. Now it is not viable as an alternative to traditional farming methods.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->



:cl:
tweak: Epinephrine results value from 3 to 6
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
