### PR TITLE
enclave nerfs

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -310,7 +310,7 @@
 	},
 /area/f13/tunnel)
 "dg" = (
-/obj/structure/frame/machine,
+/obj/effect/landmark/start/f13/enclave_synthetic,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "dh" = (
@@ -3672,6 +3672,10 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/f13,
+/area/f13/enclave)
+"CW" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave)
 "CX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23235,7 +23239,7 @@ Jj
 Jx
 Jx
 nm
-dg
+EI
 iI
 iI
 Sb
@@ -23492,8 +23496,8 @@ gm
 Hs
 CT
 AW
-EI
-iI
+CW
+dg
 Cx
 iI
 iI

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -2072,12 +2072,12 @@
 "qW" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/bot,
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
+/obj/item/card/id/syndicate,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "qY" = (

--- a/code/modules/fallout/weapons/explosives/f13grenade.dm
+++ b/code/modules/fallout/weapons/explosives/f13grenade.dm
@@ -60,7 +60,7 @@
 	ex_light = 4
 	ex_flame = 4
 	shrapnel_type = /obj/item/projectile/bullet/shrapnel/plasma
-	shrapnel_radius = 10
+	shrapnel_radius = 4 //lol no
 	var/rad_damage = 300
 
 /obj/item/grenade/f13/plasma/remnant
@@ -68,7 +68,7 @@
 	desc = "A prewar military-grade plasma grenade, used for permanent riot suppression pre-war. This one appears old. Corroded, even. Here's hoping it doesn't explode in your hand."
 	icon_state = "plasma"
 	shrapnel_type = /obj/item/projectile/bullet/shrapnel/plasma
-	shrapnel_radius = 4//Far less, for balance sake.
+	shrapnel_radius = 2//Far less, for balance sake.
 
 /obj/item/grenade/f13/plasma/prime(mob/living/lanced_by)
 	. = ..()

--- a/code/modules/fallout/weapons/projectiles/shrapnel.dm
+++ b/code/modules/fallout/weapons/projectiles/shrapnel.dm
@@ -3,12 +3,13 @@
 	embedding = list(embed_chance=0, ignore_throwspeed_threshold=FALSE, fall_chance=0, embed_chance_turf_mod=0, payload = /obj/item/shrapnel)
 	custom_materials = list(/datum/material/iron=50)
 	damage = 35
-	armour_penetration = 0.8
+	armour_penetration = 0.2
 	damage_type = BURN
-	range = 30
+	range = 7
 	dismemberment = 0
 	ricochets_max = 0
 	ricochet_chance = 0
+	flag = "energy"
 	ricochet_incidence_leeway = 0
 	sharpness = SHARP_EDGED
 	wound_bonus = 60
@@ -30,6 +31,7 @@
 	dismemberment = 15//This is a HORRIBLE idea, but by god it'll be funny. - Carl
 	icon = 'icons/obj/shards.dmi'
 	icon_state = "tiny"
+	flag = "bullet"
 	armour_penetration = 1//Identical with this. :)
 	ricochets_max = 0
 	ricochet_chance = 0

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -87,7 +87,7 @@
 		/obj/item/pda = 1,
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
-		/obj/item/card/id/syndicate/anyone =1
+		/obj/item/card/id/syndicate =1
 		)
 
 /datum/outfit/loadout/cpt_ballistics
@@ -155,7 +155,7 @@
 		/obj/item/pda = 1,
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
-		/obj/item/card/id/syndicate/anyone = 1,
+		/obj/item/card/id/syndicate = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/clothing/mask/chameleon = 1
 		)
@@ -206,14 +206,17 @@
 	exp_requirements = 1020
 
 	loadout_options = list(
-		/datum/outfit/loadout/gysgt_ballistics, // APA
-		/datum/outfit/loadout/gysgt_melee, // MCA
+		/datum/outfit/loadout/gysgt_caster,
+		/datum/outfit/loadout/gysgt_gauss,
+		/datum/outfit/loadout/gysgt_spear
 		)
 
 /datum/outfit/job/enclave/peacekeeper/f13gysergeant
 	name = "Enclave Gunnery Sergeant"
 	jobtype = /datum/job/enclave/f13gysergeant
 	accessory = /obj/item/clothing/accessory/enclave/gunnery_sergeant
+	head = /obj/item/clothing/head/helmet/f13/enclave/marine
+	suit = /obj/item/clothing/suit/armor/f13/enclave/marine
 	ears = /obj/item/radio/headset/headset_enclave/command
 
 	backpack_contents = list(
@@ -223,30 +226,38 @@
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/megaphone = 1,
-		/obj/item/card/id/syndicate/anyone = 1,
+		/obj/item/card/id/syndicate = 1,
 		/obj/item/clothing/mask/chameleon = 1
 		)
 
-/datum/outfit/loadout/gysgt_ballistics
-	name = "Armored Rifleman"
-	head = /obj/item/clothing/head/helmet/f13/power_armor/x02helmet
-	suit = /obj/item/clothing/suit/armor/f13/power_armor/x02
-
+/datum/outfit/loadout/gysgt_caster
+	name = "Close Quarters Assaultman"
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/plasma = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 3
-	)
+		/obj/item/gun/energy/laser/plasma/caster = 1,
+		/obj/item/stock_parts/cell/ammo/mfc = 5,
+		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
+		/obj/item/ammo_box/magazine/m45exp = 2,
+		/obj/item/grenade/f13/frag = 1
+		)
 
-/datum/outfit/loadout/gysgt_melee
-	name = "Mobile Rifleman"
-	suit = /obj/item/clothing/suit/armor/f13/enclave/marine
-	head = /obj/item/clothing/head/helmet/f13/enclave/marine
-
+/datum/outfit/loadout/gysgt_gauss
+	name = "Scout Sniper"
+	suit_store = /obj/item/gun/ballistic/automatic/m72
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/plasma = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 3
-	)
+		/obj/item/ammo_box/magazine/m2mm = 2,
+		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
+		/obj/item/ammo_box/magazine/m45exp = 2,
+		/obj/item/grenade/smokebomb = 2
+		)
 
+/datum/outfit/loadout/gysgt_spear
+	name = "Point Defense Assaultman"
+	backpack_contents = list(
+		/obj/item/twohanded/inquis_spear = 1,
+		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
+		/obj/item/ammo_box/magazine/m45exp = 2,
+		/obj/item/grenade/f13/incendiary = 1
+		)
 
 /datum/outfit/job/enclave/peacekeeper/f13gysergeant/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -274,9 +285,9 @@
 	exp_requirements = 780
 
 	loadout_options = list(
-		/datum/outfit/loadout/sgt_plascaster,	// Plasma Caster
-		/datum/outfit/loadout/sgt_sniper, //MK23+Gauss
-		/datum/outfit/loadout/sgt_classic, // MK23+Plasma spear
+		/datum/outfit/loadout/sgt_plasrifle,	// Plasma rifle + Mk23
+		/datum/outfit/loadout/sgt_cqc, //Neostead + Plaspistol
+		/datum/outfit/loadout/sgt_classic, // Assault carbine + Plaspistol
 		)
 
 /datum/outfit/job/enclave/peacekeeper/enclavesgt
@@ -294,32 +305,45 @@
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/clothing/head/f13/enclave/peacekeeper = 1,
-		/obj/item/card/id/syndicate/anyone = 1,
+		/obj/item/card/id/syndicate = 1,
 		/obj/item/clothing/mask/chameleon = 1
 		)
 
-/datum/outfit/loadout/sgt_plascaster
-	name = "Close Quarters Assaultman"
+/datum/outfit/loadout/sgt_plasrifle
+	name = "Frontline Assaultman"
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/plasma/caster = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 5
-		)
-
-/datum/outfit/loadout/sgt_sniper
-	name = "Scout Sniper"
-	suit_store = /obj/item/gun/ballistic/automatic/m72
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m2mm = 2,
+		/obj/item/gun/energy/laser/plasma = 1,
+		/obj/item/stock_parts/cell/ammo/mfc = 5,
 		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
 		/obj/item/ammo_box/magazine/m45exp = 2,
+		/obj/item/grenade/f13/frag = 1,
+		/obj/item/grenade/smokebomb = 1
+		)
+
+/datum/outfit/loadout/sgt_cqc
+	name = "Close Quarters Assaultman"
+	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/neostead
+	backpack_contents = list(
+		/obj/item/ammo_box/shotgun/slug = 2,
+		/obj/item/ammo_box/shotgun/buck = 2,
+		/obj/item/ammo_box/shotgun/incendiary = 1,
+		/obj/item/gun/energy/laser/plasma/pistol = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
+		/obj/item/grenade/f13/frag = 1,
+		/obj/item/grenade/smokebomb = 1
 		)
 
 /datum/outfit/loadout/sgt_classic
-	name = "Point Defense Assaultman"
+	name = "Tactical Assaultman"
 	backpack_contents = list(
-		/obj/item/twohanded/inquis_spear = 1,
-		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
-		/obj/item/ammo_box/magazine/m45exp = 2,
+		/obj/item/gun/ballistic/automatic/assault_carbine = 1,
+		/obj/item/ammo_box/magazine/m5mm = 4,
+		/obj/item/attachments/scope = 1,
+		/obj/item/suppressor = 1, //they get a flashlight in their bag
+		/obj/item/gun/energy/laser/plasma/pistol = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
+		/obj/item/grenade/f13/plasma = 2,
+		/obj/item/grenade/smokebomb = 2
 		)
 
 /datum/outfit/job/enclave/peacekeeper/enclavesgt/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -366,7 +390,7 @@
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/clothing/head/f13/enclave/peacekeeper = 1,
-		/obj/item/card/id/syndicate/anyone =1
+		/obj/item/card/id/syndicate =1
 		)
 
 /datum/outfit/loadout/acpl_ballistics
@@ -433,7 +457,7 @@
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/clothing/mask/chameleon = 1,
-		/obj/item/card/id/syndicate/anyone =1
+		/obj/item/card/id/syndicate =1
 		)
 
 /datum/outfit/loadout/combatmedic
@@ -501,7 +525,7 @@
 		/obj/item/pda = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/clothing/mask/chameleon = 1,
-		/obj/item/card/id/syndicate/anyone =1,
+		/obj/item/card/id/syndicate =1,
 		/obj/item/clothing/head/f13/enclave/peacekeeper = 1
 		)
 
@@ -560,7 +584,7 @@
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/clothing/mask/chameleon = 1,
-		/obj/item/card/id/syndicate/anyone = 1,
+		/obj/item/card/id/syndicate = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_three=1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_four=1
 		)
@@ -614,7 +638,7 @@
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/clothing/mask/chameleon = 1,
-		/obj/item/card/id/syndicate/anyone =1
+		/obj/item/card/id/syndicate =1
 		)
 
 /datum/outfit/job/enclave/noncombat/enclavepilot/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -542,7 +542,7 @@
 
 /datum/outfit/loadout/mobileartillery
 	name = "Pointman Rifleman"
-	suit_store = /obj/item/gun/energy/laser/plasma
+	suit_store = /obj/item/gun/energy/laser/plasma/pistol
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -472,6 +472,8 @@
 		/obj/item/book/granter/trait/midsurgery = 1,
 		/obj/item/storage/pill_bottle/chem_tin/mentats = 1,
 		/obj/item/ammo_box/magazine/uzim9mm = 2,
+		/obj/item/gun/energy/laser/plasma/pistol/light = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2
 		)
 
 /datum/outfit/loadout/combatengie
@@ -480,8 +482,8 @@
 	gloves = /obj/item/clothing/gloves/color/yellow
 	head = /obj/item/clothing/head/hardhat/orange
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
-		/obj/item/ammo_box/magazine/m45exp = 2,
+		/obj/item/gun/energy/laser/plasma/pistol/light = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/storage/belt/utility = 1,
 		/obj/item/gun/ballistic/shotgun/police = 1,
 		/obj/item/ammo_box/shotgun/buck = 2,
@@ -534,13 +536,17 @@
 	suit_store = /obj/item/gun/ballistic/automatic/smg/mp5
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/uzim9mm = 2,
+		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
+		/obj/item/ammo_box/magazine/m45exp = 2
 		)
 
 /datum/outfit/loadout/mobileartillery
 	name = "Pointman Rifleman"
-	suit_store = /obj/item/gun/energy/laser/plasma/pistol
+	suit_store = /obj/item/gun/energy/laser/plasma/glock
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/ec = 2,
+		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
+		/obj/item/ammo_box/magazine/m45exp = 2
 		)
 
 /datum/outfit/job/enclave/peacekeeper/enclavespy/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -536,13 +536,13 @@
 	suit_store = /obj/item/gun/ballistic/automatic/smg/mp5
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/uzim9mm = 2,
-		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
-		/obj/item/ammo_box/magazine/m45exp = 2
+		/obj/item/gun/energy/laser/plasma/pistol/light = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2
 		)
 
 /datum/outfit/loadout/mobileartillery
 	name = "Pointman Rifleman"
-	suit_store = /obj/item/gun/energy/laser/plasma/glock
+	suit_store = /obj/item/gun/energy/laser/plasma
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1273,7 +1273,7 @@
 	autofire_shot_delay = 1.75
 	spread = 18 //high-velocity
 	can_attachments = TRUE
-	can_scope = FALSE
+	can_scope = TRUE //guh
 	scope_state = "scope_short"
 	scope_x_offset = 4
 	scope_y_offset = 15

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -347,7 +347,7 @@
 	desc = "An advanced shotgun with two separate magazine tubes, allowing you to quickly toggle between ammo types."
 	icon_state = "neostead"
 	item_state = "shotguncity"
-	fire_delay = 5
+	fire_delay = 2 //why was this worse than the leveraction?
 	recoil = 1.3
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube
 	force = 10

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -144,7 +144,7 @@
 	ears = /obj/item/radio/headset/syndicate/alt
 	back = /obj/item/storage/backpack
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
-	id = /obj/item/card/id/syndicate/anyone
+	id = /obj/item/card/id/syndicate
 	implants = list(/obj/item/implant/weapons_auth)
 
 /datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source)


### PR DESCRIPTION
## About The Pull Request

gysgt no longer gets PA. sgt no longer gets pcaster/gauss/spear, gaysgt gets those now.

sgt loadouts are now:
plasrifle/mk23, 1x smoke 1x frag
neostead/plaspistol, 1x smoke 1x frag
asscarb/plaspistol, 2x smoke 2x plasmanade

plasma grenades nerfed heavily (they're only a ohko if you literally stand on top of them now)

specialist get plasma pistol sidearms

marine gets mk23 sidearms

agent IDs lock to the first person to use them now, instead of being syndicate-based

## Why It's Good For The Game

enclave too good

## Pre-Merge Checklist
untested
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
balance: gysgt no longer gets PA. sgt no longer gets pcaster/gauss/spear, gaysgt gets those now.
balance: sgt loadouts are now: plasrifle/mk23, 1x smoke 1x frag | neostead/plaspistol, 1x smoke 1x frag | asscarb/plaspistol, 2x smoke 2x plasmanade
balance: specialist get plasma pistol sidearms
balance: marine gets mk23 sidearms
balance: plasma grenades nerfed heavily (they're only a ohko if you literally stand on top of them now)
balance: agent IDs lock to the first person to use them now, instead of being syndicate-based
fix: enclave synthetic
/:cl:
