### PR TITLE
Assorted Mapping Updates

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -5856,8 +5856,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "cZy" = (
-/obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
@@ -7048,7 +7048,7 @@
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "120"
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/turf/open/floor/f13,
 /area/f13/brotherhood/reactor)
 "fgb" = (
 /obj/effect/turf_decal/huge{
@@ -7504,9 +7504,6 @@
 /obj/item/gps/mining,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
 /obj/structure/closet,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
@@ -7629,9 +7626,6 @@
 /obj/item/gps/mining,
 /obj/item/gps/mining,
 /obj/item/gps/mining,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/structure/closet,
@@ -7903,7 +7897,7 @@
 	},
 /area/f13/tunnel)
 "gUu" = (
-/obj/structure/wreck/trash/machinepiletwo,
+/obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/f13{
 	icon_state = "bluerustyfull"
 	},
@@ -8970,10 +8964,10 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "jdX" = (
-/obj/structure/wreck/trash/machinepiletwo,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/f13{
 	icon_state = "bluerustyfull"
 	},
@@ -14596,7 +14590,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel/bighorn)
 "tTH" = (
-/obj/structure/wreck/trash/machinepiletwo,
+/obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -1464,11 +1464,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/mall)
-"baW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "bbB" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
@@ -1962,11 +1957,6 @@
 "bXj" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
-"bXz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "bXY" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -2158,7 +2148,10 @@
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "cmH" = (
-/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/curtain{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "cmV" = (
@@ -2230,6 +2223,13 @@
 	dir = 4
 	},
 /turf/open/floor/f13,
+/area/f13/brotherhood)
+"cqJ" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -13
+	},
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "csj" = (
 /turf/closed/wall/r_wall/rust,
@@ -2704,6 +2704,13 @@
 	color = "#d7d7d7"
 	},
 /area/f13/building/mall)
+"dmN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "dnf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -2791,12 +2798,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
-"dvz" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "dvB" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_common,
@@ -2992,6 +2993,11 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"dNu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "dNB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3058,6 +3064,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/mall)
+"dSI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood/fancy{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "dTd" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
@@ -3349,6 +3362,10 @@
 	},
 /turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
+"euV" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "euX" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -4273,10 +4290,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"goM" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "goU" = (
 /obj/structure/guncase,
 /obj/machinery/light/small{
@@ -4314,14 +4327,6 @@
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
-/area/f13/brotherhood)
-"gss" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "gsJ" = (
 /obj/item/clothing/shoes/laceup,
@@ -4480,6 +4485,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/mall)
+"gGj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "gGz" = (
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris,
 /turf/closed/wall/mineral/wood,
@@ -4771,13 +4784,6 @@
 	icon_state = "bluedirtychess"
 	},
 /area/f13/building/mall)
-"hfZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "hgH" = (
 /obj/item/trash/popcorn,
 /obj/effect/decal/cleanable/dirt,
@@ -4828,14 +4834,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
-"hkN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "hma" = (
@@ -4983,10 +4981,6 @@
 /obj/structure/simple_door/repaired,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"hvp" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "hvP" = (
 /obj/structure/fence/wooden{
 	climbable = 0;
@@ -5642,11 +5636,7 @@
 	},
 /area/f13/building/massfusion)
 "iyK" = (
-/obj/structure/curtain{
-	pixel_y = 30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "izj" = (
@@ -5703,6 +5693,10 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks/low,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"iBN" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "iCa" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old{
@@ -5730,7 +5724,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
 "iEO" = (
-/obj/structure/chair/sofa/corp{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_fancy,
@@ -5809,6 +5804,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
+"iNy" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "iOC" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/poddoor/shutters{
@@ -6241,6 +6240,16 @@
 /obj/structure/junk/cabinet,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"jxF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
 "jye" = (
 /obj/machinery/door/unpowered/securedoor/bighorn_door,
 /turf/open/floor/wood/wood_worn,
@@ -6258,13 +6267,6 @@
 "jBO" = (
 /obj/structure/window/fulltile/store,
 /turf/open/indestructible/ground/outside/roof,
-/area/f13/brotherhood)
-"jCi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood/fancy{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "jCO" = (
 /obj/effect/overlay/junk/oldpipes{
@@ -6301,6 +6303,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jFW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "jGt" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5";
@@ -6841,16 +6848,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/city/bighorn)
-"kIr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood)
 "kJl" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
@@ -6942,7 +6939,6 @@
 	},
 /area/f13/building/hospital)
 "kSF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
@@ -7657,14 +7653,17 @@
 	},
 /area/f13/followers)
 "lVz" = (
-/obj/structure/chair/sofa/corp/left,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood/fancy{
+	dir = 8
+	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "lVE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cabinet,
+/obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "lWj" = (
@@ -7820,13 +7819,6 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
-"mjY" = (
-/obj/structure/curtain{
-	pixel_y = 30
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "mke" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -7863,6 +7855,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mlq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "mls" = (
 /obj/structure/punching_bag,
 /obj/effect/landmark/poster_spawner/prewar{
@@ -7972,6 +7972,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
+/area/f13/brotherhood)
+"mrT" = (
+/obj/structure/curtain{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "msi" = (
 /obj/machinery/light/broken{
@@ -8269,6 +8277,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"mYe" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "mYy" = (
 /obj/structure/table/optable,
 /obj/machinery/defibrillator_mount/loaded{
@@ -8368,9 +8382,7 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building/massfusion)
 "nfP" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
+/obj/structure/chair/sofa/corp,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "ngj" = (
@@ -8426,6 +8438,12 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"nll" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "nlA" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -8879,11 +8897,6 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"nWU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cabinet,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "nXg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -9669,6 +9682,10 @@
 	icon_state = "bluerustychess"
 	},
 /area/f13/building/mall)
+"pgZ" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "phD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -10224,6 +10241,13 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
+"qli" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-24"
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "qlq" = (
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
@@ -10707,6 +10731,13 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/building)
+"qVr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "qVF" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -11681,10 +11712,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
-"sMG" = (
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "sOn" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -12721,13 +12748,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
-"urv" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -13
-	},
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "urF" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -12750,10 +12770,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/hospital)
-"usl" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "usA" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/oil{
@@ -12822,13 +12838,6 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"uwR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood/fancy{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "uwZ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13{
@@ -12882,13 +12891,6 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/carpet/arcade,
 /area/f13/building/mall)
-"uBH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "uCQ" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -13117,12 +13119,6 @@
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/area/f13/brotherhood)
-"veM" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "vfk" = (
 /obj/structure/chair/bench{
@@ -13720,9 +13716,7 @@
 	},
 /area/f13/building/hospital)
 "wjr" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
+/obj/structure/chair/sofa/corp/right,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "wjJ" = (
@@ -13767,15 +13761,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/arcade,
 /area/f13/building/mall)
-"wqj" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-24"
-	},
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood/wood_fancy,
-/area/f13/brotherhood)
 "wqA" = (
-/obj/structure/chair/sofa/corp,
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "wqF" = (
@@ -13860,6 +13849,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"wAG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "wBn" = (
 /obj/structure/cargocrate{
 	icon_state = "cargocrate2"
@@ -14112,6 +14106,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"wWW" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "wXb" = (
 /obj/structure/table,
 /obj/item/organ/heart,
@@ -35591,11 +35591,11 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -35847,13 +35847,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -36104,13 +36104,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -36361,13 +36361,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -36618,13 +36618,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -36875,13 +36875,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -37132,13 +37132,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -37389,13 +37389,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -37646,13 +37646,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -37903,13 +37903,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -38160,13 +38160,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -38417,13 +38417,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -38674,13 +38674,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -38931,13 +38931,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -39188,13 +39188,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -39446,11 +39446,11 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
+dtb
+dtb
+dtb
+dtb
+dtb
 oez
 oez
 oez
@@ -66506,9 +66506,9 @@ deS
 lDT
 sSr
 tDK
-nfP
-nfP
-wjr
+nll
+nll
+mYe
 sSr
 abv
 abv
@@ -66765,7 +66765,7 @@ jVC
 mTY
 cFn
 fJN
-iEO
+wWW
 sSr
 abv
 abv
@@ -67022,7 +67022,7 @@ jVC
 dVt
 mgP
 cFn
-hfZ
+qVr
 sSr
 abv
 abv
@@ -67279,7 +67279,7 @@ jVC
 hQC
 xHZ
 mgP
-gss
+mlq
 sSr
 abv
 abv
@@ -68821,7 +68821,7 @@ jVC
 hQC
 xHZ
 hsO
-urv
+cqJ
 sSr
 abv
 abv
@@ -69078,7 +69078,7 @@ jVC
 txY
 xHZ
 hsO
-baW
+wAG
 sSr
 abv
 abv
@@ -70877,7 +70877,7 @@ jVC
 hQC
 mgP
 hsO
-goM
+euV
 sSr
 qhO
 pKM
@@ -71391,7 +71391,7 @@ jVC
 mQG
 mgP
 hsO
-dvz
+wqA
 sSr
 dgy
 uzX
@@ -71647,8 +71647,8 @@ oez
 jVC
 ngj
 xHZ
-uBH
-hfZ
+lVE
+qVr
 hdz
 wZB
 mMf
@@ -71904,8 +71904,8 @@ oez
 jVC
 wdo
 mgP
-uBH
-hfZ
+lVE
+qVr
 sSr
 lKR
 uzX
@@ -72162,7 +72162,7 @@ jVC
 agR
 mgP
 lvW
-kSF
+iEO
 sSr
 hAg
 rLl
@@ -72676,7 +72676,7 @@ jVC
 mTY
 mgP
 mgP
-baW
+wAG
 sSr
 sSr
 sSr
@@ -73448,7 +73448,7 @@ jVC
 mTY
 mgP
 hsO
-uwR
+lVz
 sSr
 hsx
 cjT
@@ -73962,7 +73962,7 @@ jVC
 mTY
 mgP
 xHZ
-baW
+wAG
 sSr
 cqi
 cqi
@@ -75247,7 +75247,7 @@ jVC
 mTY
 mTY
 xHZ
-goM
+euV
 sSr
 sSr
 cmj
@@ -75501,7 +75501,7 @@ oez
 oez
 oez
 jVC
-hvp
+wjr
 xHZ
 xHZ
 mTY
@@ -75758,12 +75758,12 @@ oez
 oez
 oez
 jVC
-wqA
+nfP
 cFn
 mgP
-dvz
+wqA
 trg
-mjY
+cmH
 xHZ
 mgP
 mgP
@@ -76015,12 +76015,12 @@ oez
 oez
 oez
 jVC
-wqA
+nfP
 fJN
 xHZ
-iEO
+wWW
 trg
-mjY
+cmH
 vyI
 hZM
 oRc
@@ -76272,10 +76272,10 @@ oez
 oez
 oez
 jVC
-lVz
+iyK
 mTY
 xHZ
-veM
+kSF
 trg
 oJN
 dwr
@@ -76532,7 +76532,7 @@ jVC
 mTY
 mTY
 xHZ
-goM
+euV
 sSr
 sSr
 cmj
@@ -76786,7 +76786,7 @@ oez
 oez
 oez
 jVC
-cmH
+iNy
 mTY
 xHZ
 mTY
@@ -77045,10 +77045,10 @@ oez
 jVC
 mTY
 mTY
-bXz
-hkN
+dNu
+gGj
 trg
-iyK
+mrT
 xHZ
 mgP
 mgP
@@ -77302,10 +77302,10 @@ oez
 jVC
 mgP
 mTY
-bXz
-hkN
+dNu
+gGj
 trg
-mjY
+cmH
 vyI
 vyI
 hZM
@@ -77557,10 +77557,10 @@ oez
 oez
 oez
 jVC
-jCi
+dSI
 mTY
 mgP
-sMG
+iBN
 trg
 oJN
 dwr
@@ -78328,12 +78328,12 @@ oez
 oez
 oez
 jVC
-cmH
+iNy
 mTY
 mgP
 mTY
 trg
-iyK
+mrT
 mgP
 xHZ
 mgP
@@ -78585,12 +78585,12 @@ oez
 oez
 oez
 jVC
-jCi
+dSI
 mTY
 mgP
 mTY
 trg
-mjY
+cmH
 vyI
 vyI
 cQa
@@ -79102,7 +79102,7 @@ jVC
 cFn
 fLn
 mgP
-wqj
+qli
 sSr
 sSr
 sSr
@@ -79356,14 +79356,14 @@ oez
 oez
 oez
 jVC
-uwR
+lVz
 mTY
 xHZ
 mTY
 sWg
 kXJ
 mru
-kIr
+jxF
 kLv
 sSr
 abv
@@ -79870,10 +79870,10 @@ oez
 oez
 oez
 jVC
-nWU
-usl
-lVE
-usl
+jFW
+pgZ
+dmN
+pgZ
 eDg
 mcT
 xHl

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -1464,6 +1464,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/mall)
+"baW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "bbB" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
@@ -1726,9 +1731,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
-	},
+/obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "bAA" = (
@@ -1959,6 +1962,11 @@
 "bXj" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
+"bXz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "bXY" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -2150,9 +2158,8 @@
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "cmH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "cmV" = (
 /mob/living/simple_animal/cockroach,
@@ -2350,9 +2357,7 @@
 /area/f13/building/mall)
 "cFn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
-	},
+/obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "cFt" = (
@@ -2786,6 +2791,12 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
+"dvz" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "dvB" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_common,
@@ -4262,6 +4273,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"goM" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "goU" = (
 /obj/structure/guncase,
 /obj/machinery/light/small{
@@ -4299,6 +4314,14 @@
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
+/area/f13/brotherhood)
+"gss" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "gsJ" = (
 /obj/item/clothing/shoes/laceup,
@@ -4719,7 +4742,7 @@
 /area/f13/building/hospital)
 "hdz" = (
 /obj/structure/sign/poster/prewar/poster74,
-/turf/closed/wall/r_wall/f13/vault,
+/turf/closed/wall/f13/wood,
 /area/f13/brotherhood)
 "hdT" = (
 /obj/structure/bed/dogbed,
@@ -4748,6 +4771,13 @@
 	icon_state = "bluedirtychess"
 	},
 /area/f13/building/mall)
+"hfZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "hgH" = (
 /obj/item/trash/popcorn,
 /obj/effect/decal/cleanable/dirt,
@@ -4798,6 +4828,14 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
+"hkN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "hma" = (
@@ -4945,6 +4983,10 @@
 /obj/structure/simple_door/repaired,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hvp" = (
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "hvP" = (
 /obj/structure/fence/wooden{
 	climbable = 0;
@@ -5600,13 +5642,11 @@
 	},
 /area/f13/building/massfusion)
 "iyK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
+/obj/structure/curtain{
+	pixel_y = 30
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "izj" = (
@@ -5690,10 +5730,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
 "iEO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
+/obj/structure/chair/sofa/corp{
+	dir = 1
 	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
@@ -5898,10 +5936,11 @@
 	},
 /area/f13/followers)
 "iYk" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
+	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "iYm" = (
@@ -6219,6 +6258,13 @@
 "jBO" = (
 /obj/structure/window/fulltile/store,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/brotherhood)
+"jCi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood/fancy{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "jCO" = (
 /obj/effect/overlay/junk/oldpipes{
@@ -6795,6 +6841,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/city/bighorn)
+"kIr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood)
 "kJl" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
@@ -6886,10 +6942,11 @@
 	},
 /area/f13/building/hospital)
 "kSF" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "kSM" = (
 /obj/effect/decal/cleanable/dirt{
@@ -7219,11 +7276,8 @@
 	},
 /area/f13/building/mall)
 "ltS" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
-	},
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
+/obj/structure/cargocrate{
+	icon_state = "cargocrate5"
 	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
@@ -7603,18 +7657,15 @@
 	},
 /area/f13/followers)
 "lVz" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "lVE" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "lWj" = (
 /obj/structure/barricade/wooden,
@@ -7769,6 +7820,13 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
+"mjY" = (
+/obj/structure/curtain{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "mke" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -8310,10 +8368,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building/massfusion)
 "nfP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "ngj" = (
 /obj/structure/table/wood,
@@ -8821,6 +8879,11 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"nWU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "nXg" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -11618,6 +11681,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"sMG" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "sOn" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -12217,11 +12284,8 @@
 "tDK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
@@ -12657,6 +12721,13 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"urv" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -13
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "urF" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -12679,6 +12750,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/hospital)
+"usl" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "usA" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/oil{
@@ -12747,6 +12822,13 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"uwR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood/fancy{
+	dir = 8
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "uwZ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13{
@@ -12800,6 +12882,13 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/carpet/arcade,
 /area/f13/building/mall)
+"uBH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
 "uCQ" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -13028,6 +13117,12 @@
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
+/area/f13/brotherhood)
+"veM" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "vfk" = (
 /obj/structure/chair/bench{
@@ -13625,8 +13720,8 @@
 	},
 /area/f13/building/hospital)
 "wjr" = (
-/obj/structure/curtain{
-	pixel_y = 30
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
 	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
@@ -13672,10 +13767,15 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet/arcade,
 /area/f13/building/mall)
-"wqA" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	name = "Broken HVAC Machine"
+"wqj" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-24"
 	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/brotherhood)
+"wqA" = (
+/obj/structure/chair/sofa/corp,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
 "wqF" = (
@@ -66147,12 +66247,12 @@ aKa
 aKa
 deS
 lDT
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
 abv
 abv
 abv
@@ -66404,12 +66504,12 @@ deS
 deS
 deS
 lDT
-hQC
+sSr
 tDK
-wqA
-wqA
-wqA
-hQC
+nfP
+nfP
+wjr
+sSr
 abv
 abv
 abv
@@ -66662,11 +66762,11 @@ oez
 oez
 oez
 jVC
-wqA
+mTY
 cFn
-wqA
-wqA
-hQC
+fJN
+iEO
+sSr
 abv
 abv
 abv
@@ -66921,9 +67021,9 @@ oez
 jVC
 dVt
 mgP
-xHZ
-xHZ
-hQC
+cFn
+hfZ
+sSr
 abv
 abv
 abv
@@ -67179,8 +67279,8 @@ jVC
 hQC
 xHZ
 mgP
-mgP
-hQC
+gss
+sSr
 abv
 abv
 abv
@@ -67437,7 +67537,7 @@ lNw
 xHZ
 xHZ
 hsO
-hQC
+sSr
 abv
 abv
 abv
@@ -67694,7 +67794,7 @@ shk
 evS
 mgP
 bzh
-hQC
+sSr
 abv
 abv
 abv
@@ -67950,8 +68050,8 @@ jVC
 wdo
 foM
 lvW
-lVz
-hQC
+mgP
+sSr
 abv
 abv
 abv
@@ -68208,7 +68308,7 @@ ngj
 fLn
 hsO
 iYk
-hQC
+sSr
 abv
 abv
 abv
@@ -68464,8 +68564,8 @@ jVC
 lOI
 mgP
 lvW
-cFn
-hQC
+eDg
+sSr
 abv
 abv
 abv
@@ -68721,8 +68821,8 @@ jVC
 hQC
 xHZ
 hsO
-mTY
-hQC
+urv
+sSr
 abv
 abv
 abv
@@ -68978,8 +69078,8 @@ jVC
 txY
 xHZ
 hsO
-xHZ
-hQC
+baW
+sSr
 abv
 abv
 abv
@@ -69236,7 +69336,7 @@ mQG
 xHZ
 hsO
 mgP
-hQC
+sSr
 abv
 abv
 abv
@@ -69492,8 +69592,8 @@ jVC
 wdo
 evS
 mgP
-wqA
-hQC
+ltS
+sSr
 abv
 abv
 abv
@@ -69749,8 +69849,8 @@ jVC
 ngj
 evS
 mgP
-wqA
-hQC
+mTY
+sSr
 abv
 abv
 abv
@@ -70007,17 +70107,17 @@ vEt
 xHZ
 xHZ
 ltS
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -70263,18 +70363,18 @@ jVC
 mTY
 mTY
 xHZ
-iEO
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
+mgP
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -70521,7 +70621,7 @@ dVt
 xHZ
 xHZ
 mgP
-hQC
+sSr
 vCt
 pQp
 gzo
@@ -70530,8 +70630,8 @@ gAS
 rst
 hpL
 lyu
-hQC
-hQC
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -70777,8 +70877,8 @@ jVC
 hQC
 mgP
 hsO
-mTY
-hQC
+goM
+sSr
 qhO
 pKM
 uzX
@@ -70787,8 +70887,8 @@ uzX
 dqs
 dqs
 vkK
-hQC
-hQC
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -71033,9 +71133,9 @@ oez
 jVC
 txY
 mgP
-bzh
-wqA
-hQC
+hsO
+mTY
+sSr
 blz
 uzX
 qGu
@@ -71044,8 +71144,8 @@ ezc
 hPw
 pKM
 vep
-hQC
-hQC
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -71290,9 +71390,9 @@ oez
 jVC
 mQG
 mgP
-bzh
-wqA
-hQC
+hsO
+dvz
+sSr
 dgy
 uzX
 vkK
@@ -71301,8 +71401,8 @@ pqF
 blz
 bfc
 oFd
-hQC
-hQC
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -71547,8 +71647,8 @@ oez
 jVC
 ngj
 xHZ
-hsO
-xHZ
+uBH
+hfZ
 hdz
 wZB
 mMf
@@ -71558,8 +71658,8 @@ avR
 hIC
 bfc
 qtn
-hQC
-hQC
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -71804,9 +71904,9 @@ oez
 jVC
 wdo
 mgP
-hsO
-xHZ
-hQC
+uBH
+hfZ
+sSr
 lKR
 uzX
 gYY
@@ -71815,8 +71915,8 @@ pQp
 qLE
 pKM
 lcy
-hQC
-hQC
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -72061,9 +72161,9 @@ oez
 jVC
 agR
 mgP
-iyK
-cFn
-hQC
+lvW
+kSF
+sSr
 hAg
 rLl
 pKM
@@ -72072,8 +72172,8 @@ uzX
 uzX
 uzX
 vkK
-hQC
-hQC
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -72318,9 +72418,9 @@ oez
 jVC
 vEt
 xHZ
-iEO
-iEO
-hQC
+mgP
+mgP
+sSr
 pFg
 nlA
 dKc
@@ -72329,8 +72429,8 @@ xCB
 dKc
 xCe
 tJF
-hQC
-hQC
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -72576,18 +72676,18 @@ jVC
 mTY
 mgP
 mgP
-xHZ
-hQC
-hQC
-hQC
+baW
+sSr
+sSr
+sSr
 jBO
 ktz
 ktz
 jBO
-hQC
-hQC
-hQC
-hQC
+sSr
+sSr
+sSr
+sSr
 qmb
 qmb
 qmb
@@ -72834,8 +72934,8 @@ mTY
 mgP
 xHZ
 mgP
-mTY
-hQC
+mQG
+sSr
 gvC
 slA
 slA
@@ -73091,8 +73191,8 @@ ujZ
 mgP
 mgP
 mgP
-mTY
-hQC
+fJN
+sSr
 gvC
 slA
 cjT
@@ -73348,8 +73448,8 @@ jVC
 mTY
 mgP
 hsO
-xHZ
-hQC
+uwR
+sSr
 hsx
 cjT
 slA
@@ -73862,8 +73962,8 @@ jVC
 mTY
 mgP
 xHZ
-xHZ
-hQC
+baW
+sSr
 cqi
 cqi
 cqi
@@ -74120,7 +74220,7 @@ mQG
 xHZ
 hsO
 xHZ
-hQC
+sSr
 uGE
 uGE
 uGE
@@ -74376,13 +74476,13 @@ jVC
 wdo
 evS
 mgP
-mTY
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
+oQs
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
 row
 qmb
 qmb
@@ -74639,7 +74739,7 @@ mTY
 dXi
 xHZ
 xHZ
-hQC
+sSr
 slA
 bqA
 bqA
@@ -75147,13 +75247,13 @@ jVC
 mTY
 mTY
 xHZ
+goM
 sSr
 sSr
 cmj
 cmj
-lVE
+cmj
 sSr
-hQC
 abP
 bvw
 cmD
@@ -75401,16 +75501,16 @@ oez
 oez
 oez
 jVC
+hvp
+xHZ
+xHZ
 mTY
-xHZ
-xHZ
 ecZ
-mTY
+xHZ
 tyV
 tyV
 oCS
 sSr
-hQC
 oSJ
 bvw
 fJN
@@ -75659,15 +75759,15 @@ oez
 oez
 jVC
 wqA
+cFn
+mgP
+dvz
+trg
+mjY
 xHZ
 mgP
-trg
-wjr
-mTY
-xHZ
-xHZ
-sSr
-hQC
+mgP
+eDg
 abP
 xHZ
 hkJ
@@ -75916,15 +76016,15 @@ oez
 oez
 jVC
 wqA
-wqA
+fJN
 xHZ
+iEO
 trg
-wjr
+mjY
 vyI
 hZM
 oRc
 sSr
-hQC
 abP
 mTY
 sSr
@@ -76172,16 +76272,16 @@ oez
 oez
 oez
 jVC
-wqA
-wqA
+lVz
+mTY
 xHZ
+veM
 trg
 oJN
 dwr
 sez
 sez
 sSr
-hQC
 oSJ
 xHZ
 txY
@@ -76432,13 +76532,13 @@ jVC
 mTY
 mTY
 xHZ
+goM
 sSr
 sSr
-lVE
-lVE
-lVE
+cmj
+cmj
+cmj
 sSr
-hQC
 abP
 bvw
 fJN
@@ -76686,16 +76786,16 @@ oez
 oez
 oez
 jVC
-mTY
+cmH
 mTY
 xHZ
-ecZ
 mTY
+ecZ
+xHZ
 tyV
 gsJ
 cjb
 sSr
-hQC
 abP
 bvw
 fJN
@@ -76943,16 +77043,16 @@ oez
 oez
 oez
 jVC
-wqA
-wqA
-xHZ
-trg
-wjr
 mTY
+mTY
+bXz
+hkN
+trg
+iyK
 xHZ
-xHZ
+mgP
+mgP
 sSr
-hQC
 abP
 oSJ
 oSJ
@@ -77200,16 +77300,16 @@ oez
 oez
 oez
 jVC
-iEO
-wqA
-xHZ
-trg
-wjr
+mgP
 mTY
+bXz
+hkN
+trg
+mjY
+vyI
 vyI
 hZM
 sSr
-hQC
 laR
 laR
 laR
@@ -77457,16 +77557,16 @@ oez
 oez
 oez
 jVC
-xHZ
-wqA
+jCi
+mTY
 mgP
+sMG
 trg
 oJN
 dwr
 sez
 sez
 sSr
-hQC
 abv
 abv
 abv
@@ -77714,16 +77814,16 @@ oez
 oez
 oez
 jVC
-mTY
-mTY
+fJN
+fLn
 mgP
+mTY
 sSr
 sSr
-lVE
-lVE
-lVE
+cmj
+cmj
+cmj
 sSr
-hQC
 abv
 abv
 abv
@@ -77971,16 +78071,16 @@ oez
 oez
 oez
 jVC
-wqA
+vEt
 mTY
 mgP
-ecZ
 mTY
+ecZ
+mgP
 tyV
 gsJ
 cjb
 sSr
-hQC
 abv
 abv
 abv
@@ -78228,16 +78328,16 @@ oez
 oez
 oez
 jVC
-wqA
-wqA
+cmH
+mTY
 mgP
-kSF
-wjr
 mTY
-mTY
+trg
+iyK
+mgP
 xHZ
+mgP
 sSr
-hQC
 abv
 abv
 abv
@@ -78485,16 +78585,16 @@ oez
 oez
 oez
 jVC
-xHZ
-wqA
+jCi
+mTY
 mgP
-kSF
-wjr
+mTY
+trg
+mjY
 vyI
 vyI
 cQa
 sSr
-hQC
 abv
 abv
 abv
@@ -78742,16 +78842,16 @@ oez
 oez
 oez
 jVC
+cFn
+fLn
 xHZ
 mTY
-xHZ
-kSF
+trg
 lhQ
 tZh
 tZh
 imW
 sSr
-hQC
 abv
 abv
 abv
@@ -78999,16 +79099,16 @@ oez
 oez
 oez
 jVC
-xHZ
-mTY
+cFn
+fLn
 mgP
+wqj
 sSr
 sSr
 sSr
 eDg
 sSr
 sSr
-hQC
 abv
 abv
 abv
@@ -79256,16 +79356,16 @@ oez
 oez
 oez
 jVC
-cFn
-wqA
+uwR
+mTY
 xHZ
+mTY
 sWg
 kXJ
 mru
-mcT
+kIr
 kLv
 sSr
-hQC
 abv
 abv
 abv
@@ -79513,16 +79613,16 @@ oez
 oez
 oez
 jVC
-cFn
-wqA
-hsO
+mTY
+mTY
+mTY
+mTY
 eDg
 kXJ
-xHl
-fmk
-xHl
+kXJ
+kXJ
+kXJ
 sSr
-hQC
 beJ
 beJ
 beJ
@@ -79770,16 +79870,16 @@ oez
 oez
 oez
 jVC
+nWU
+usl
+lVE
+usl
 eDg
-eDg
+mcT
+xHl
+fmk
+xHl
 sSr
-sSr
-eDg
-cmH
-nfP
-cmH
-sSr
-hQC
 abv
 abv
 abv
@@ -80027,16 +80127,16 @@ oez
 oez
 oez
 jVC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
-hQC
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
+sSr
 abv
 abv
 abv

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -19823,10 +19823,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
-"bvq" = (
-/obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "bvx" = (
 /mob/living/simple_animal/opossum/poppy,
 /turf/open/floor/f13{
@@ -21000,6 +20996,11 @@
 	},
 /turf/open/water,
 /area/f13/brotherhood)
+"bIm" = (
+/obj/structure/car/rubbish2,
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "bIo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrighttop"
@@ -21693,10 +21694,6 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"bVF" = (
-/obj/structure/wreck/trash/bus_door,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "bVI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22472,10 +22469,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/city/bighorn)
-"cfc" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "cfd" = (
 /obj/effect/decal/cleanable/vomit/old{
 	pixel_y = 15
@@ -23578,11 +23571,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"csm" = (
-/obj/structure/wreck/trash/three_barrels,
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "csn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood/drip,
@@ -24749,6 +24737,12 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
+"cQu" = (
+/obj/structure/fence{
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "cQz" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -26251,11 +26245,9 @@
 /turf/open/floor/plating,
 /area/f13/city/bighorn)
 "dDB" = (
-/obj/structure/car/rubbish2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/brotherhood)
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "dDE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -26446,6 +26438,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/building)
+"dGR" = (
+/obj/structure/fence/corner{
+	dir = 4;
+	icon_state = "end";
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "dHk" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -27317,6 +27317,7 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
 "eeT" = (
@@ -27409,6 +27410,15 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"eiq" = (
+/obj/structure/chair/stool/retro/black{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fluff/railing,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "eit" = (
 /obj/structure/wreck/trash/one_tire{
 	pixel_x = -10;
@@ -27825,12 +27835,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/followers)
-"etF" = (
-/obj/structure/reagent_dispensers/barrel/four{
-	pixel_x = -7
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "etN" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/cigarette/pipe,
@@ -27861,13 +27865,6 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"euy" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/flora/junglebush/b,
-/turf/open/indestructible/ground/outside/savannah,
-/area/f13/brotherhood)
 "euM" = (
 /obj/structure/guncase{
 	anchored = 1
@@ -28205,6 +28202,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"eCt" = (
+/obj/structure/debris/v3{
+	pixel_x = -11;
+	pixel_y = 22
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "eCy" = (
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/inside/mountain,
@@ -28277,6 +28282,11 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland/bighornbunker)
+"eFh" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "eFx" = (
 /obj/machinery/iv_drip,
 /obj/structure/decoration/clock/old/active{
@@ -29146,11 +29156,6 @@
 /obj/item/clothing/neck/mantle/ragged,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eZM" = (
-/obj/structure/car/rubbish3,
-/obj/effect/decal/cleanable/glass,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "fah" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building/mall)
@@ -29808,16 +29813,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"fqf" = (
-/obj/structure/fence/corner{
-	dir = 8;
-	pixel_x = 1
-	},
-/obj/structure/fence{
-	pixel_y = 1
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "fqn" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -29845,13 +29840,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"fqP" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/reagent_dispensers/barrel/four{
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "fre" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
@@ -30056,11 +30044,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"fvc" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/glass,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "fvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30872,12 +30855,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
-"fPI" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/blood,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "fPS" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -31477,15 +31454,6 @@
 	dir = 1
 	},
 /area/f13/brotherhood/offices1st)
-"gdh" = (
-/obj/structure/fence{
-	dir = 8;
-	pixel_y = 20
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
-	},
-/area/f13/wasteland/west)
 "gdn" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War wall made of solid concrete.";
@@ -31637,6 +31605,10 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/heaven)
+"gij" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "giH" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
@@ -31649,15 +31621,6 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland/massfusion)
-"giL" = (
-/obj/structure/fence/corner{
-	dir = 5
-	},
-/obj/structure/fence{
-	pixel_y = 1
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "giN" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -31761,8 +31724,8 @@
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "gml" = (
-/obj/structure/reagent_dispensers/barrel/four,
-/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/structure/car/rubbish4,
+/obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "gmm" = (
@@ -31779,7 +31742,8 @@
 	},
 /area/f13/building/firestation)
 "gmM" = (
-/obj/effect/spawner/lootdrop/trash,
+/obj/structure/wreck/trash/engine,
+/obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "gmP" = (
@@ -32205,6 +32169,12 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
+"gzU" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "gzV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -33478,10 +33448,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
-"hbl" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "hbq" = (
 /obj/item/flag/khan{
 	pixel_y = 28;
@@ -33625,6 +33591,16 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood/leisure)
+"heY" = (
+/obj/structure/fence/corner{
+	dir = 8;
+	pixel_x = 1
+	},
+/obj/structure/fence{
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "hfi" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/road{
@@ -33812,11 +33788,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/east)
-"hlJ" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "hlR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag,
@@ -34056,6 +34027,11 @@
 "hsc" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/massfusion)
+"htK" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "htR" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
@@ -34088,6 +34064,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
+/area/f13/wasteland/west)
+"huW" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/reagent_dispensers/barrel/four{
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "hvo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34139,6 +34122,11 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"hxy" = (
+/obj/structure/car/rubbish3,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "hxC" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -34671,6 +34659,11 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland/massfusion)
+"hKJ" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "hKS" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -34890,6 +34883,14 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland/east)
+"hRk" = (
+/mob/living/simple_animal/hostile/ghoul/legendary{
+	name = "Trash Master"
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland/west)
 "hRl" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -35112,10 +35113,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building/museum)
-"hWi" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "hWp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -35150,10 +35147,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
-/area/f13/wasteland/west)
-"hWN" = (
-/obj/structure/wreck/bus/rusted,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "hXb" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -36232,6 +36225,14 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/west)
+"ixR" = (
+/obj/structure/reagent_dispensers/barrel/four{
+	layer = 6
+	},
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "ixZ" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -36243,12 +36244,6 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland/quarry)
-"izn" = (
-/obj/item/flag/bos,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland/east)
 "izr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -36469,6 +36464,10 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/quarry)
+"iDu" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "iDA" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -37174,10 +37173,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
-"iSu" = (
-/obj/structure/reagent_dispensers/barrel/four,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "iSC" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -37286,6 +37281,11 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland/quarry)
+"iUu" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "iUv" = (
 /obj/structure/noticeboard{
 	layer = 3.8
@@ -37363,8 +37363,7 @@
 	},
 /area/f13/wasteland/east)
 "iVP" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/barricade/wooden,
+/obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "iVS" = (
@@ -37968,12 +37967,6 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood/leisure)
-"jiS" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/savannah,
-/area/f13/brotherhood)
 "jiX" = (
 /obj/effect/decal/riverbank,
 /obj/structure/fence/wooden{
@@ -38311,11 +38304,6 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland/east)
-"jrT" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "jrX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -38779,6 +38767,13 @@
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/east)
+"jEy" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/savannah,
+/area/f13/brotherhood)
 "jEC" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13{
@@ -39155,14 +39150,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"jPR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/savannah{
-	icon_state = "savannah6"
-	},
-/area/f13/brotherhood)
 "jPV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -39224,14 +39211,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "jRg" = (
-/obj/structure/chair/bench{
-	dir = 4;
-	pixel_y = 1;
-	pixel_x = -7
-	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
 "jRH" = (
@@ -39712,6 +39695,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/store,
 /area/f13/brotherhood/rnd)
+"kgD" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "khe" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -40823,6 +40812,12 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/quarry)
+"kIh" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland/east)
 "kIn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
@@ -43049,10 +43044,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/bighorn)
-"lHj" = (
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "lHm" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -43590,9 +43581,7 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/building)
 "lSN" = (
-/obj/structure/reagent_dispensers/barrel/four{
-	layer = 6
-	},
+/obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "lSQ" = (
@@ -43844,10 +43833,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/quarry)
-"lXF" = (
-/obj/structure/wreck/trash/engine,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "lXP" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -44241,7 +44226,9 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/kirbyplants{
+	icon_state = "plant-04"
+	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
 "mhf" = (
@@ -44315,6 +44302,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
+"miB" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "miP" = (
 /obj/structure/sign/poster/contraband/pinup_vixen,
 /turf/closed/wall/r_wall/rust,
@@ -44516,6 +44508,10 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/building/mall)
+"mnk" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "mnl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -44565,14 +44561,6 @@
 	dir = 1
 	},
 /area/f13/building/museum)
-"mnT" = (
-/mob/living/simple_animal/hostile/ghoul/legendary{
-	name = "Trash Master"
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
-	},
-/area/f13/wasteland/west)
 "mof" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -44666,6 +44654,13 @@
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/followers)
+"mpR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
+	},
+/turf/open/floor/wood/wood_wide,
+/area/f13/brotherhood)
 "mpS" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/desert,
@@ -45546,8 +45541,7 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
 "mMf" = (
-/obj/structure/car/rubbish2,
-/obj/effect/decal/cleanable/glass,
+/obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "mMr" = (
@@ -45696,10 +45690,13 @@
 	},
 /area/f13/wasteland/firestation)
 "mPX" = (
-/obj/structure/car/rubbish4,
-/obj/effect/decal/cleanable/glass,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
+/obj/structure/curtain{
+	color = "#845f58";
+	pixel_y = 30
+	},
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "mPZ" = (
 /obj/item/bodypart/l_arm/robot,
 /obj/structure/chair/office/dark,
@@ -45864,6 +45861,12 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
+"mTm" = (
+/obj/structure/fence{
+	pixel_x = -14
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "mTp" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -46097,6 +46100,15 @@
 /obj/structure/railing/handrail,
 /turf/open/floor/plasteel/white,
 /area/f13/brotherhood)
+"mZf" = (
+/obj/structure/fence/corner{
+	dir = 5
+	},
+/obj/structure/fence{
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "mZq" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -46243,6 +46255,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"ncV" = (
+/obj/structure/fence{
+	dir = 8;
+	pixel_y = 20
+	},
+/obj/structure/wreck/trash/bus_door,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "ndc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -46381,15 +46401,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/city/bighorn)
-"nio" = (
-/obj/structure/fence{
-	dir = 8;
-	pixel_y = 20
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
-/area/f13/wasteland/west)
 "niB" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Storage"
@@ -47307,6 +47318,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/bighorn)
+"nDu" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "nEd" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -47390,10 +47406,9 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "nGL" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/wood_wide,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "nGM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -48183,6 +48198,9 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
+	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
 "nXk" = (
@@ -48775,13 +48793,9 @@
 	},
 /area/f13/building/mall)
 "oli" = (
-/obj/structure/chair/stool/retro/black{
-	pixel_x = 2;
-	pixel_y = 9
-	},
-/obj/structure/fluff/railing,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "olx" = (
 /obj/structure/decoration/rag,
 /obj/effect/turf_decal/weather/dirt{
@@ -48793,6 +48807,11 @@
 /obj/machinery/door/unpowered/securedoor/khandoor,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building)
+"olD" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "olN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -49103,12 +49122,6 @@
 "osB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
-	},
-/area/f13/wasteland/west)
-"otr" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
 	},
 /area/f13/wasteland/west)
 "otA" = (
@@ -49679,14 +49692,12 @@
 	},
 /area/f13/building/hospital)
 "oHo" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/camera/autoname{
-	dir = 10;
-	name = "North Facing Camera";
-	network = list("BoS")
+/obj/structure/fence{
+	dir = 8;
+	pixel_y = 20
 	},
-/turf/open/floor/wood/wood_wide,
-/area/f13/brotherhood)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "oHs" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowbroken"
@@ -49859,7 +49870,6 @@
 	pixel_x = 2;
 	pixel_y = 9
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/railing,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -50171,10 +50181,6 @@
 	name = "metal plating"
 	},
 /area/f13/village)
-"oPR" = (
-/obj/structure/wreck/trash/two_tire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "oPV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/three{
@@ -50446,13 +50452,10 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"oXd" = (
-/obj/structure/fence{
-	pixel_x = -14;
-	pixel_y = -12
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
+"oXn" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/brotherhood)
 "oXp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -51021,11 +51024,6 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland/west)
-"plL" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "plR" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/bars{
@@ -51075,6 +51073,10 @@
 /obj/item/clothing/shoes/f13/fancy,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"pmA" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "pmC" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
@@ -52222,6 +52224,21 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/east)
+"pNg" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = 32
+	},
+/obj/machinery/camera/autoname{
+	dir = 6;
+	name = "South Facing Camera";
+	network = list("BoS")
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood/wood_wide,
+/area/f13/brotherhood)
 "pNy" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -52847,9 +52864,11 @@
 	},
 /area/f13/building)
 "qdI" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/savannah,
+/area/f13/brotherhood)
 "qdR" = (
 /obj/machinery/computer/terminal{
 	dir = 8;
@@ -53259,6 +53278,16 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland/hospital)
+"qnF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_y = 1;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/wood_wide,
+/area/f13/brotherhood)
 "qnK" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -54240,6 +54269,15 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland/museum)
+"qLI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "North Facing Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/wood/wood_wide,
+/area/f13/brotherhood)
 "qLX" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/melee/onehanded/knife/survival,
@@ -54614,11 +54652,6 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/nanotrasen)
-"qUu" = (
-/obj/structure/wreck/trash/engine,
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "qUE" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -54925,14 +54958,6 @@
 "rbg" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
-"rbh" = (
-/obj/structure/debris/v3{
-	pixel_x = -11;
-	pixel_y = 22
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "rbt" = (
 /obj/structure/window/fulltile/house,
 /obj/machinery/door/poddoor/shutters{
@@ -55065,13 +55090,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"rcT" = (
-/obj/structure/reagent_dispensers/barrel/four{
-	layer = 6
-	},
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "rcV" = (
 /obj/structure/window/spawner/east,
 /obj/item/clothing/shoes/sandal{
@@ -55080,11 +55098,6 @@
 /obj/item/clothing/under/dress/westernbustle,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
 /area/f13/building/mall)
-"rda" = (
-/obj/structure/car/rubbish2,
-/obj/structure/wreck/trash/two_tire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "rdb" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/weather/dirt{
@@ -55203,6 +55216,12 @@
 	icon_state = "horizontalbottomborderbottom1"
 	},
 /area/f13/wasteland/east)
+"rgg" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "rgj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -55370,6 +55389,12 @@
 "rkl" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
+"rko" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland/west)
 "rkp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -55959,9 +55984,9 @@
 /turf/open/floor/holofloor/carpet,
 /area/f13/city/bighorn)
 "ryr" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/wood/wood_wide,
-/area/f13/brotherhood)
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "ryw" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/regular,
@@ -56137,11 +56162,6 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
-"rEb" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "rEj" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
@@ -56232,6 +56252,12 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/east)
+"rGh" = (
+/obj/structure/reagent_dispensers/barrel/four{
+	pixel_x = -7
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "rGi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -56702,6 +56728,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/quarry)
+"rRC" = (
+/obj/structure/fence{
+	pixel_x = -14;
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "rRH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/jungle/b,
@@ -57116,6 +57149,15 @@
 	icon_state = "cross1"
 	},
 /area/f13/wasteland/firestation)
+"rZD" = (
+/obj/structure/fence{
+	dir = 8;
+	pixel_y = 20
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland/west)
 "rZP" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab"
@@ -57465,14 +57507,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/bighorn)
-"sko" = (
-/obj/structure/fence/corner{
-	dir = 4;
-	icon_state = "end";
-	pixel_y = -12
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "skt" = (
 /obj/machinery/workbench,
 /turf/open/floor/wood/wood_mosaic,
@@ -57564,20 +57598,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
-"snm" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/graveldirt{
-	dir = 4
-	},
-/area/f13/brotherhood)
 "snn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -58375,6 +58395,15 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"sGB" = (
+/obj/structure/fence{
+	dir = 8;
+	pixel_y = 20
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland/west)
 "sGY" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
@@ -58744,9 +58773,9 @@
 	},
 /area/f13/building/museum)
 "sRn" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/brotherhood)
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "sRF" = (
 /obj/structure/rack,
 /obj/item/toy/plush/carpplushie,
@@ -58821,18 +58850,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city/bighorn)
-"sTe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/wood/wood_wide,
-/area/f13/brotherhood/leisure)
 "sTn" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-04"
@@ -58980,12 +58997,6 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
-"sWv" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "sWy" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -59444,8 +59455,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light/floor,
+/obj/item/kirbyplants{
+	icon_state = "plant-17"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
 "thI" = (
@@ -60940,12 +60954,6 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
-"tSi" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "tSs" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/outside/desert{
@@ -61278,6 +61286,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"uac" = (
+/obj/structure/car/rubbish2,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "uai" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -61610,14 +61623,6 @@
 /obj/structure/lattice,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
-"uix" = (
-/obj/structure/reagent_dispensers/barrel/four{
-	layer = 6
-	},
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/obj/effect/decal/cleanable/glass,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "uiC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -61731,20 +61736,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/quarry)
-"uli" = (
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = 30
-	},
-/obj/structure/filingcabinet{
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
 "ulk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -61847,9 +61838,10 @@
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood/leisure)
 "umU" = (
-/obj/structure/fence{
-	pixel_x = -14
+/obj/structure/reagent_dispensers/barrel/four{
+	layer = 6
 	},
+/obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "unj" = (
@@ -62003,7 +61995,6 @@
 	},
 /area/f13/building/massfusion)
 "upN" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = 32
 	},
@@ -62016,6 +62007,7 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
 "upR" = (
@@ -62836,6 +62828,11 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland/firestation)
+"uIq" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "uJa" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/rack/shelf_metal,
@@ -62886,11 +62883,6 @@
 	icon_state = "verticalrightborderright1"
 	},
 /area/f13/building)
-"uJY" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "uKa" = (
 /obj/effect/landmark/start/f13/knightcap,
 /turf/open/floor/f13{
@@ -63014,10 +63006,6 @@
 /obj/item/seeds/xander,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"uMv" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "uMR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -63614,6 +63602,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/city/bighorn)
+"uZx" = (
+/obj/structure/wreck/bus/rusted,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "uZC" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -63625,7 +63617,13 @@
 	color = "#845f58";
 	pixel_y = 30
 	},
-/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/structure/filingcabinet{
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "uZR" = (
@@ -64346,6 +64344,10 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/carpet,
 /area/f13/building)
+"vsb" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "vsg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
@@ -64735,10 +64737,6 @@
 /obj/item/clothing/under/f13/picnicdress50s,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
-"vBn" = (
-/obj/structure/wreck/trash/autoshaft,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "vBH" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/road{
@@ -64827,6 +64825,20 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vFc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 4
+	},
+/area/f13/brotherhood)
 "vFw" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/decal/cleanable/dirt,
@@ -65192,12 +65204,6 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland/quarry)
-"vQm" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/glass,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "vQv" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -65254,10 +65260,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "vRe" = (
-/obj/structure/fence{
-	dir = 8;
-	pixel_y = 20
-	},
+/obj/structure/reagent_dispensers/barrel/four,
+/obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "vRf" = (
@@ -65623,6 +65627,10 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/wood_common,
 /area/f13/village)
+"vZR" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "wae" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -66862,6 +66870,12 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/mall)
+"wCl" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "wCs" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
@@ -67280,6 +67294,14 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland/firestation)
+"wLC" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/savannah{
+	icon_state = "savannah6"
+	},
+/area/f13/brotherhood)
 "wLP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -68647,18 +68669,6 @@
 "xsk" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/quarry)
-"xsl" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
-"xsu" = (
-/obj/structure/fence{
-	dir = 8;
-	pixel_y = 20
-	},
-/obj/structure/wreck/trash/bus_door,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
 "xsA" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -69547,6 +69557,12 @@
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"xOy" = (
+/obj/structure/reagent_dispensers/barrel/four{
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "xOz" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/road{
@@ -70421,11 +70437,17 @@
 	},
 /area/f13/wasteland/west)
 "yil" = (
-/obj/structure/fence{
-	pixel_y = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/wood/wood_wide,
+/area/f13/brotherhood/leisure)
 "yiM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/structure/table/wood,
@@ -92771,23 +92793,23 @@ cjX
 cLQ
 ftD
 aHF
-sko
-yil
-yil
-yil
-yil
-yil
-yil
-yil
-yil
-iVP
-yil
-yil
-yil
-yil
-yil
-yil
-fqf
+dGR
+cQu
+cQu
+cQu
+cQu
+cQu
+cQu
+cQu
+cQu
+olD
+cQu
+cQu
+cQu
+cQu
+cQu
+cQu
+heY
 wEd
 wEd
 wEd
@@ -93029,21 +93051,21 @@ cjX
 cjX
 aHF
 flC
-vRe
+oHo
 aVW
 wEd
-bvq
+mMf
 lPa
-bVF
+lSN
 pOX
-gmM
+dDB
 wEd
 wEd
 wEd
-eZM
+hxy
 wEd
 wEd
-lXF
+pmA
 uBi
 wEd
 wEd
@@ -93286,21 +93308,21 @@ axj
 kPb
 aHF
 wEd
-vRe
+oHo
 wEd
-qdI
-qdI
+vZR
+vZR
 wEd
-vQm
+wCl
 wEd
 wEd
-otr
+rko
 flC
 wEd
 wEd
-gmM
+dDB
 wEd
-csm
+uIq
 uBi
 wEd
 wEd
@@ -93543,8 +93565,8 @@ kPb
 kPb
 sMy
 wEd
-vRe
-etF
+oHo
+rGh
 wEd
 wEd
 wEd
@@ -93552,7 +93574,7 @@ wEd
 wEd
 wEd
 flC
-cfc
+sRn
 wEd
 wEd
 wEd
@@ -93800,21 +93822,21 @@ sOu
 kPb
 aHF
 wEd
-xsu
+ncV
 tTm
-rbh
+eCt
 wEd
 wEd
 wEd
 wEd
 wEd
-mPX
+gml
 wEd
 tTm
 wEd
 wEd
 wEd
-mPX
+gml
 uBi
 wEd
 wEd
@@ -94057,21 +94079,21 @@ aHF
 aHF
 aHF
 wEd
+oHo
+wEd
+wEd
+wEd
 vRe
+vZR
+uac
 wEd
 wEd
 wEd
-gml
-qdI
 mMf
+vRe
+vZR
 wEd
-wEd
-wEd
-bvq
-gml
-qdI
-wEd
-gmM
+dDB
 uBi
 wEd
 wEd
@@ -94314,19 +94336,19 @@ eOm
 iOF
 aHF
 wEd
-nio
+rZD
 wEd
-uJY
+iUu
 wEd
 wEd
 aVW
-qdI
+vZR
+vRe
+iVP
+wEd
+wEd
+aVW
 gml
-vBn
-wEd
-wEd
-aVW
-mPX
 wEd
 wEd
 uBi
@@ -94571,21 +94593,21 @@ fjN
 lEk
 rpL
 wEd
-vRe
-fvc
+oHo
+eFh
 wEd
 wEd
 wEd
 wEd
-hWi
+vsb
 wEd
 aVW
 tTm
-qdI
+vZR
 wEd
 wEd
 wEd
-uMv
+mnk
 uBi
 wEd
 wEd
@@ -94828,8 +94850,8 @@ vXr
 aHF
 aHF
 wEd
-vRe
-hWi
+oHo
+vsb
 wEd
 lPa
 wEd
@@ -94837,12 +94859,12 @@ wEd
 wEd
 wEd
 wEd
-qdI
+vZR
 wEd
 wEd
-eZM
+hxy
 wEd
-gml
+vRe
 uBi
 wEd
 ocu
@@ -95085,20 +95107,20 @@ aHF
 aHF
 wEd
 wEd
-vRe
+oHo
 wEd
 wEd
 wEd
 wEd
-hbl
-hbl
-gmM
+nGL
+nGL
+dDB
 wEd
 tTm
-oPR
-qdI
+oli
+vZR
 wEd
-gmM
+dDB
 wEd
 uBi
 wEd
@@ -95342,16 +95364,16 @@ wEd
 wEd
 wEd
 wEd
-vRe
-fvc
+oHo
+eFh
 wEd
-qdI
-gmM
-qdI
+vZR
+dDB
+vZR
 wEd
-mnT
-qdI
-fvc
+hRk
+vZR
+eFh
 wEd
 wEd
 wEd
@@ -95599,22 +95621,22 @@ wEd
 wEd
 wEd
 wEd
+oHo
+uIq
+wEd
+sRn
+wEd
+wEd
 vRe
-csm
-wEd
-cfc
-wEd
-wEd
-gml
-bvq
+mMf
 wEd
 wEd
 wEd
-gmM
+dDB
 wEd
 wEd
-gmM
-rEb
+dDB
+hKJ
 wEd
 wEd
 chG
@@ -95856,19 +95878,19 @@ wEd
 wEd
 wEd
 wEd
-vRe
+oHo
 wEd
 wEd
-hWN
+uZx
 wEd
 wEd
 aVW
 wEd
 wEd
-bvq
+mMf
 wEd
 wEd
-bvq
+mMf
 wEd
 wEd
 uBi
@@ -96113,21 +96135,21 @@ aLx
 aLx
 wEd
 wEd
-vRe
-lHj
+oHo
+gij
 wEd
 wEd
-uMv
+mnk
 wEd
 wEd
-qUu
+gmM
 wEd
 wEd
 awx
 wEd
 aVW
 wEd
-plL
+miB
 uBi
 wEd
 wEd
@@ -96370,7 +96392,7 @@ aUD
 aLx
 wEd
 wEd
-vRe
+oHo
 wEd
 wEd
 wEd
@@ -96627,21 +96649,21 @@ aJl
 aUr
 flC
 wEd
+oHo
+gij
+wEd
+wEd
+wEd
+wEd
 vRe
-lHj
-wEd
-wEd
-wEd
-wEd
-gml
 wEd
 wEd
 wEd
 wEd
 wEd
-xsl
+ryr
 wEd
-gml
+vRe
 uBi
 wEd
 wEd
@@ -96884,21 +96906,21 @@ aHp
 aUr
 wEd
 wEd
-vRe
+oHo
 wEd
 wEd
 wEd
-uMv
+mnk
 wEd
 wEd
-gmM
+dDB
 wEd
 wEd
 flC
 wEd
 wEd
 wEd
-oPR
+oli
 uBi
 wEd
 wEd
@@ -97141,17 +97163,17 @@ aJl
 aLx
 wEd
 wEd
-vRe
+oHo
 wEd
 wEd
 wEd
 wEd
-gmM
+dDB
 wEd
-qdI
+vZR
 wEd
-cfc
-gmM
+sRn
+dDB
 wEd
 wEd
 wEd
@@ -97398,19 +97420,19 @@ aUD
 aLx
 wEd
 wEd
-vRe
-uMv
-iSu
-hWi
-vBn
+oHo
+mnk
+iDu
+vsb
+iVP
 wEd
 wEd
 wEd
-jrT
+htK
 wEd
 wEd
 wEd
-gmM
+dDB
 wEd
 wEd
 uBi
@@ -97655,17 +97677,17 @@ aJD
 aKw
 wEd
 wEd
+oHo
+wEd
+sRn
+wEd
+wEd
+wEd
+oli
+dDB
+wEd
+oli
 vRe
-wEd
-cfc
-wEd
-wEd
-wEd
-oPR
-gmM
-wEd
-oPR
-gml
 wEd
 wEd
 tTm
@@ -97912,11 +97934,11 @@ aJl
 aKw
 wEd
 wEd
-vRe
+oHo
 wEd
 wEd
 wEd
-gmM
+dDB
 wEd
 wEd
 wEd
@@ -97924,9 +97946,9 @@ wEd
 pOX
 aVW
 wEd
-gmM
+dDB
 wEd
-uMv
+mnk
 uBi
 wEd
 wEd
@@ -98169,22 +98191,22 @@ aTz
 aKw
 wEd
 wEd
-vRe
-gmM
+oHo
+dDB
 wEd
 wEd
 wEd
 wEd
-xsl
+ryr
 wEd
 wEd
 wEd
 wEd
-rda
+bIm
 aXq
-yil
-yil
-giL
+cQu
+cQu
+mZf
 wEd
 wEd
 wEd
@@ -98426,16 +98448,16 @@ aaQ
 aaQ
 wEd
 wEd
-vRe
-cfc
+oHo
+sRn
 wEd
 wEd
 wEd
 pOX
 aVW
-qdI
+vZR
 wEd
-uix
+ixR
 wEd
 wEd
 gYz
@@ -98683,16 +98705,16 @@ aVp
 aaQ
 wEd
 wEd
-gdh
+sGB
 awx
 wEd
 wEd
 sEB
 wEd
 awx
-fqP
+huW
 wEd
-qdI
+vZR
 pOX
 wEd
 gYz
@@ -98940,7 +98962,7 @@ aVq
 aaQ
 wEd
 wEd
-vRe
+oHo
 wEd
 wEd
 wEd
@@ -98951,7 +98973,7 @@ wEd
 wEd
 wEd
 wEd
-lSN
+xOy
 gYz
 abP
 ahY
@@ -99197,7 +99219,7 @@ aVp
 aaQ
 wEd
 wEd
-vRe
+oHo
 wEd
 wEd
 wEd
@@ -99207,8 +99229,8 @@ wEd
 wEd
 aVW
 wEd
-xsl
-gmM
+ryr
+dDB
 gYz
 abP
 bcF
@@ -99454,13 +99476,13 @@ oUj
 aHy
 wEd
 wEd
-vRe
-hlJ
+oHo
+nDu
 wEd
 wEd
-qdI
+vZR
 wEd
-gmM
+dDB
 wEd
 awx
 wEd
@@ -99711,10 +99733,10 @@ aAf
 aaQ
 wEd
 wEd
-vRe
-uMv
+oHo
+mnk
 wEd
-fPI
+kgD
 amE
 wEd
 wEd
@@ -99722,7 +99744,7 @@ wEd
 wEd
 wEd
 wEd
-rcT
+umU
 gYz
 abP
 xyU
@@ -99967,20 +99989,20 @@ aUV
 aHu
 aaQ
 wEd
-oXd
-umU
-umU
-umU
+rRC
+mTm
+mTm
+mTm
 amE
-sWv
-umU
-umU
-umU
-umU
-umU
-umU
-umU
-umU
+gzU
+mTm
+mTm
+mTm
+mTm
+mTm
+mTm
+mTm
+mTm
 abP
 xyU
 meQ
@@ -122398,7 +122420,7 @@ lNa
 lNa
 oqX
 vSj
-nGL
+wkH
 jRg
 jqa
 cGx
@@ -122655,8 +122677,8 @@ drl
 biN
 eKD
 eKD
-eKD
-eKD
+ycy
+ycy
 jqa
 cGx
 jlI
@@ -122912,7 +122934,7 @@ drl
 biN
 ycy
 wkH
-wkH
+qnF
 wkH
 jqa
 cGx
@@ -123167,9 +123189,9 @@ qDt
 vUg
 dvJ
 eeQ
-ycy
+wGE
 fcE
-ycy
+fcE
 fcE
 jjl
 cGx
@@ -123423,13 +123445,13 @@ uao
 gYB
 vUg
 drl
-biN
-eKD
+rnR
+ycy
 bzg
 thC
 dQk
-ycy
-oHo
+jjl
+jqa
 jqa
 nzT
 kwE
@@ -123680,13 +123702,13 @@ bok
 bok
 vUg
 drl
-biN
-ycy
+rnR
+fcE
 wGE
 dJt
 dJt
-ycy
-eKD
+mpR
+eaA
 jqa
 cPi
 rZl
@@ -123917,7 +123939,7 @@ bfZ
 rmP
 rmP
 eiK
-izn
+kIh
 iVI
 knn
 knn
@@ -123937,13 +123959,13 @@ bok
 bok
 vUg
 rcg
-eKD
+ycy
 ycy
 wGE
 snF
 wGE
-ryr
-ycy
+eKD
+qLI
 jqa
 qDO
 wHS
@@ -124447,7 +124469,7 @@ mgd
 bok
 qDt
 bok
-bok
+oXn
 bok
 sAA
 fOl
@@ -124703,8 +124725,8 @@ bok
 bok
 mgd
 bok
-sRn
-dDB
+bok
+qDt
 bok
 sAA
 fOl
@@ -125222,7 +125244,7 @@ bok
 oQI
 juJ
 rcg
-upN
+pNg
 ycy
 ovz
 evE
@@ -125459,7 +125481,7 @@ bfZ
 rmP
 rmP
 rmP
-izn
+kIh
 jPD
 qLf
 aoN
@@ -126021,8 +126043,8 @@ wTf
 wTf
 jVJ
 qSU
-euy
-jiS
+jEy
+qdI
 qke
 rOg
 rOg
@@ -127549,8 +127571,8 @@ wHS
 cPi
 gZC
 qMn
-snm
-snm
+vFc
+vFc
 wTf
 jVJ
 kEn
@@ -128334,7 +128356,7 @@ cVE
 jVJ
 jVJ
 mkD
-jiS
+qdI
 dLA
 pXJ
 sIa
@@ -128824,7 +128846,7 @@ jqa
 mwM
 lwz
 lwz
-sTe
+yil
 lwz
 qOt
 bAd
@@ -130880,9 +130902,9 @@ tnO
 cOc
 buS
 lax
-uli
+uZO
 pbq
-oli
+oKU
 chI
 lXi
 jsL
@@ -130904,7 +130926,7 @@ dtO
 hxC
 jVJ
 ldD
-jPR
+wLC
 avM
 pal
 xKP
@@ -131139,7 +131161,7 @@ buS
 qjz
 qoz
 nSr
-oli
+oKU
 uZo
 mfV
 mfV
@@ -131394,9 +131416,9 @@ tnO
 rZd
 buS
 lax
-uZO
+mPX
 pbq
-oKU
+eiq
 nwf
 lXi
 ftZ
@@ -131651,7 +131673,7 @@ tnO
 cOc
 buS
 lax
-uZO
+mPX
 pbq
 nSu
 nlO
@@ -132423,7 +132445,7 @@ cOc
 cOc
 tnO
 tnO
-tSi
+rgg
 dOr
 tnO
 eqs
@@ -132935,7 +132957,7 @@ jRH
 tnO
 pbq
 pVq
-oli
+oKU
 nbd
 dSE
 hST
@@ -133192,7 +133214,7 @@ jRH
 tnO
 bKO
 pbq
-oli
+oKU
 rRk
 xnY
 iYH
@@ -133449,7 +133471,7 @@ jRH
 tnO
 wtV
 nSr
-oli
+oKU
 kTO
 rzz
 ddC
@@ -133706,7 +133728,7 @@ jRH
 tnO
 nKn
 nSr
-oli
+oKU
 wgd
 rzz
 tup

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -67,9 +67,8 @@
 	},
 /area/f13/wasteland/west)
 "aau" = (
-/obj/item/twohanded/required/kirbyplants/random{
-	pixel_x = 8;
-	pixel_y = 3
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood/leisure)
@@ -3152,9 +3151,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "alT" = (
-/obj/item/twohanded/required/kirbyplants/random{
-	pixel_y = -2;
-	pixel_x = -7
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
@@ -13681,6 +13679,9 @@
 /obj/machinery/computer/operating/bos{
 	dir = 1
 	},
+/obj/structure/curtain{
+	pixel_y = 33
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -19822,6 +19823,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
+"bvq" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "bvx" = (
 /mob/living/simple_animal/opossum/poppy,
 /turf/open/floor/f13{
@@ -21688,6 +21693,10 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"bVF" = (
+/obj/structure/wreck/trash/bus_door,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "bVI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22463,6 +22472,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/city/bighorn)
+"cfc" = (
+/obj/structure/wreck/trash/five_tires,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "cfd" = (
 /obj/effect/decal/cleanable/vomit/old{
 	pixel_y = 15
@@ -23565,6 +23578,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"csm" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "csn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood/drip,
@@ -26122,9 +26140,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "dAC" = (
-/obj/structure/bookshelf{
-	icon_state = "book-4"
-	},
 /obj/machinery/computer/auxillary_base{
 	pixel_y = 25
 	},
@@ -26136,6 +26151,9 @@
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
+	},
+/obj/structure/bookshelf{
+	icon_state = "book-5"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -27807,6 +27825,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/followers)
+"etF" = (
+/obj/structure/reagent_dispensers/barrel/four{
+	pixel_x = -7
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "etN" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/cigarette/pipe,
@@ -27837,6 +27861,13 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"euy" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/savannah,
+/area/f13/brotherhood)
 "euM" = (
 /obj/structure/guncase{
 	anchored = 1
@@ -28721,10 +28752,6 @@
 	},
 /area/f13/building/massfusion)
 "eRg" = (
-/obj/item/twohanded/required/kirbyplants/random{
-	pixel_y = 5;
-	pixel_x = -1
-	},
 /obj/machinery/camera/autoname{
 	dir = 10;
 	name = "North Facing Camera";
@@ -28732,6 +28759,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -29116,6 +29146,11 @@
 /obj/item/clothing/neck/mantle/ragged,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eZM" = (
+/obj/structure/car/rubbish3,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "fah" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building/mall)
@@ -29773,6 +29808,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
+"fqf" = (
+/obj/structure/fence/corner{
+	dir = 8;
+	pixel_x = 1
+	},
+/obj/structure/fence{
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "fqn" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -29800,6 +29845,13 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"fqP" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/reagent_dispensers/barrel/four{
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "fre" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
@@ -30004,6 +30056,11 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"fvc" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "fvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30815,6 +30872,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"fPI" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "fPS" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -31277,7 +31340,6 @@
 	name = "North Facing Camera";
 	network = list("BoS")
 	},
-/obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/brotherhood)
 "fZB" = (
@@ -31384,7 +31446,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "gcr" = (
 /obj/structure/curtain{
@@ -31415,6 +31477,15 @@
 	dir = 1
 	},
 /area/f13/brotherhood/offices1st)
+"gdh" = (
+/obj/structure/fence{
+	dir = 8;
+	pixel_y = 20
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland/west)
 "gdn" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War wall made of solid concrete.";
@@ -31578,6 +31649,15 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland/massfusion)
+"giL" = (
+/obj/structure/fence/corner{
+	dir = 5
+	},
+/obj/structure/fence{
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "giN" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -31681,33 +31761,10 @@
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "gml" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/item/stack/sheet/prewar/five,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/rnd)
+/obj/structure/reagent_dispensers/barrel/four,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "gmm" = (
 /obj/structure/railing/handrail,
 /turf/open/floor/plasteel/white/side,
@@ -31722,11 +31779,9 @@
 	},
 /area/f13/building/firestation)
 "gmM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/brotherhood/leisure)
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "gmP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/fernybush,
@@ -33423,6 +33478,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
+"hbl" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "hbq" = (
 /obj/item/flag/khan{
 	pixel_y = 28;
@@ -33753,6 +33812,11 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/east)
+"hlJ" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "hlR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag,
@@ -34119,10 +34183,6 @@
 	dir = 4;
 	pixel_y = 1;
 	pixel_x = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -34974,7 +35034,6 @@
 	name = "North Facing Camera";
 	network = list("BoS")
 	},
-/obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/savannah{
 	icon_state = "savannah8"
 	},
@@ -35053,6 +35112,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building/museum)
+"hWi" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "hWp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -35087,6 +35150,10 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
+/area/f13/wasteland/west)
+"hWN" = (
+/obj/structure/wreck/bus/rusted,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "hXb" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -36176,6 +36243,12 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland/quarry)
+"izn" = (
+/obj/item/flag/bos,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland/east)
 "izr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -37101,6 +37174,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
+"iSu" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "iSC" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -37286,14 +37363,10 @@
 	},
 /area/f13/wasteland/east)
 "iVP" = (
-/obj/item/twohanded/required/kirbyplants/random{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light,
-/turf/open/floor/carpet/blue,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "iVS" = (
 /obj/structure/wreck/bus/rusted{
 	pixel_y = 11
@@ -37895,6 +37968,12 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood/leisure)
+"jiS" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/savannah,
+/area/f13/brotherhood)
 "jiX" = (
 /obj/effect/decal/riverbank,
 /obj/structure/fence/wooden{
@@ -38232,6 +38311,11 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland/east)
+"jrT" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "jrX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -38708,7 +38792,7 @@
 /obj/structure/lamp_post{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "jEW" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -39071,6 +39155,14 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"jPR" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/savannah{
+	icon_state = "savannah6"
+	},
+/area/f13/brotherhood)
 "jPV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -40165,7 +40257,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "kvj" = (
 /obj/structure/chair/bench,
@@ -40812,6 +40904,9 @@
 	pixel_x = -32;
 	pixel_y = -3
 	},
+/obj/structure/curtain{
+	pixel_y = 33
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -41078,7 +41173,9 @@
 /area/f13/brotherhood/leisure)
 "kQj" = (
 /obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/darkpurple,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "kQV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41171,10 +41268,6 @@
 "kSY" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
 	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
@@ -41676,7 +41769,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "ldR" = (
 /obj/structure/barricade/sandbags,
@@ -42825,7 +42918,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "lEk" = (
 /obj/structure/bed,
@@ -42956,6 +43049,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/bighorn)
+"lHj" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "lHm" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -43493,9 +43590,11 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/building)
 "lSN" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/darkpurple,
-/area/f13/brotherhood/chemistry)
+/obj/structure/reagent_dispensers/barrel/four{
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "lSQ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -43745,6 +43844,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/quarry)
+"lXF" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "lXP" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -44462,6 +44565,14 @@
 	dir = 1
 	},
 /area/f13/building/museum)
+"mnT" = (
+/mob/living/simple_animal/hostile/ghoul/legendary{
+	name = "Trash Master"
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland/west)
 "mof" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -45435,15 +45546,10 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
 "mMf" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/f13/brotherhood/offices1st)
+/obj/structure/car/rubbish2,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "mMr" = (
 /obj/structure/table/snooker{
 	dir = 5
@@ -45590,23 +45696,10 @@
 	},
 /area/f13/wasteland/firestation)
 "mPX" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = 30
-	},
-/turf/open/water,
-/area/f13/brotherhood/offices1st)
+/obj/structure/car/rubbish4,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "mPZ" = (
 /obj/item/bodypart/l_arm/robot,
 /obj/structure/chair/office/dark,
@@ -46288,6 +46381,15 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/city/bighorn)
+"nio" = (
+/obj/structure/fence{
+	dir = 8;
+	pixel_y = 20
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland/west)
 "niB" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Storage"
@@ -46969,9 +47071,6 @@
 	dir = 6;
 	name = "South Facing Camera";
 	network = list("BoS")
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -48676,14 +48775,11 @@
 	},
 /area/f13/building/mall)
 "oli" = (
-/obj/structure/fluff/railing,
 /obj/structure/chair/stool/retro/black{
 	pixel_x = 2;
 	pixel_y = 9
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/fluff/railing,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "olx" = (
@@ -49007,6 +49103,12 @@
 "osB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
+	},
+/area/f13/wasteland/west)
+"otr" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
 	},
 /area/f13/wasteland/west)
 "otA" = (
@@ -49743,6 +49845,7 @@
 	color = "#845f58";
 	pixel_x = -31
 	},
+/obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "oKR" = (
@@ -49752,12 +49855,12 @@
 	},
 /area/f13/wasteland/massfusion)
 "oKU" = (
-/obj/structure/fluff/railing,
 /obj/structure/chair/stool/retro/black{
 	pixel_x = 2;
 	pixel_y = 9
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fluff/railing,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "oLb" = (
@@ -50068,6 +50171,10 @@
 	name = "metal plating"
 	},
 /area/f13/village)
+"oPR" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "oPV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/three{
@@ -50120,7 +50227,6 @@
 	name = "North Facing Camera";
 	network = list("BoS")
 	},
-/obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/brotherhood)
 "oQN" = (
@@ -50340,6 +50446,13 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"oXd" = (
+/obj/structure/fence{
+	pixel_x = -14;
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "oXp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -50755,14 +50868,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
 "phc" = (
-/obj/item/twohanded/required/kirbyplants/random{
-	pixel_y = 5;
-	pixel_x = -1
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
+/obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "phY" = (
@@ -50914,6 +51020,11 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
+/area/f13/wasteland/west)
+"plL" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "plR" = (
 /obj/structure/barricade/wooden,
@@ -52736,12 +52847,9 @@
 	},
 /area/f13/building)
 "qdI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "qdR" = (
 /obj/machinery/computer/terminal{
 	dir = 8;
@@ -53616,12 +53724,11 @@
 	},
 /area/f13/brotherhood)
 "qxy" = (
-/obj/item/twohanded/required/kirbyplants/random{
-	pixel_y = -2;
-	pixel_x = -7
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood/leisure)
@@ -54507,6 +54614,11 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/nanotrasen)
+"qUu" = (
+/obj/structure/wreck/trash/engine,
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "qUE" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -54813,6 +54925,14 @@
 "rbg" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
+"rbh" = (
+/obj/structure/debris/v3{
+	pixel_x = -11;
+	pixel_y = 22
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "rbt" = (
 /obj/structure/window/fulltile/house,
 /obj/machinery/door/poddoor/shutters{
@@ -54945,6 +55065,13 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"rcT" = (
+/obj/structure/reagent_dispensers/barrel/four{
+	layer = 6
+	},
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "rcV" = (
 /obj/structure/window/spawner/east,
 /obj/item/clothing/shoes/sandal{
@@ -54953,6 +55080,11 @@
 /obj/item/clothing/under/dress/westernbustle,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
 /area/f13/building/mall)
+"rda" = (
+/obj/structure/car/rubbish2,
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "rdb" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/weather/dirt{
@@ -55940,13 +56072,6 @@
 	},
 /area/f13/wasteland/nanotrasen)
 "rCQ" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
 /obj/structure/curtain{
 	color = "#845f58";
 	pixel_x = -31
@@ -55955,7 +56080,14 @@
 	color = "#845f58";
 	pixel_y = 30
 	},
-/turf/open/water,
+/obj/structure/filingcabinet{
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = 11
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "rDf" = (
 /obj/effect/decal/marking{
@@ -56005,6 +56137,11 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood)
+"rEb" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "rEj" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
@@ -56867,7 +57004,7 @@
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "rXk" = (
 /obj/structure/debris/v1{
@@ -57328,6 +57465,14 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/bighorn)
+"sko" = (
+/obj/structure/fence/corner{
+	dir = 4;
+	icon_state = "end";
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "skt" = (
 /obj/machinery/workbench,
 /turf/open/floor/wood/wood_mosaic,
@@ -57419,6 +57564,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
+"snm" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 4
+	},
+/area/f13/brotherhood)
 "snn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -58662,10 +58821,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city/bighorn)
+"sTe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/wood/wood_wide,
+/area/f13/brotherhood/leisure)
 "sTn" = (
-/obj/item/twohanded/required/kirbyplants/random{
-	pixel_y = 5;
-	pixel_x = -1
+/obj/item/kirbyplants{
+	icon_state = "plant-04"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -58689,7 +58859,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "sTP" = (
 /obj/structure/barricade/wooden,
@@ -58810,6 +58980,12 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
+"sWv" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "sWy" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -59791,7 +59967,9 @@
 /area/f13/building)
 "tup" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "tuu" = (
@@ -60339,7 +60517,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "tGQ" = (
 /obj/structure/flora/grass/wasteland{
@@ -60762,6 +60940,12 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
+"tSi" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "tSs" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/outside/desert{
@@ -61426,6 +61610,14 @@
 /obj/structure/lattice,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
+"uix" = (
+/obj/structure/reagent_dispensers/barrel/four{
+	layer = 6
+	},
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "uiC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -61539,6 +61731,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/quarry)
+"uli" = (
+/obj/structure/curtain{
+	color = "#845f58";
+	pixel_y = 30
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/offices1st)
 "ulk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -61641,9 +61847,11 @@
 /turf/open/floor/wood/wood_wide,
 /area/f13/brotherhood/leisure)
 "umU" = (
-/obj/structure/fluff/railing,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/obj/structure/fence{
+	pixel_x = -14
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "unj" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -62005,11 +62213,8 @@
 	},
 /area/f13/building)
 "uud" = (
-/obj/item/twohanded/required/kirbyplants/random{
-	pixel_x = 8;
-	pixel_y = 3
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants,
 /turf/open/floor/carpet/blue,
 /area/f13/brotherhood/leisure)
 "uul" = (
@@ -62681,6 +62886,11 @@
 	icon_state = "verticalrightborderright1"
 	},
 /area/f13/building)
+"uJY" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "uKa" = (
 /obj/effect/landmark/start/f13/knightcap,
 /turf/open/floor/f13{
@@ -62804,6 +63014,10 @@
 /obj/item/seeds/xander,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"uMv" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "uMR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -63407,20 +63621,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uZO" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
 /obj/structure/curtain{
 	color = "#845f58";
 	pixel_y = 30
 	},
-/turf/open/water,
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "uZR" = (
 /obj/structure/table/wood,
@@ -63855,7 +64061,6 @@
 	name = "North Facing Camera";
 	network = list("BoS")
 	},
-/obj/item/flag/bos,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
@@ -64530,6 +64735,10 @@
 /obj/item/clothing/under/f13/picnicdress50s,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"vBn" = (
+/obj/structure/wreck/trash/autoshaft,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "vBH" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/road{
@@ -64983,6 +65192,12 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland/quarry)
+"vQm" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "vQv" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -65039,12 +65254,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "vRe" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/fence{
+	dir = 8;
+	pixel_y = 20
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "vRf" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -66364,6 +66579,9 @@
 	pixel_x = 8
 	},
 /obj/effect/landmark/start/f13/seniorscribe,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -68429,6 +68647,18 @@
 "xsk" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/quarry)
+"xsl" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
+"xsu" = (
+/obj/structure/fence{
+	dir = 8;
+	pixel_y = 20
+	},
+/obj/structure/wreck/trash/bus_door,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "xsA" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -70191,11 +70421,11 @@
 	},
 /area/f13/wasteland/west)
 "yil" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/fence{
+	pixel_y = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/offices1st)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/west)
 "yiM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/structure/table/wood,
@@ -92036,7 +92266,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+ocu
 wEd
 wEd
 wEd
@@ -92302,7 +92532,7 @@ wEd
 wEd
 wEd
 flC
-wEd
+ocu
 wEd
 abP
 abP
@@ -92541,23 +92771,23 @@ cjX
 cLQ
 ftD
 aHF
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+sko
+yil
+yil
+yil
+yil
+yil
+yil
+yil
+yil
+iVP
+yil
+yil
+yil
+yil
+yil
+yil
+fqf
 wEd
 wEd
 wEd
@@ -92799,22 +93029,22 @@ cjX
 cjX
 aHF
 flC
+vRe
+aVW
 wEd
-wEd
-wEd
-wEd
+bvq
 lPa
+bVF
+pOX
+gmM
 wEd
 wEd
 wEd
+eZM
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+lXF
+uBi
 wEd
 wEd
 wEd
@@ -93056,22 +93286,22 @@ axj
 kPb
 aHF
 wEd
+vRe
+wEd
+qdI
+qdI
+wEd
+vQm
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+otr
 flC
-flC
 wEd
 wEd
+gmM
 wEd
-wEd
-wEd
-wEd
+csm
+uBi
 wEd
 wEd
 wEd
@@ -93313,8 +93543,8 @@ kPb
 kPb
 sMy
 wEd
-wEd
-wEd
+vRe
+etF
 wEd
 wEd
 wEd
@@ -93322,16 +93552,16 @@ wEd
 wEd
 wEd
 flC
-wEd
-wEd
-wEd
-wEd
-ahE
+cfc
 wEd
 wEd
 wEd
 wEd
 wEd
+uBi
+wEd
+wEd
+ocu
 apO
 bbG
 xyU
@@ -93570,23 +93800,23 @@ sOu
 kPb
 aHF
 wEd
+xsu
+tTm
+rbh
 wEd
 wEd
 wEd
 wEd
 wEd
+mPX
+wEd
+tTm
 wEd
 wEd
 wEd
+mPX
+uBi
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-ocu
 wEd
 wEd
 apO
@@ -93827,22 +94057,22 @@ aHF
 aHF
 aHF
 wEd
+vRe
 wEd
 wEd
 wEd
+gml
+qdI
+mMf
 wEd
 wEd
 wEd
+bvq
+gml
+qdI
 wEd
-wEd
-wEd
-wEd
-wEd
-lPa
-wEd
-wEd
-wEd
-wEd
+gmM
+uBi
 wEd
 wEd
 wEd
@@ -94084,22 +94314,22 @@ eOm
 iOF
 aHF
 wEd
-sEB
+nio
+wEd
+uJY
 wEd
 wEd
+aVW
+qdI
+gml
+vBn
 wEd
 wEd
+aVW
+mPX
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+uBi
 wEd
 wEd
 wEd
@@ -94341,22 +94571,22 @@ fjN
 lEk
 rpL
 wEd
+vRe
+fvc
 wEd
 wEd
 wEd
 wEd
+hWi
+wEd
+aVW
+tTm
+qdI
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+uMv
+uBi
 wEd
 wEd
 wEd
@@ -94598,8 +94828,8 @@ vXr
 aHF
 aHF
 wEd
-wEd
-wEd
+vRe
+hWi
 wEd
 lPa
 wEd
@@ -94607,15 +94837,15 @@ wEd
 wEd
 wEd
 wEd
+qdI
 wEd
 wEd
+eZM
 wEd
+gml
+uBi
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+ocu
 wEd
 aXZ
 abP
@@ -94855,22 +95085,22 @@ aHF
 aHF
 wEd
 wEd
+vRe
 wEd
 wEd
 wEd
 wEd
+hbl
+hbl
+gmM
 wEd
+tTm
+oPR
+qdI
 wEd
+gmM
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+uBi
 wEd
 wEd
 wEd
@@ -95112,22 +95342,22 @@ wEd
 wEd
 wEd
 wEd
+vRe
+fvc
 wEd
+qdI
+gmM
+qdI
 wEd
-wEd
+mnT
+qdI
+fvc
 wEd
 wEd
 wEd
 wEd
 flC
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-flC
-wEd
+uBi
 wEd
 wEd
 wEd
@@ -95369,22 +95599,22 @@ wEd
 wEd
 wEd
 wEd
+vRe
+csm
+wEd
+cfc
+wEd
+wEd
+gml
+bvq
 wEd
 wEd
 wEd
+gmM
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+gmM
+rEb
 wEd
 wEd
 chG
@@ -95626,22 +95856,22 @@ wEd
 wEd
 wEd
 wEd
+vRe
 wEd
 wEd
+hWN
 wEd
 wEd
+aVW
 wEd
 wEd
+bvq
 wEd
 wEd
+bvq
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+uBi
 wEd
 wEd
 gYz
@@ -95883,22 +96113,22 @@ aLx
 aLx
 wEd
 wEd
+vRe
+lHj
 wEd
 wEd
+uMv
 wEd
 wEd
-ocu
+qUu
 wEd
 wEd
+awx
 wEd
+aVW
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+plL
+uBi
 wEd
 wEd
 gYz
@@ -96140,22 +96370,22 @@ aUD
 aLx
 wEd
 wEd
+vRe
 wEd
 wEd
 wEd
 wEd
 wEd
+tTm
+wEd
+wEd
+pOX
 wEd
 wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+uBi
 wEd
 wEd
 gYz
@@ -96397,22 +96627,22 @@ aJl
 aUr
 flC
 wEd
+vRe
+lHj
+wEd
+wEd
+wEd
+wEd
+gml
 wEd
 wEd
 wEd
 wEd
 wEd
+xsl
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-lPa
+gml
+uBi
 wEd
 wEd
 gYz
@@ -96654,22 +96884,22 @@ aHp
 aUr
 wEd
 wEd
+vRe
 wEd
 wEd
 wEd
+uMv
 wEd
 wEd
-ahE
-wEd
-wEd
+gmM
 wEd
 wEd
 flC
 wEd
 wEd
 wEd
-wEd
-wEd
+oPR
+uBi
 wEd
 wEd
 gYz
@@ -96911,22 +97141,22 @@ aJl
 aLx
 wEd
 wEd
+vRe
 wEd
 wEd
 wEd
 wEd
+gmM
+wEd
+qdI
+wEd
+cfc
+gmM
 wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+uBi
 wEd
 wEd
 gYz
@@ -97168,22 +97398,22 @@ aUD
 aLx
 wEd
 wEd
+vRe
+uMv
+iSu
+hWi
+vBn
 wEd
 wEd
 wEd
+jrT
 wEd
 wEd
 wEd
+gmM
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+uBi
 wEd
 wEd
 gYz
@@ -97425,22 +97655,22 @@ aJD
 aKw
 wEd
 wEd
-lPa
+vRe
+wEd
+cfc
 wEd
 wEd
 wEd
+oPR
+gmM
+wEd
+oPR
+gml
 wEd
 wEd
-lPa
+tTm
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+uBi
 wEd
 wEd
 aXZ
@@ -97682,6 +97912,22 @@ aJl
 aKw
 wEd
 wEd
+vRe
+wEd
+wEd
+wEd
+gmM
+wEd
+wEd
+wEd
+wEd
+pOX
+aVW
+wEd
+gmM
+wEd
+uMv
+uBi
 wEd
 wEd
 wEd
@@ -97693,22 +97939,6 @@ wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-gYz
-wEd
-wEd
-gYz
 wEd
 uki
 rma
@@ -97939,22 +98169,22 @@ aTz
 aKw
 wEd
 wEd
+vRe
+gmM
 wEd
 wEd
 wEd
 wEd
+xsl
 wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+rda
+aXq
+yil
+yil
+giL
 wEd
 wEd
 wEd
@@ -98196,19 +98426,19 @@ aaQ
 aaQ
 wEd
 wEd
+vRe
+cfc
 wEd
 wEd
 wEd
+pOX
+aVW
+qdI
+wEd
+uix
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-lPa
+gYz
 abP
 abP
 abP
@@ -98452,20 +98682,20 @@ brV
 aVp
 aaQ
 wEd
-flC
 wEd
-wEd
+gdh
+awx
 wEd
 wEd
 sEB
 wEd
+awx
+fqP
 wEd
+qdI
+pOX
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+gYz
 abP
 aZv
 aZY
@@ -98710,19 +98940,19 @@ aVq
 aaQ
 wEd
 wEd
-wEd
-lPa
-wEd
+vRe
 wEd
 wEd
 wEd
 wEd
 wEd
-lPa
 wEd
 wEd
 wEd
 wEd
+wEd
+lSN
+gYz
 abP
 ahY
 aZZ
@@ -98967,6 +99197,7 @@ aVp
 aaQ
 wEd
 wEd
+vRe
 wEd
 wEd
 wEd
@@ -98974,12 +99205,11 @@ wEd
 wEd
 wEd
 wEd
+aVW
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+xsl
+gmM
+gYz
 abP
 bcF
 abP
@@ -99224,19 +99454,19 @@ oUj
 aHy
 wEd
 wEd
+vRe
+hlJ
+wEd
+wEd
+qdI
+wEd
+gmM
+wEd
+awx
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+gYz
 abP
 xyU
 uQs
@@ -99481,19 +99711,19 @@ aAf
 aaQ
 wEd
 wEd
+vRe
+uMv
+wEd
+fPI
+amE
 wEd
 wEd
 wEd
 wEd
 wEd
 wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
+rcT
+gYz
 abP
 xyU
 aub
@@ -99737,20 +99967,20 @@ aUV
 aHu
 aaQ
 wEd
-wEd
-wEd
-wEd
-wEd
-lPa
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-wEd
-lPa
-wEd
+oXd
+umU
+umU
+umU
+amE
+sWv
+umU
+umU
+umU
+umU
+umU
+umU
+umU
+umU
 abP
 xyU
 meQ
@@ -123687,7 +123917,7 @@ bfZ
 rmP
 rmP
 eiK
-ify
+izn
 iVI
 knn
 knn
@@ -125229,7 +125459,7 @@ bfZ
 rmP
 rmP
 rmP
-ify
+izn
 jPD
 qLf
 aoN
@@ -125791,8 +126021,8 @@ wTf
 wTf
 jVJ
 qSU
-pYU
-bQS
+euy
+jiS
 qke
 rOg
 rOg
@@ -126047,7 +126277,7 @@ qke
 jVJ
 wTf
 wTf
-hfr
+ovr
 tao
 vUp
 aje
@@ -126304,7 +126534,7 @@ tao
 qke
 wTf
 wTf
-hfr
+ovr
 pwG
 iEy
 mrI
@@ -126561,7 +126791,7 @@ dET
 tVt
 jVJ
 wTf
-hfr
+ovr
 xGE
 ktF
 eeI
@@ -126818,7 +127048,7 @@ tao
 tVt
 jVJ
 wTf
-hfr
+ovr
 iEy
 vUd
 iEy
@@ -127076,8 +127306,8 @@ pBW
 jVJ
 wTf
 rWY
-tPX
-tPX
+wiQ
+wiQ
 miw
 pEe
 oNv
@@ -127319,8 +127549,8 @@ wHS
 cPi
 gZC
 qMn
-rkp
-rkp
+snm
+snm
 wTf
 jVJ
 kEn
@@ -128104,7 +128334,7 @@ cVE
 jVJ
 jVJ
 mkD
-bQS
+jiS
 dLA
 pXJ
 sIa
@@ -128361,12 +128591,12 @@ wzk
 jVJ
 jVJ
 lPm
-qdI
-kOz
+vUp
+tao
 tao
 mrI
 jcp
-gml
+uab
 jNN
 kYv
 jNN
@@ -128594,7 +128824,7 @@ jqa
 mwM
 lwz
 lwz
-kPP
+sTe
 lwz
 qOt
 bAd
@@ -129133,7 +129363,7 @@ kGU
 jVJ
 wTf
 jVJ
-hfr
+ovr
 xGE
 tao
 pwG
@@ -129401,7 +129631,7 @@ xLv
 xLv
 xLv
 xLv
-lSN
+dUs
 xLv
 xLv
 aaa
@@ -129646,8 +129876,8 @@ jVJ
 wTf
 jVJ
 jES
-vRe
-tPX
+miw
+wiQ
 bsT
 nvH
 pal
@@ -130133,8 +130363,8 @@ tDa
 jRH
 jRH
 tnO
-gmM
-iVP
+ajW
+cOc
 tnO
 qOG
 qOG
@@ -130650,14 +130880,14 @@ tnO
 cOc
 buS
 lax
-uZO
+uli
 pbq
-nSu
+oli
 chI
-mMf
+lXi
 jsL
 pjt
-dSE
+rzz
 mfV
 cRn
 tnO
@@ -130674,7 +130904,7 @@ dtO
 hxC
 jVJ
 ldD
-bQS
+jPR
 avM
 pal
 xKP
@@ -130909,7 +131139,7 @@ buS
 qjz
 qoz
 nSr
-oKU
+oli
 uZo
 mfV
 mfV
@@ -130930,8 +131160,8 @@ hIT
 sCX
 hxC
 jVJ
-hfr
-kOz
+ovr
+dOS
 cQX
 xKP
 xKP
@@ -131164,7 +131394,7 @@ tnO
 rZd
 buS
 lax
-mPX
+uZO
 pbq
 oKU
 nwf
@@ -131187,8 +131417,8 @@ hIT
 sCX
 hxC
 jVJ
-hfr
-hUv
+ovr
+uTp
 pal
 xKP
 xez
@@ -131422,8 +131652,8 @@ cOc
 buS
 lax
 uZO
-nSr
-umU
+pbq
+nSu
 nlO
 qsc
 kBw
@@ -131444,8 +131674,8 @@ hIT
 sCX
 hxC
 jVJ
-hfr
-hUv
+ovr
+uTp
 pal
 xKP
 hfr
@@ -131701,8 +131931,8 @@ hIT
 sCX
 hxC
 jVJ
-hfr
-hUv
+ovr
+uTp
 pal
 xKP
 fVr
@@ -131958,8 +132188,8 @@ hIT
 sCX
 hxC
 jVJ
-hfr
-hUv
+ovr
+uTp
 pal
 xKP
 xKP
@@ -132189,11 +132419,11 @@ jRH
 jRH
 jRH
 tnO
-gOo
+cOc
 cOc
 tnO
 tnO
-sTn
+tSi
 dOr
 tnO
 eqs
@@ -132215,8 +132445,8 @@ esN
 wzD
 hxC
 jVJ
-hfr
-kOz
+ovr
+dOS
 hfW
 pal
 xKP
@@ -132472,8 +132702,8 @@ lMr
 juJ
 gAl
 jVJ
-hfr
-kOz
+ovr
+dOS
 hUv
 pal
 xKP
@@ -132703,7 +132933,7 @@ jRH
 jRH
 jRH
 tnO
-yil
+pbq
 pVq
 oli
 nbd
@@ -132729,8 +132959,8 @@ jwU
 jfz
 jVJ
 jVJ
-hfr
-kOz
+ovr
+dOS
 leO
 pal
 xKP
@@ -132962,7 +133192,7 @@ jRH
 tnO
 bKO
 pbq
-nSu
+oli
 rRk
 xnY
 iYH
@@ -132986,7 +133216,7 @@ rjk
 rYF
 jVJ
 kuM
-kOz
+tao
 eGi
 pUp
 pal
@@ -133219,7 +133449,7 @@ jRH
 tnO
 wtV
 nSr
-nSu
+oli
 kTO
 rzz
 ddC
@@ -133242,7 +133472,7 @@ kOz
 kOz
 vdV
 jVJ
-hfr
+ovr
 ebC
 vUy
 tVQ
@@ -133476,7 +133706,7 @@ jRH
 tnO
 nKn
 nSr
-nSu
+oli
 wgd
 rzz
 tup

--- a/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
@@ -2783,10 +2783,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/legion)
-"sq" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "sy" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -5011,10 +5007,6 @@
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"Kw" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "Ky" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -19826,9 +19818,9 @@ TS
 pR
 uT
 Va
-sq
+xy
 se
-Kw
+uT
 bZ
 Wi
 UL
@@ -20083,9 +20075,9 @@ wE
 wE
 Va
 uT
-Kw
+Va
 uT
-xy
+Va
 wS
 Wi
 UL
@@ -20852,11 +20844,11 @@ gi
 gi
 gi
 fz
-sq
+Va
 uT
 Va
 uT
-Kw
+xy
 bZ
 Wi
 UL
@@ -21109,11 +21101,11 @@ gi
 gi
 gi
 fz
-Kw
+Va
 Va
 Va
 uT
-xy
+uT
 bZ
 Wi
 UL
@@ -21623,7 +21615,7 @@ gi
 gi
 gi
 fz
-sq
+Va
 uT
 Va
 Va
@@ -21884,7 +21876,7 @@ xy
 Va
 uT
 Va
-Va
+xy
 wS
 Wi
 UL


### PR DESCRIPTION
## About The Pull Request
NEEDS TESTMERGE

This PR updates some minor map issues, introduces a neutral scrap yard that has to be claimed, and removes the innate salvage bonus BoS had. Also adds the roof to the Church

![image](https://github.com/f13babylon/f13babylon/assets/93557430/21646f94-94c6-4526-b60f-2c6bd1c99d5d)

![image](https://github.com/f13babylon/f13babylon/assets/93557430/cf9b27cc-d682-4956-8c81-722be7f96985)

![image](https://github.com/f13babylon/f13babylon/assets/93557430/cb9d4130-d507-4aea-9ffe-deb49b1322cf)

![image](https://github.com/f13babylon/f13babylon/assets/93557430/753e106b-19d6-44b3-b411-69cbd7c9f8b4)
Removes extra stuff NOT needed by BoS
(Drills and mesons)

![image](https://github.com/f13babylon/f13babylon/assets/93557430/4f89214a-78ca-46f1-bfc4-8fd4330de256)

![image](https://github.com/f13babylon/f13babylon/assets/93557430/9a386e83-1379-4d0c-9e17-369ebd8f63b1)
Trash Master spawn.

![image](https://github.com/f13babylon/f13babylon/assets/93557430/5d2fee80-d725-412a-b5f1-c63d98307528)
The new balcony (NERFED!!)

![image](https://github.com/f13babylon/f13babylon/assets/93557430/bd7fb037-d3f3-4947-bf05-70ab54aea9e5)   

![image](https://github.com/f13babylon/f13babylon/assets/93557430/7818e4e9-0af6-4dbd-85a1-71df38a66f06)
Railings here to give an added sense of depth, turned to fluff. Water removed
 
## Why It's Good For The Game

Nerfs BoS, adjusts innate salvage, adds a POI in a big field of nothing. Fixes some mapping errors.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.


## Changelog
:cl:
tweak: adjusts the BoS balcony area & legion slave area (advanced tools)
fix: adds a roof to the Church
add: neutral POI with a legendary ghoul
/:cl:
