### PR TITLE
Fixes Digitigrade Suit Errors

### DIFF
--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -15,6 +15,7 @@
 	var/obj/item/clothing/armoraccessory/attached_accessory
 	var/mutable_appearance/accessory_overlay
 	var/dummy_thick = FALSE // is able to hold accessories on its item
+	mutantrace_variation = NONE
 
 /obj/item/clothing/suit/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
#61 didn't completely fix this as mutantrace_variation = none was applied to a commented-out reference version of /obj/item/clothing/suit rather than the actual object. Applying this properly fixes the rest of the digitigrade errors.

(_That I can find. Noone has time to spawn every single suit item but every single one I knew errored no longer does._)


## Why It's Good For The Game
digi leg work good

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

:cl:
fix: Fixed digitigrade leg errors. 
/:cl:
