### PR TITLE
removes roleplay exclusive from existence

### DIFF
--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -35,7 +35,6 @@ Mayor
 	department_flag = DEP_BIGHORN
 	total_positions = 1
 	spawn_positions = 1
-	roleplay_exclusive_notify = 1
 	supervisors = "Yourself"
 	description = "You are the benevolent tyrant of La Verkin, chosen by the people to represent and lead them. Pass laws to protect your citizens, distribute town funds and make deals with the powers present within the Region to better the people, and yourself, of course."
 	selection_color = "#d7b088"
@@ -180,7 +179,6 @@ Mayor
 	department_flag = DEP_BIGHORN
 	total_positions = 2
 	spawn_positions = 2
-	roleplay_exclusive_notify = 1
 	supervisors = "the free market and La Verkin laws"
 	description = "As a proprietor of the Blue Oyster, you are responsible for ensuring both citizens and travellers in La Verkin can get some food, drink and rest. This town is usually run by the Great Khans, and the farm within their compound could provide fresh supplies for your business, so try negotiating with them if they are present."
 	enforces = "While you have dominion over your private business, your premium status as a citizen may be revoked if you are considered a danger to the populace or anger those in control of the town."
@@ -269,7 +267,6 @@ Mayor
 	department_flag = DEP_BIGHORN
 	total_positions = 2
 	spawn_positions = 2
-	roleplay_exclusive_notify = 1
 	supervisors = "the free market, Sierra Trading Company, and La Verkin laws"
 	description = "You are one of the many workers who live in the city of La Verkin. Working with the town council you have rented out a space in the shop for you to make your living."
 	enforces = "While you have dominion over your private business, your premium status as a citizen may be revoked if you are considered a danger to the populace or anger those in control of the town."
@@ -340,7 +337,6 @@ Mayor
 	department_flag = DEP_BIGHORN
 	total_positions = -1
 	spawn_positions = -1
-	roleplay_exclusive_notify = 1
 	supervisors = "La Verkin laws"
 	description = "You are a citizen living in La Verkin. Treat your town with respect and make sure to follow the laws in place, as your premium status may be revoked if you are considered a danger to the populace. One of the local businesses may have work if you require funds."
 	enforces = "Your premium status as a citizen may be revoked if you are considered a danger to the populace or anger those in control of the town"
@@ -375,7 +371,6 @@ Mayor
 	faction = FACTION_WASTELAND
 	total_positions = 1
 	spawn_positions = 1
-	roleplay_exclusive_notify = 1
 	supervisors = "your faith and the Five Laws"
 	description = "You are a New Canaanite serving as a missionary to Bighorn, and a connection to other Mormons. While the town has no shortage of skepticism or biting remarks about Faith, you do what you can for the people of Bighorn, for God has love, even for the Gentiles. Sometimes this also means advocating on behalf of criminals, if the evidence against them is weak enough."
 	enforces = "Your premium status as a citizen may be revoked if you break the Five Laws too often or too severely. Khan justice is harsh, but typically also fair. However, your chapel is sacred ground, and you and your clergy have the right to protect it from bloodshed."
@@ -673,7 +668,6 @@ Mayor
 	department_flag = DEP_BIGHORN
 	total_positions = 1
 	spawn_positions = 1
-	roleplay_exclusive_notify = 1
 	supervisors = "the mayor"
 	description = "Working alongside the Mayor, you've known them for a while. Your duties mainly consist of handling appointments and managing mundane tasks."
 	selection_color = "#dcba97"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -58,7 +58,6 @@ Elder
 	supervisors = "the high elders"
 	selection_color = "#7f8c8d"
 	req_admin_notify = 1
-	roleplay_exclusive_notify = 1
 
 	exp_requirements = 0
 
@@ -974,7 +973,6 @@ Off-Duty
 	enforces = "You are not permited to leave the base. You are a non-combatant. You cannot join any raids or battles on the surface. You cannot not run dungeons."
 	selection_color = "#95a5a6"
 	roleplay_exclusive_notify = 1
-	exp_requirements = 0
 	exp_type = EXP_TYPE_WASTELAND//So you can't sit on it and play Baron / Inquisitor. :)
 	outfit = /datum/outfit/job/bos/f13offdutybos
 	access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -539,7 +539,6 @@
 	outfit = /datum/outfit/job/enclave/noncombat/enclavesci
 	exp_type = EXP_TYPE_FALLOUT
 	exp_requirements = 600
-	roleplay_exclusive_notify = 1
 	access = list(ACCESS_ENCLAVE, ACCESS_SECURITY, ACCESS_AI_UPLOAD)
 
 /datum/outfit/job/enclave/noncombat/enclavesci
@@ -596,7 +595,6 @@
 	supervisors = "Enclave Upper Echelon, Air Force Division."
 	outfit = /datum/outfit/job/enclave/noncombat/enclavepilot
 	req_admin_notify = 1
-	roleplay_exclusive_notify = 1
 	exp_requirements = 1000
 	access = list(ACCESS_ENCLAVE, ACCESS_ENCLAVE_COMMAND, ACCESS_SECURITY, ACCESS_AI_UPLOAD)
 
@@ -641,7 +639,6 @@
 	enforces = "You are not permitted to leave the base. You are a non-combatant. You cannot join any raids or battles on the surface. You cannot run dungeons."
 	supervisors = "Everyone else."
 	outfit = /datum/outfit/job/enclave/noncombat/f13BDUTY
-	roleplay_exclusive_notify = 1
 	exp_type = EXP_TYPE_FALLOUT
 	exp_requirements = 600
 
@@ -731,7 +728,6 @@
 	supervisors = "United States Secret Service"
 	access = list(ACCESS_ENCLAVE, ACCESS_CHANGE_IDS, ACCESS_ENCLAVE_COMMAND, ACCESS_SECURITY, ACCESS_AI_UPLOAD)
 	outfit = /datum/outfit/job/enclave/noncombat/enc_maj
-	roleplay_exclusive_notify = 1
 	req_admin_notify = 1
 	exp_requirements = 2500//Well above Lieutenant for good reason. It's RP exclusive, and comes with some heavy perks.
 

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -53,7 +53,6 @@
 	req_admin_notify = 1
 	exp_type = EXP_TYPE_KHAN
 	exp_requirements = 300
-	roleplay_exclusive_notify = 1
 	exp_type = EXP_TYPE_KHAN
 	outfit = /datum/outfit/job/khan/smith
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -151,7 +151,6 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	display_order = JOB_DISPLAY_ORDER_ORATOR
 	access = list(ACCESS_LEGION, ACCESS_CHANGE_IDS, ACCESS_LEGION_COMMAND, ACCESS_LEGION_SLAVE)
 	minimal_access = list(ACCESS_LEGION, ACCESS_CHANGE_IDS, ACCESS_LEGION_COMMAND, ACCESS_LEGION_SLAVE)
-	roleplay_exclusive_notify = 1
 	exp_type = EXP_TYPE_LEGION
 	exp_requirements = 900
 
@@ -198,7 +197,6 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	display_order = JOB_DISPLAY_ORDER_PRIESTESS
 	access = list(ACCESS_LEGION, ACCESS_LEGION_COMMAND, ACCESS_LEGION_SLAVE)
 	minimal_access = list(ACCESS_LEGION, ACCESS_LEGION_COMMAND, ACCESS_LEGION_SLAVE)
-	roleplay_exclusive_notify = 1
 	exp_type = EXP_TYPE_LEGION
 	exp_requirements = 900
 
@@ -1038,7 +1036,6 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	supervisors = "the Centurion."
 	display_order = JOB_DISPLAY_ORDER_IMMUNE
 	outfit = /datum/outfit/job/CaesarsLegion/immune
-	roleplay_exclusive_notify = 1
 	exp_requirements = 0
 
 /datum/outfit/job/CaesarsLegionimmune
@@ -1073,7 +1070,6 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	supervisors = "the Centurion."
 	display_order = JOB_DISPLAY_ORDER_CAMPFOLLOWER
 	outfit = /datum/outfit/job/CaesarsLegion/f13campfollower
-	roleplay_exclusive_notify = 1
 	exp_requirements = 0
 
 /datum/outfit/job/CaesarsLegion/f13campfollower
@@ -1134,7 +1130,6 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	supervisors = "the Centurion"
 	display_order = JOB_DISPLAY_ORDER_AUXILIA
 	outfit = /datum/outfit/job/CaesarsLegion/auxilia
-	roleplay_exclusive_notify = 1
 	exp_requirements = 0
 	exp_type = EXP_TYPE_WASTELAND//So you can't sit on it and play Centurion. :)
 
@@ -1257,7 +1252,6 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	display_order = JOB_DISPLAY_ORDER_LEGIONSLAVE
 	exp_requirements = 0
 	outfit = /datum/outfit/job/CaesarsLegion/slave
-	roleplay_exclusive_notify = 1
 	exp_type = EXP_TYPE_WASTELAND//So you can't sit on it and play Centurion. :)
 
 	access = list(ACCESS_LEGION_SLAVE)
@@ -1386,7 +1380,6 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 	spawn_positions = 1
 	description = "You are the feared and respected disciplinary corps of the Legion. Acting as both master of the Slaves and de-facto executioner of the Centurion's will within his ranks, you are a faceless and undoubtedly cruel torturer... but be careful to not let your hubris and malice lead to a strikeback from those you thought broken."
 	supervisors = "the Decani and Centurion"
-	roleplay_exclusive_notify = 1
 	exp_requirements = 0
 	display_order = JOB_DISPLAY_ORDER_SLAVEMASTER
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -401,7 +401,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_NCR_COMMAND)
 	display_order = JOB_DISPLAY_ORDER_SERGEANT
 	outfit = /datum/outfit/job/ncr/f13drillsergeant
-	roleplay_exclusive_notify = 1
 	exp_requirements = 0
 
 	loadout_options = list( // ALL: Bayonet
@@ -480,7 +479,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	supervisors = "The Captain and the NCR"
 	display_order = JOB_DISPLAY_ORDER_REPRESENTATIVE
 	outfit = /datum/outfit/job/ncr/f13representative
-	roleplay_exclusive_notify = 1
 	exp_type = EXP_TYPE_NCR
 	exp_requirements = 840
 
@@ -927,7 +925,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_TROOPER
 	outfit = /datum/outfit/job/ncr/f13mp
-	roleplay_exclusive_notify = 1
 	exp_requirements = 0
 
 /datum/outfit/job/ncr/f13mp		// .45 Pistol, Beanbag Shotgun, Military baton
@@ -1246,7 +1243,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_NCR_COMMAND)
 	display_order = JOB_DISPLAY_ORDER_MEDICALOFFICER
 	outfit = /datum/outfit/job/ncr/f13medicalofficer
-	roleplay_exclusive_notify = 1
 	exp_type = EXP_TYPE_NCR
 	exp_requirements = 840
 	matchmaking_allowed = list(
@@ -1304,7 +1300,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_LOGISTICSOFFICER
 	outfit = /datum/outfit/job/ncr/f13logisticsofficer
-	roleplay_exclusive_notify = 1
 	exp_type = EXP_TYPE_NCR
 	exp_requirements = 840
 
@@ -1381,7 +1376,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	exp_type = EXP_TYPE_NCR
 	display_order = JOB_DISPLAY_ORDER_REAR_ECHELON
 	outfit = /datum/outfit/job/ncr/f13rearechelon
-	roleplay_exclusive_notify = 1
 	exp_requirements = 0
 
 /datum/outfit/job/ncr/f13rearechelon

--- a/code/modules/jobs/job_types/tribal.dm
+++ b/code/modules/jobs/job_types/tribal.dm
@@ -98,7 +98,6 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	exp_requirements = 0
 	total_positions = -1
 	spawn_positions = -1
-	roleplay_exclusive_notify = 1
 
 	outfit = /datum/outfit/job/tribal/gatherer
 
@@ -132,7 +131,6 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	exp_requirements = 300
 	total_positions = 1
 	spawn_positions = 1
-	roleplay_exclusive_notify = 1
 
 	outfit = /datum/outfit/job/tribal/shaman
 


### PR DESCRIPTION
##About this PR
redundant feature. roles that are not meant to run dungeons are already defined as such in their enforces. also replaces the very silly enforce from followers with the default one.