### PR TITLE
Fixes Action Grant Runtime

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -65,7 +65,12 @@
 			if(bitfield & bitflag)
 				if(button == null)
 					button = new
-				button.id = bitflag
+					button.linked_action = src
+					button.name = name
+					button.actiontooltipstyle = buttontooltipstyle
+					if(desc)
+						button.desc = desc
+					button.id = bitflag
 				break
 			bitflag *= 2
 

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -63,6 +63,8 @@
 		var/bitflag = 1
 		for(var/i in 1 to (counter + 1))
 			if(bitfield & bitflag)
+				if(button == null)
+					button = new
 				button.id = bitflag
 				break
 			bitflag *= 2


### PR DESCRIPTION
Fixes a runtime where actions would not be granted the correct new value while being granted, which would cause a runtime and result in the action not being granted. Specifically prevalent in granting observers the voting action.