### PR TITLE
those khan nerfs i was talking about earlier

### DIFF
--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -31,7 +31,6 @@
 	..()
 	if(visualsOnly)
 		return
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/set_vrboard/den)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/trail_carbine)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/grease_gun)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
@@ -44,8 +43,8 @@
 	title = "Khan Smith"
 	flag = F13KHANSMITH
 	faction = FACTION_KHAN
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the smith, a mixture of an Electrician and Engineer through trial-and-error. Maintain the camp and assist the Senior Enforcer when possible."
 	enforces = "You have control over the forge, a valuable asset in maintaining your presence in the area."
 	supervisors = "your fellow Khans"
@@ -280,4 +279,3 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/empgrenade)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/xbow)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/cheaparrow)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/set_vrboard/den)

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -48,7 +48,7 @@
 	spawn_positions = 1
 	description = "You are the smith, a mixture of an Electrician and Engineer through trial-and-error. Maintain the camp and assist the Senior Enforcer when possible."
 	enforces = "You have control over the forge, a valuable asset in maintaining your presence in the area."
-	supervisors = "the Senior Enforcer"
+	supervisors = "your fellow Khans"
 	selection_color = "#ff915e"
 	req_admin_notify = 1
 	exp_type = EXP_TYPE_KHAN
@@ -65,8 +65,8 @@
 	title = "Khan Senior Enforcer"
 	flag = F13KHANSEN
 	faction = FACTION_KHAN
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a Khan, atop being the senior of all within this camp. Maintain some manner of control and assure the Chemist doesn't blow their hands off."
 	supervisors = "the Senior Enforcer"
 	selection_color = "#ff915e"
@@ -84,10 +84,10 @@
 	title = "Khan Enforcer"
 	flag = F13KHAN
 	faction = FACTION_KHAN
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 3
+	spawn_positions = 3
 	description = "You are a Khan, a member of the local band that the Chief has sent to scout these lands. Listen to the Chemist, and assure you've a steady supply of caps for the Chief."
-	supervisors = "the Senior Enforcer"
+	supervisors = "your fellow Khans"
 	selection_color = "#ff915e"
 	exp_requirements = 0
 	exp_type = EXP_TYPE_WASTELAND
@@ -107,7 +107,7 @@
 	spawn_positions = 2
 	description = "You are a Chemist, one of the few Khans present in this camp that can produce those sweet, sweet chems. Keep them flowing and assure a supply of caps, so you can send them back to the Chief."
 	enforces = "You have control over the lab, a valuable asset in generating profit."
-	supervisors = "the Senior Enforcer"
+	supervisors = "your fellow Khans"
 	selection_color = "#ff915e"
 	req_admin_notify = 1
 	exp_requirements = 300
@@ -280,3 +280,4 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/empgrenade)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/xbow)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/cheaparrow)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/set_vrboard/den)

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -83,8 +83,8 @@
 	title = "Khan Enforcer"
 	flag = F13KHAN
 	faction = FACTION_KHAN
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 5
+	spawn_positions = 5
 	description = "You are a Khan, a member of the local band that the Chief has sent to scout these lands. Listen to the Chemist, and assure you've a steady supply of caps for the Chief."
 	supervisors = "your fellow Khans"
 	selection_color = "#ff915e"
@@ -152,7 +152,7 @@
 /datum/outfit/loadout/soldier
 	name = "Heavy Enforcer"
 	belt = /obj/item/storage/backpack/spearquiver
-	r_hand = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever
+	r_hand = /obj/item/gun/ballistic/shotgun/trench
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/armored
 	head = /obj/item/clothing/head/helmet/f13/khan
 	backpack_contents = list(


### PR DESCRIPTION
## About The Pull Request

khans are, frankly, WAY more powerful than they have any right to be at the moment. senior enforcer and smith shouldn't exist. having no defined leadership role is good for them, actually- it drives rp and people vying for popularity and power, something we saw a lot of on previous servers. smith is too much too- ALL khans get access to a pretty good set of roundstart gear, and a workable set of recipes to boot.


## Why It's Good For The Game
putting khans squarely in their 'small faction that actually has to be smart to survive' instead of just being able bruteforcie things by virtue of overly high slot count + dedicated playerbase + solid gear and dedi crafting/leadership roles to boot

they should feel more like tribals or a loose informal group, without real defined roles- just people chipping in as needed. this pivots them towards that


## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.



## Changelog

:cl:
balance: khan smith slots 1 >> 0, khan senior enforcer slots 1 >> 0
/:cl:


