### PR TITLE
Fixes Citizen Loadout Items

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -443,7 +443,7 @@
 
 /proc/get_all_jobs()
 	return list("Wastelander", "Raider", "Outsider", "Raider Captain", "Tribal", "Tribal Hunter", "Tribal Gatherer", "Tribal Shaman",
-				"Mayor", "Sheriff", "Deputy", "Banker", "Barkeep", "Shopkeeper", "Citizen", "Preacher", "Secretary",
+				"Mayor", "Sheriff", "Deputy", "Banker", "Barkeep", "Shopkeeper", "La Verkin Citizen", "Preacher", "Secretary",
 				"Baron", "Castellan","Keeper", "Knight-Commander", "Paladin Marshal", "Paladin", "Librarian", "Scribe", "Knight-Captain", "Knight", "Initiate", "BoS Off-Duty", "Inquisitorial Acolyte",
 				"Enclave Internal Security", "Enclave Lieutenant", "Enclave Platoon Sergeant", "Enclave Sergeant", "Enclave Specialist", ,"Enclave Private", "Enclave Scientist", "Enclave Pilot Officer", "Enclave Bunker Duty",
 				"Followers Administrator", "Followers Doctor", "Followers Volunteer", "Followers Guard", "Followers Robot",

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -184,7 +184,7 @@
 							"Secretary",
 							"Sheriff",
 							"Doctor",
-							"Citizen",
+							"La Verkin Citizen",
 							"Deputy",
 							"Shopkeeper",
 							"Farmer",

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -677,7 +677,7 @@
 							"Secretary",
 							"Sheriff",
 							"Doctor",
-							"Citizen",
+							"La Verkin Citizen",
 							"Deputy",
 							"Shopkeeper",
 							"Farmer",


### PR DESCRIPTION
## About The Pull Request
Citizens are now known as 'La Verkin Citizens' but this broke their access to two loadout items. Fixes it, and a proc too.

## Why It's Good For The Game
Broken bad

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed citizen loadout access.
/:cl: