### PR TITLE
Makes Prayers and Command Messages Half as Loud (and other misc. changes)

### DIFF
--- a/code/game/machinery/msgterminal.dm
+++ b/code/game/machinery/msgterminal.dm
@@ -196,7 +196,9 @@ GLOBAL_LIST_EMPTY(allTerminals)
 			if(message)
 				var/mutable_appearance/flag = mutable_appearance('icons/obj/flags.dmi', "vtccflag")
 				var/message_span = "notice"
+				var/sound/message_sound = sound(get_sfx('sound/items/stalker_pda_sos.ogg'))
 				var/superiors = "Top Brass"
+
 				switch(terminalid)
 					if("ncr")
 						flag.icon_state = "ncrflag"
@@ -206,6 +208,7 @@ GLOBAL_LIST_EMPTY(allTerminals)
 						flag.icon_state = "legionflag"
 						superiors = "Zion War Council"
 						message_span = get_radio_span(FREQ_LEGION)
+						message_sound = sound(get_sfx('sound/items/cornu.ogg'))
 					if("brotherhood")
 						flag.icon_state = "bosflag"
 						superiors = "Utah Council of Elders"
@@ -214,7 +217,10 @@ GLOBAL_LIST_EMPTY(allTerminals)
 						flag.icon_state = "enclaveflag"
 						superiors = "West Temple HighComm"
 						message_span = get_radio_span(FREQ_ENCLAVE)
-				var/admin_msg = "<span class='adminnotice'><span class='comradio'><b>[icon2html(flag, GLOB.admins)]COMMAND MESSAGE[superiors ? " to [superiors]" : ""]:</b></span> [ADMIN_FULLMONTY(usr)]:<span class=[message_span]><br>\"[message]\"</span> <br>Jump to the reply terminal:[ADMIN_JMP_MSGTERMINAL(src)]</span>"
+
+				message_sound.volume = 50
+
+				var/admin_msg = "<span class='adminnotice'><span class=[message_span]><b>[icon2html(flag, GLOB.admins)]Message[superiors ? " to [superiors]" : ""]:</b></span> [ADMIN_FULLMONTY(usr)]:<span class=[message_span]>\"[message]\"</span> <br>Jump to the reply terminal:[ADMIN_JMP_MSGTERMINAL(src)]</span>"
 				log_terminal("[key_name(usr)] sent a Command message, '[message]' from the terminal at [AREACOORD(usr)].")
 				screen = 6
 				dat += "<span class='good'>Message to Command delivered.</span><br><br>"
@@ -224,7 +230,7 @@ GLOBAL_LIST_EMPTY(allTerminals)
 					if(C.prefs.chat_toggles & CHAT_COMM_CENTER)
 						to_chat(C, admin_msg)
 						if(C.prefs.toggles & SOUND_COMM_CENTER)
-							SEND_SOUND(C, sound('sound/items/stalker_pda_sos.ogg'))
+							SEND_SOUND(C, message_sound)
 			else
 				screen = 7
 				dat += "<span class='bad'>Message to Command aborted.</span><br><br>"

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -20,22 +20,26 @@
 	var/mutable_appearance/icon = mutable_appearance('icons/obj/storage.dmi', "bible")
 	var/prayer_type = "PRAYER"
 	var/prayer_span = "prayer"
+	var/sound/prayer_sound = sound(get_sfx('sound/effects/ghost2.ogg'))
 	var/deity
 	if(usr.job == "Preacher")
 		icon.icon_state = "kingyellow"
 		prayer_type = "PREACHER PRAYER"
 		prayer_span = "preacher_prayer"
+		prayer_sound = sound(get_sfx('sound/effects/pray_chaplain.ogg'))
 		if(GLOB.deity)
 			deity = GLOB.deity
 	if(usr.job == "Legion Orator" || usr.job == "Legion Priestess")
 		icon = mutable_appearance('icons/obj/statue.dmi', "marsred")
 		prayer_type = "LEGION PRAYER"
 		prayer_span = "legion_prayer"
+		prayer_sound = sound(get_sfx('sound/items/cornu.ogg'))
 		deity = "Mars"
 	else if(iscultist(usr))
 		icon.icon_state = "tome"
 		prayer_type = "CULTIST PRAYER"
 		prayer_span = "cult_prayer"
+		prayer_sound = sound(get_sfx('sound/hallucinations/i_see_you1.ogg'))
 		deity = "Nar'Sie"
 	else if(isliving(usr))
 		var/mob/living/L = usr
@@ -43,25 +47,18 @@
 			icon.icon_state = "holylight"
 			prayer_type = "SPIRITUAL PRAYER"
 			prayer_span = "spiritual_prayer"
+			prayer_sound = sound(get_sfx('sound/effects/pray.ogg'))
 
+	prayer_sound.volume = 50
 	var/msg_tmp = msg
-	msg = "<span class='adminnotice'><span class=[prayer_span]>[icon2html(icon, GLOB.admins)][prayer_type][deity ? " to [deity]" : ""]:</span> [ADMIN_FULLMONTY(src)] [ADMIN_SC(src)]:<span class='notice'><br>\"[msg]\"</span></span>"
+	msg = "<span class='adminnotice'><span class=[prayer_span]>[icon2html(icon, GLOB.admins)][prayer_type][deity ? " to [deity]" : ""]:</span> [ADMIN_FULLMONTY(src)] [ADMIN_SC(src)]:<span class='notice'>\"[msg]\"</span></span>"
 
 	for(var/client/C in GLOB.admins)
 		if(C.prefs.chat_toggles & CHAT_PRAYER)
 			to_chat(C, msg)
 			if(C.prefs.toggles & SOUND_PRAYERS)
-				switch(prayer_type)
-					if("PREACHER PRAYER")
-						SEND_SOUND(C, sound('sound/effects/pray_chaplain.ogg'))
-					if("LEGION PRAYER")
-						SEND_SOUND(C, sound('sound/items/cornu.ogg'))
-					if("SPIRITUAL PRAYER")
-						SEND_SOUND(C, sound('sound/effects/pray.ogg'))
-					if("CULTIST PRAYER")
-						SEND_SOUND(C, sound('sound/hallucinations/i_see_you1.ogg'))
-					else
-						SEND_SOUND(C, sound('sound/effects/ghost2.ogg'))
+				SEND_SOUND(C, prayer_sound)
+
 	to_chat(usr, "<span class='info'>You pray to the gods: \"[msg_tmp]\"</span>")
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Prayer") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -98,8 +98,12 @@
 
 	log_directed_talk(mob, H, input, LOG_ADMIN, "reply")
 	message_admins("[key_name_admin(src)] replied to [key_name_admin(H)]'s [sender] message with: \"[input]\"")
-	SEND_SOUND(H, sound('sound/items/stalker_pda_news.ogg'))
-	to_chat(H, "<span class='notice'>You hear something crackle in your headset for a moment before a voice speaks.</span><br><span class=[radio_span]>\"This is <b>[sender_full_info]</b>, [input]\"</span>")
+
+	var/sound/message_sound = sound(get_sfx('sound/items/stalker_pda_news.ogg'))
+	message_sound.volume = 50
+
+	SEND_SOUND(H, message_sound)
+	to_chat(H, "<span class='notice'>You hear something crackle in your headset for a moment before a voice speaks:</span><span class=[radio_span]>\"This is <b>[sender_full_info]</b>, [input]\"</span>")
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Headset Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
- Prayers and command message sounds are now half as loud as they used to be.
- Different span used for command message headers for admins, now takes faction colors instead of golden command color.
- Slightly different text formatting on headset and command messages.
