### PR TITLE
Fixes Ghost Voting

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -550,7 +550,7 @@ SUBSYSTEM_DEF(vote)
 			var/choice = choices[i]
 			choice_statclicks[choice] = "[i]"
 		//
-		for(var/c in GLOB.clients)
+		for(var/c as anything in GLOB.clients)
 //			SEND_SOUND(c, sound('sound/misc/server-ready.ogg'))
 			var/client/C = c
 			var/datum/action/vote/V = new


### PR DESCRIPTION
this has been a problem for like 2 years, it only sent votes to living carbon client mobs. should now send the vote action to all clients, regardless of the mob they occupy.