### PR TITLE
Stamina Damage Fix (For Real This Time)

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -293,6 +293,8 @@
 		log_combat(firer, L, "shot", src, reagent_note)
 	else
 		L.log_message("has been shot by [firer] with [src]", LOG_ATTACK, color="orange")
+	if(irradiate != 0)
+		L.apply_damage(irradiate, RADIATION)
 
 	return L.apply_effects(stun, knockdown, unconscious, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter, knockdown_stamoverride, knockdown_stam_max)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -135,6 +135,7 @@
 	var/knockdown_stamoverride
 	var/knockdown_stam_max
 	var/unconscious = 0
+	var/irradiate = 0
 	var/stutter = 0
 	var/slur = 0
 	var/eyeblur = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -135,7 +135,6 @@
 	var/knockdown_stamoverride
 	var/knockdown_stam_max
 	var/unconscious = 0
-	var/irradiate = 0
 	var/stutter = 0
 	var/slur = 0
 	var/eyeblur = 0
@@ -294,7 +293,7 @@
 	else
 		L.log_message("has been shot by [firer] with [src]", LOG_ATTACK, color="orange")
 
-	return L.apply_effects(stun, knockdown, unconscious, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter, knockdown_stamoverride, knockdown_stam_max)
+	return L.apply_effects(stun, knockdown, unconscious, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter, knockdown_stamoverride, knockdown_stam_max)
 
 /obj/item/projectile/proc/vol_by_damage()
 	if(src.damage)


### PR DESCRIPTION
The stamina damage issues were caused by incorrect arguments being passed to projectile.dm apply_effect proc call.
