### PR TITLE
Enclave Gunny Mask Fix

### DIFF
--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -224,7 +224,6 @@
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/megaphone = 1,
 		/obj/item/card/id/syndicate/anyone = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 3,
 		/obj/item/clothing/mask/chameleon = 1
 		)
 
@@ -234,7 +233,8 @@
 	suit = /obj/item/clothing/suit/armor/f13/power_armor/x02
 
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/plasma = 1
+		/obj/item/gun/energy/laser/plasma = 1,
+		/obj/item/stock_parts/cell/ammo/mfc = 3
 	)
 
 /datum/outfit/loadout/gysgt_melee
@@ -243,7 +243,8 @@
 	head = /obj/item/clothing/head/helmet/f13/enclave/marine
 
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/plasma = 1
+		/obj/item/gun/energy/laser/plasma = 1,
+		/obj/item/stock_parts/cell/ammo/mfc = 3
 	)
 
 


### PR DESCRIPTION
## About The Pull Request

Fixes a (probably) unintended consequence of #224 
Before, the chameleon mask would not spawn in a Gunnery Sergeant's backpack, as there were too many items. This rectifies that.
(Please tell me if I screwed anything up. It's been a while since I've done one of these and I tend to not put much brainpower to remembering how to use GitHub.)

## Why It's Good For The Game

Because everyone should get what the codes says they should!

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
fix: Gunny now gets their mask again!
/:cl:
