### PR TITLE
Chruch PR, attempt 3 to fix merge coflict

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -3082,7 +3082,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland/west)
+/area/f13/wasteland/bighorn)
 "alL" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/f13/wood,
@@ -5941,6 +5941,12 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/west)
+"axj" = (
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "axk" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14553,9 +14559,9 @@
 /turf/open/indestructible/ground/outside/savannah/bottomright,
 /area/f13/building/nanotrasen)
 "bab" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/west)
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/bighorn)
 "bac" = (
 /obj/structure/flora/wasteplant/wild_punga,
 /turf/open/indestructible/ground/outside/dirt{
@@ -22166,6 +22172,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/city/bighorn)
+"cfA" = (
+/obj/dugpit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/bighorn)
 "cfD" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -23751,6 +23761,13 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/building/massfusion)
+"cBo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "cBt" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -24104,6 +24121,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/brotherhood/chemistry)
+"cLQ" = (
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "cMI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -24968,6 +24991,13 @@
 	icon_state = "plating"
 	},
 /area/f13/building/firestation)
+"dmL" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/item/storage/fancy/candle_box,
+/obj/item/gun/ballistic/shotgun/hunting,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "dmO" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/f13/wood,
@@ -25106,6 +25136,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"dpR" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland/bighorn)
 "dqx" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -25349,6 +25385,24 @@
 /area/f13/brotherhood/leisure)
 "dwM" = (
 /obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/bighorn)
+"dwP" = (
+/obj/structure/closet/crate/grave,
+/obj/item/reagent_containers/food/snacks/grown/poppy{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/snacks/grown/poppy{
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/food/snacks/grown/poppy{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/snacks/grown/poppy{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/grown/harebell,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/bighorn)
 "dxg" = (
@@ -26511,6 +26565,14 @@
 /obj/item/stack/f13Cash/random/denarius/med,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"edr" = (
+/obj/structure/railing/wood{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/bighorn)
 "edw" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13{
@@ -27740,6 +27802,28 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/brotherhood)
+"eOm" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 4
+	},
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "eOy" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -28567,6 +28651,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
+"fjN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "fjQ" = (
 /obj/structure/table/wood,
 /obj/machinery/door/poddoor/shutters{
@@ -28900,6 +28988,13 @@
 	pixel_y = -2
 	},
 /turf/open/transparent/openspace,
+/area/f13/city/bighorn)
+"ftD" = (
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "ftF" = (
 /obj/structure/flora/grass/wasteland,
@@ -31428,6 +31523,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/f13/brotherhood/leisure)
+"gOs" = (
+/obj/structure/statue/wood/headstonewood{
+	pixel_y = 2
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/city/bighorn)
 "gOH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -34737,6 +34838,12 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
+"iIs" = (
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite,
+/obj/item/reagent_containers/food/snacks/store/cake/holy_cake,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "iIO" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/oil,
@@ -35025,6 +35132,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/museum)
+"iOF" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "iOU" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -37766,6 +37877,13 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ruins)
+"kom" = (
+/obj/structure/spirit_board{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "kox" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/mug{
@@ -39610,6 +39728,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
+"lnb" = (
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/mob/living/simple_animal/butterfly,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/bighorn)
 "lnm" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light{
@@ -39736,6 +39863,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/museum)
+"lpM" = (
+/obj/structure/railing/wood{
+	pixel_x = -1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland/bighorn)
 "lpY" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40319,12 +40455,23 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
+"lEk" = (
+/obj/structure/bed,
+/obj/effect/landmark/start/f13/preacher,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "lEr" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/east)
+"lEw" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland/bighorn)
 "lEA" = (
 /obj/structure/table/wood,
 /obj/item/paper/pamphlet{
@@ -40357,6 +40504,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
+"lFp" = (
+/mob/living/simple_animal/butterfly,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/bighorn)
 "lFy" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = null;
@@ -40620,6 +40771,11 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/bunker)
+"lLR" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderrighttop"
+	},
+/area/f13/wasteland/bighorn)
 "lMd" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -41537,6 +41693,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mhQ" = (
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "mhX" = (
 /obj/structure/simple_door/house{
 	icon_state = "glassclosing"
@@ -41609,6 +41772,12 @@
 	icon_state = "verticalleftborderright1"
 	},
 /area/f13/wasteland/east)
+"mjH" = (
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "mkh" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -42520,6 +42689,10 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/savannah/rightcenter,
 /area/f13/caves)
+"mIu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "mIw" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
@@ -42723,6 +42896,13 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/building/hospital)
+"mOu" = (
+/obj/structure/simple_door/metal/fence/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland/bighorn)
 "mOV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -43474,6 +43654,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
+"nmo" = (
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/bighorn)
 "nmx" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -43527,6 +43711,14 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nng" = (
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/bighorn)
 "nni" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 1
@@ -44294,7 +44486,7 @@
 "nHC" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/west)
+/area/f13/wasteland/bighorn)
 "nHR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
@@ -47186,6 +47378,11 @@
 /obj/structure/junk/locker,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"pdF" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/book/bible/booze,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "pdO" = (
 /obj/machinery/computer/monitor,
 /obj/structure/cable{
@@ -47980,7 +48177,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland/west)
+/area/f13/wasteland/bighorn)
 "pzo" = (
 /obj/machinery/mineral/wasteland_vendor/advcomponents,
 /turf/open/floor/f13{
@@ -48494,6 +48691,15 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/east)
+"pNy" = (
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "pNB" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/desert,
@@ -49058,6 +49264,15 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland/train)
+"qgy" = (
+/obj/structure/chair/pew{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "qgB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -51395,6 +51610,13 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
+"rpL" = (
+/obj/structure/window/fulltile/wood,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "rpN" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
@@ -52906,6 +53128,11 @@
 	dir = 1
 	},
 /area/f13/building/museum)
+"seM" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/f13/hubologist,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "sfo" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt,
@@ -53843,6 +54070,10 @@
 "sGk" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood)
+"sGr" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/bighorn)
 "sGY" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
@@ -53881,6 +54112,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"sHZ" = (
+/obj/structure/railing/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland/bighorn)
 "sIa" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -54045,6 +54282,12 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland/bighorn)
+"sOu" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "sOF" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag{
@@ -55465,7 +55708,7 @@
 "tzi" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/west)
+/area/f13/wasteland/bighorn)
 "tzm" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
@@ -60154,6 +60397,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"vXr" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/reagent_containers/food/snacks/twobread,
+/obj/item/reagent_containers/food/snacks/twobread,
+/obj/item/reagent_containers/food/snacks/store/bread/plain,
+/obj/item/reagent_containers/food/snacks/store/bread/plain,
+/obj/item/reagent_containers/food/snacks/store/bread/plain,
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/turf/open/floor/carpet,
+/area/f13/city/bighorn)
 "vXy" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8";
@@ -60167,6 +60427,15 @@
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
 	},
+/area/f13/wasteland/bighorn)
+"vXB" = (
+/obj/structure/railing/wood{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/mob/living/simple_animal/butterfly,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/bighorn)
 "vXG" = (
 /obj/structure/sign/map/right{
@@ -60221,6 +60490,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/firestation)
+"vZC" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "wae" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -64202,6 +64475,10 @@
 /area/f13/followers)
 "ydE" = (
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland/bighorn)
+"ydG" = (
+/obj/structure/closet/crate/grave,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/bighorn)
 "yeo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -84427,18 +84704,18 @@ wEd
 sEB
 wEd
 wEd
-wEd
-sEB
-aqA
-vxN
-vxN
-vxN
-vxN
-vxN
-vxN
-wOD
-vxN
-vxN
+dQd
+aXF
+lLR
+oBf
+oBf
+oBf
+oBf
+oBf
+oBf
+tJO
+oBf
+oBf
 woT
 woT
 woT
@@ -84684,18 +84961,18 @@ wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-vtR
-lWk
-lWk
-lWk
-lWk
-lWk
-lWk
-lWk
-lWk
-lWk
+dQd
+dQd
+lEw
+dfu
+dfu
+dfu
+dfu
+dfu
+dfu
+dfu
+dfu
+dfu
 rbU
 rbU
 rbU
@@ -84939,20 +85216,20 @@ pUh
 wEd
 flC
 wEd
-ahE
-wEd
-sEB
 wEd
 wEd
-flC
-wEd
-wEd
-wEd
-wEd
-wEd
-flC
-wEd
-wEd
+aXF
+dQd
+dQd
+ahF
+dQd
+dQd
+dQd
+dQd
+dQd
+ahF
+dQd
+dQd
 nvE
 nvE
 nvE
@@ -85198,18 +85475,18 @@ wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+dQd
+dQd
+dQd
+dQd
+bji
+bji
+bji
+bji
+bji
+dQd
+dQd
+dQd
 nvE
 qiP
 nvE
@@ -85455,18 +85732,18 @@ wEd
 wEd
 wEd
 sEB
-wEd
-flC
-wEd
-wEd
-sEB
-jzD
-iKu
-wEd
-wEd
-wEd
-wEd
-wEd
+dQd
+aXF
+dQd
+gOs
+bji
+cLQ
+qgy
+mjH
+bji
+bji
+dQd
+dQd
 nvE
 nvE
 nvE
@@ -85704,26 +85981,26 @@ wEd
 wEd
 wEd
 wEd
-lPa
-wEd
-wEd
-sEB
-wEd
-wEd
-flC
-wEd
-flC
-wEd
-wEd
-wEd
-wEd
-wWc
-xCM
-wEd
-wEd
-wEd
-wEd
-wEd
+qjc
+dQd
+dQd
+aXF
+dQd
+dQd
+ahF
+dQd
+ahF
+dQd
+dQd
+vZC
+lUX
+lUX
+lUX
+lUX
+mIu
+bji
+dQd
+dQd
 nvE
 nvE
 nvE
@@ -85961,26 +86238,26 @@ wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-flC
-wEd
-wEd
-wEd
-wEd
-jyZ
-wEd
-wEd
-wEd
-flC
-wEd
-flC
-wEd
-wEd
-wEd
-lPa
-wEd
+dQd
+dQd
+dQd
+ahF
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+vZC
+lUX
+lUX
+mIu
+lUX
+lUX
+bji
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -86218,26 +86495,26 @@ wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-jzD
-iKu
-wEd
-flC
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+dQd
+dQd
+ueP
+rwS
+rwS
+rwS
+rwS
+rwS
+rwS
+dCX
+dQd
+gOs
+pNy
+mjH
+mIu
+cLQ
+mhQ
+bji
+bab
+aXF
 wEd
 wEd
 wEd
@@ -86475,26 +86752,26 @@ wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wWc
-xCM
-wEd
-wEd
-wEd
-wEd
-wEd
-flC
-wEd
-wEd
-flC
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+dQd
+dQd
+sHZ
+edr
+edr
+edr
+edr
+edr
+vXB
+lpM
+ahF
+cbN
+lUX
+lUX
+lUX
+lUX
+mIu
+cbN
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -86732,26 +87009,26 @@ wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-sEB
-wEd
-sEB
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-flC
-wEd
-wEd
-wEd
+dQd
+dQd
+sHZ
+ydG
+diz
+ydG
+diz
+dwP
+diz
+lpM
+dQd
+bji
+cLQ
+mjH
+lUX
+cLQ
+ftD
+bji
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -86989,26 +87266,26 @@ wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-flC
-jzD
-eNJ
-eNJ
-eNJ
-iKu
-wEd
-wEd
-wEd
-wEd
-wEd
-flC
-wEd
+dQd
+dQd
+sHZ
+diz
+diz
+lFp
+diz
+diz
+diz
+mOu
+aXF
+bji
+lUX
+mIu
+mIu
+lUX
+lUX
+bji
+ahF
+dQd
 wEd
 wEd
 wEd
@@ -87246,26 +87523,26 @@ wEd
 wEd
 tTm
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-xOD
-vOV
-vOV
-vOV
-pUh
-wEd
-lPa
-wEd
-wEd
-wEd
-wEd
-wEd
+dQd
+dQd
+sHZ
+ydG
+diz
+ydG
+diz
+ydG
+diz
+lpM
+dQd
+bji
+kIS
+iIs
+pdF
+axj
+kIS
+bji
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -87503,26 +87780,26 @@ aPQ
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-sEB
-wEd
-sEB
-wEd
-xOD
-vOV
-vOV
-vOV
-pUh
-wEd
-wEd
-wEd
-wEd
-ahE
-wEd
-wEd
+dQd
+dQd
+sHZ
+diz
+diz
+diz
+diz
+diz
+diz
+lpM
+dQd
+cbN
+kIS
+kIS
+kIS
+kIS
+kIS
+cbN
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -87761,25 +88038,25 @@ sEB
 jzD
 eNJ
 pzg
-eNJ
-iKu
-wEd
-wEd
-wEd
-wEd
-wEd
-xOD
-vOV
-vOV
-sfD
-xCM
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+rwS
+sHZ
+ydG
+diz
+ydG
+diz
+ydG
+diz
+lpM
+ahF
+bji
+kIS
+sOu
+kom
+sOu
+kIS
+bji
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -88019,24 +88296,24 @@ kyU
 vOV
 tzi
 nHC
-pUh
-wEd
-wEd
-wEd
-wEd
-wEd
-wWc
-hVy
-hVy
-xCM
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+sHZ
+diz
+lFp
+diz
+diz
+diz
+diz
+lpM
+dQd
+bji
+kIS
+bji
+bji
+bji
+bji
+bji
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -88274,26 +88551,26 @@ wEd
 xOD
 vOV
 vOV
-sfD
-hVy
-xCM
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-lPa
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+dpR
+oiD
+sHZ
+ydG
+diz
+ydG
+diz
+cfA
+dZG
+lpM
+dQd
+bji
+kIS
+fjN
+cBo
+eOm
+iOF
+bji
+dQd
+aXF
 wEd
 wEd
 wEd
@@ -88531,26 +88808,26 @@ wEd
 xOD
 vOV
 vOV
-pUh
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+fFU
+dQd
+sHZ
+nng
+nng
+nng
+nng
+nng
+lnb
+lpM
+dQd
+rpL
+seM
+kIS
+fjN
+fjN
+lEk
+rpL
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -88788,26 +89065,26 @@ vyl
 wWc
 hVy
 hVy
-xCM
-wEd
-wEd
-sEB
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-flC
-wEd
-wEd
-wEd
+bpa
+dQd
+awv
+oiD
+oiD
+oiD
+oiD
+oiD
+oiD
+bpa
+dQd
+bji
+bji
+dmL
+fjN
+vXr
+bji
+bji
+dQd
+dQd
 wEd
 wEd
 lPa
@@ -89045,26 +89322,26 @@ pIq
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-flC
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+ahF
+dQd
+dQd
+dQd
+bji
+bji
+vZC
+bji
+bji
+dQd
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -89302,26 +89579,26 @@ xCM
 wEd
 wEd
 vyl
-jzD
+ueP
 alI
-wEd
-wEd
-wEd
-tTm
-wEd
-aPQ
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+dQd
+dQd
+dQd
+sGr
+dQd
+nmo
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
 wEd
 wEd
 wEd
@@ -89418,7 +89695,7 @@ geF
 aZH
 vOV
 cQh
-bab
+aZT
 dXd
 bad
 geF
@@ -89567,18 +89844,18 @@ wEd
 wEd
 pNB
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+dQd
+dQd
+dQd
+dQd
+dQd
+dQd
+aXF
+dQd
+dQd
+dQd
+dQd
+dQd
 wEd
 wEd
 wEd

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -1,4 +1,4 @@
-/obj/item/claymore 
+/obj/item/claymore
 	name = "claymore"
 	desc = "What are you standing around staring at this for? Get to killing!"
 	icon_state = "claymore"
@@ -782,7 +782,7 @@
 	if(user.a_intent == INTENT_HARM)
 		return ..()
 
-	if(!user.mind || user.mind.assigned_role != "Chaplain")
+	if(!user.mind || user.mind.assigned_role != "Preacher")
 		to_chat(user, "<span class='notice'>You are not close enough with [deity_name] to use [src].</span>")
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

this PR works on redesigning, and moving the warren church to bighorn

![2023-11-24 13 33 01](https://github.com/f13babylon/f13babylon/assets/118483925/f9e8cb97-cdb1-46b7-950a-4c0364fad0a8)

![2023-11-24 13 33 20](https://github.com/f13babylon/f13babylon/assets/118483925/3ee346c1-c788-4c87-8e9b-31381030bc31)


the preacher already is considered a bighorn citizen so the church being in warren used to make no sense

this fixes the issue and adds a few additional community requested changes


this is a second attempt because the last one was closed because of a item that crashed the server that i forgot to mention in changelogs


### **please if you want something changed then say it**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Preacher is supposed to be a citizen of bighorn therefore have a church in bighorn, but they for some reason had a church in warren instead of bighorn, i have heard some community members arguing about it and decided to act on it as it only makes sense for the church to be somewhere close to bighorn instead of in warren.

adds more items for the priest to use, adds an actual spawning landmark for the priest to spawn in the church instead of a random matrix

adds several other misc items such as a angel food cake, a holy water bottle, bread, wine, and several spare bibles

oh also gives the preacher closet a shotgun with no ammo, since the preacher landmark seems to have a shotgun icon.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: church in (front of) bighorn
add: bible, bread, wine and water crate
add: holy water flask
add: angel food cake
add: Priest shotgun (with no ammo)
add: Preacher starter landmark
add: water bottles
tweak: changes the bible on the table to the whiskey bible
fix: fixes the prayer breads not working

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
