### PR TITLE
Map Changes, NML Edits, E-Weapon Loot Spawners & More

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -101,6 +101,12 @@
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"adl" = (
+/mob/living/simple_animal/hostile/renegade/guardian{
+	extra_projectiles = 2
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "aey" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/high,
@@ -3757,7 +3763,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200
+	health = 200;
+	maxHealth = 200
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -5664,7 +5671,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200
+	health = 200;
+	maxHealth = 200
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -6291,6 +6299,16 @@
 "hyL" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
+"hAm" = (
+/obj/machinery/hydroponics/soil/crafted,
+/mob/living/simple_animal/hostile/renegade/drifter{
+	vision_range = 15;
+	minimum_distance = 8;
+	health = 300;
+	check_friendly_fire = 0
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hAx" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/barber{
@@ -6338,11 +6356,8 @@
 	},
 /area/f13/ahs)
 "hBD" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/machinery/door/airlock/medical{
-	name = "Clinic";
-	req_one_access_txt = "25"
-	},
+/obj/item/shard,
+/obj/item/stack/sheet/metal/five,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -6378,6 +6393,12 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"hEL" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "hFd" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -6743,7 +6764,9 @@
 /area/f13/city)
 "iaG" = (
 /obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/renegade/doc,
+/mob/living/simple_animal/hostile/renegade/doc{
+	extra_projectiles = 2
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "iba" = (
@@ -8054,7 +8077,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200
+	health = 200;
+	maxHealth = 200
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -8493,7 +8517,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "kdT" = (
-/mob/living/simple_animal/hostile/renegade/doc,
+/mob/living/simple_animal/hostile/renegade/doc{
+	extra_projectiles = 2
+	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -10066,7 +10092,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "lQs" = (
-/mob/living/simple_animal/hostile/renegade/doc,
+/mob/living/simple_animal/hostile/renegade/doc{
+	extra_projectiles = 2
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "lQY" = (
@@ -17008,7 +17036,9 @@
 	name = "The Boss";
 	obj_damage = 500;
 	retreat_distance = 0;
-	melee_damage_upper = 40
+	melee_damage_upper = 40;
+	maxHealth = 1000;
+	health = 1000
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -17816,6 +17846,13 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"uJD" = (
+/obj/structure/table_frame,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "uJZ" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -19840,7 +19877,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200
+	health = 200;
+	maxHealth = 200
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -28112,7 +28150,7 @@ aTA
 tGX
 tGX
 wUU
-wUU
+hAm
 wUU
 wUU
 wUU
@@ -31971,7 +32009,7 @@ hou
 rOp
 sfc
 uBL
-sfc
+wYa
 mQN
 kiI
 sfc
@@ -32228,7 +32266,7 @@ uLm
 uLm
 uLm
 uLm
-wYa
+sfc
 wEe
 kiI
 wYa
@@ -37901,7 +37939,7 @@ pYx
 pYx
 dFB
 pYx
-pYx
+gYY
 mVL
 dFB
 tGX
@@ -38158,7 +38196,7 @@ pYx
 pYx
 jBt
 pYx
-pYx
+hEL
 pYx
 pYx
 tGX
@@ -38417,7 +38455,7 @@ cfX
 pYx
 puk
 hBD
-puk
+uJD
 tGX
 tGX
 aTA
@@ -38906,7 +38944,7 @@ aTA
 tGX
 tGX
 bVH
-bVH
+adl
 xpR
 bVH
 bVH

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -17030,7 +17030,7 @@
 	faction = list("raider","wastebot","hostile","supermutant","ghoul");
 	aggro_vision_range = 15;
 	vision_range = 15;
-	minimum_distance = 1;
+	minimum_distance = 8;
 	extra_projectiles = 4;
 	rapid_melee = 2;
 	name = "The Boss";
@@ -17038,7 +17038,8 @@
 	retreat_distance = 0;
 	melee_damage_upper = 40;
 	maxHealth = 1000;
-	health = 1000
+	health = 1000;
+	environment_smash = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -27657,7 +27658,7 @@ sfc
 sfc
 sfc
 ciA
-tGX
+lOD
 sfc
 sjT
 fgd
@@ -28171,7 +28172,7 @@ sfc
 cFz
 sfc
 sfc
-tGX
+lOD
 wba
 sfc
 oPn
@@ -28428,7 +28429,7 @@ sfc
 pIZ
 nsN
 bke
-tGX
+lOD
 wba
 sfc
 bke
@@ -28685,7 +28686,7 @@ sfc
 tVF
 sfc
 ciA
-tGX
+lOD
 wba
 wYa
 sfc
@@ -28942,7 +28943,7 @@ sfc
 pIZ
 sfc
 sfc
-tGX
+lOD
 hTg
 vMb
 vMb
@@ -29199,11 +29200,11 @@ lOD
 uLm
 mxj
 mxj
-tGX
-tGX
-tGX
-tGX
-tGX
+lOD
+lOD
+lOD
+lOD
+lOD
 tGX
 tGX
 aTA
@@ -34335,7 +34336,7 @@ akh
 daU
 lfv
 leL
-puk
+lOD
 tij
 tFv
 pIZ
@@ -34592,7 +34593,7 @@ akh
 nph
 bVH
 bVH
-puk
+lOD
 sfc
 sfc
 oEm
@@ -34849,7 +34850,7 @@ akh
 nph
 bVH
 bVH
-puk
+lOD
 tJs
 wYa
 pIZ
@@ -35106,7 +35107,7 @@ akh
 nph
 kCV
 bVH
-puk
+lOD
 tJs
 sfc
 oEm
@@ -35363,7 +35364,7 @@ akh
 nph
 bVH
 bVH
-puk
+lOD
 kZb
 sfc
 sfc
@@ -35620,7 +35621,7 @@ akh
 nph
 bVH
 bVH
-puk
+lOD
 tJs
 sfc
 sfc
@@ -35875,17 +35876,17 @@ akh
 akh
 akh
 hiB
-puk
-puk
-puk
-puk
-puk
-puk
-puk
-puk
-puk
-puk
-puk
+lOD
+lOD
+lOD
+lOD
+lOD
+lOD
+lOD
+lOD
+lOD
+lOD
+lOD
 tGX
 tGX
 aTA
@@ -36132,15 +36133,15 @@ akh
 akh
 rDA
 pSm
-puk
+lOD
 eII
 kIC
 kIC
 eII
-puk
+lOD
 xWB
 pYx
-puk
+lOD
 hag
 lpb
 tGX
@@ -36394,10 +36395,10 @@ pYx
 pYx
 pYx
 pYx
-puk
+lOD
 hjM
 ejd
-puk
+lOD
 uiH
 aOl
 tGX
@@ -36646,15 +36647,15 @@ akh
 akh
 akh
 daU
-puk
+lOD
 fRH
 rdM
 fRH
 pYx
-puk
+lOD
 bGB
 pYx
-puk
+lOD
 kdT
 tDv
 tGX
@@ -36908,10 +36909,10 @@ pYx
 kzS
 pYx
 pYx
-puk
+lOD
 cqI
 kdT
-puk
+lOD
 pYx
 jrR
 tGX
@@ -37165,10 +37166,10 @@ pYx
 pYx
 jBt
 pYx
-puk
+lOD
 aOl
 ejd
-puk
+lOD
 uiH
 rvz
 tGX
@@ -37422,10 +37423,10 @@ uUV
 pYx
 pYx
 uUV
-puk
+lOD
 lpb
 pYx
-puk
+lOD
 pYx
 cUl
 tGX
@@ -37674,15 +37675,15 @@ khx
 akh
 akh
 hiB
-puk
-puk
-puk
+lOD
+lOD
+lOD
 jhJ
-puk
-puk
-puk
+lOD
+lOD
+lOD
 gPL
-puk
+lOD
 gYY
 puk
 tGX
@@ -37931,7 +37932,7 @@ akh
 akh
 akh
 nph
-puk
+lOD
 pYx
 dFB
 pYx
@@ -38188,7 +38189,7 @@ akh
 akh
 khx
 nph
-puk
+lOD
 pYx
 pYx
 pYx
@@ -38445,7 +38446,7 @@ akh
 akh
 akh
 nph
-puk
+lOD
 pYx
 gHp
 cfX
@@ -38453,7 +38454,7 @@ pYx
 fRH
 cfX
 pYx
-puk
+lOD
 hBD
 uJD
 tGX
@@ -38702,7 +38703,7 @@ rDA
 gLT
 vCf
 nph
-puk
+lOD
 kdT
 cfX
 rdM
@@ -38710,7 +38711,7 @@ pYx
 uGl
 gHp
 kdT
-puk
+lOD
 uiH
 eAR
 tGX
@@ -38959,7 +38960,7 @@ rDA
 rDA
 rDA
 nph
-puk
+lOD
 pYx
 pYx
 pYx
@@ -38967,7 +38968,7 @@ teJ
 pYx
 pYx
 pYx
-puk
+jcA
 vuu
 nZo
 tGX
@@ -39216,7 +39217,7 @@ akh
 akh
 akh
 nph
-puk
+lOD
 pYx
 fRH
 cfX
@@ -39224,7 +39225,7 @@ pYx
 rdM
 cfX
 pYx
-puk
+lOD
 tTD
 hKP
 tGX
@@ -39473,7 +39474,7 @@ akh
 akh
 akh
 nph
-puk
+lOD
 pYx
 cfX
 rdM
@@ -39481,7 +39482,7 @@ mVL
 cfX
 rdM
 pYx
-puk
+jcA
 pYx
 uul
 tGX
@@ -39730,7 +39731,7 @@ khx
 iEs
 akh
 hiB
-puk
+lOD
 pYx
 uUV
 pYx
@@ -39738,7 +39739,7 @@ pYx
 pYx
 uUV
 pYx
-puk
+lOD
 uiH
 xwd
 tGX

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -12415,10 +12415,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "oBR" = (
-/obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
+/obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "oCt" = (
@@ -16072,12 +16072,6 @@
 	name = "metal plating"
 	},
 /area/f13/bunker)
-"sMe" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "sNQ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -17004,11 +16998,18 @@
 	},
 /area/f13/bunker)
 "tTD" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/mob/living/simple_animal/hostile/raider/junker/boss{
+	faction = list("raider","wastebot","hostile","supermutant","ghoul");
+	aggro_vision_range = 15;
+	vision_range = 15;
+	minimum_distance = 1;
+	extra_projectiles = 4;
+	rapid_melee = 2;
+	name = "The Boss";
+	obj_damage = 500;
+	retreat_distance = 0;
+	melee_damage_upper = 40
 	},
-/obj/structure/barricade/wooden,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -18533,15 +18534,6 @@
 /area/f13/vault)
 "vuu" = (
 /obj/structure/chair/office/dark,
-/mob/living/simple_animal/hostile/deathclaw/power_armor{
-	faction = list("raider","hostile","supermutant","deathclaw");
-	rapid_melee = 2;
-	melee_damage_lower = 20;
-	melee_damage_upper = 30;
-	obj_damage = 500;
-	name = "Kebab Kehmist";
-	desc = "A massive, reptilian creature with powerful muscles, razor-sharp claws, and aggression to match. Someone had managed to put power armor on him, alongside unusual gauntlets that seem to speed up his hands further"
-	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -37911,7 +37903,7 @@ dFB
 pYx
 pYx
 mVL
-tTD
+dFB
 tGX
 tGX
 aTA
@@ -38167,8 +38159,8 @@ pYx
 jBt
 pYx
 pYx
-sMe
-sMe
+pYx
+pYx
 tGX
 tGX
 aTA
@@ -39195,7 +39187,7 @@ rdM
 cfX
 pYx
 puk
-pYx
+tTD
 hKP
 tGX
 tGX

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -17030,7 +17030,7 @@
 	faction = list("raider","wastebot","hostile","supermutant","ghoul");
 	aggro_vision_range = 15;
 	vision_range = 15;
-	minimum_distance = 8;
+	minimum_distance = 0;
 	extra_projectiles = 4;
 	rapid_melee = 2;
 	name = "The Boss";

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -197,7 +197,7 @@
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "120"
 	},
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "aiH" = (
 /obj/structure/chair{
@@ -2422,6 +2422,15 @@
 "cZa" = (
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"cZe" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/structure/nest/ghoul{
+	max_mobs = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/city)
 "cZR" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -3317,6 +3326,9 @@
 /obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/vault)
+"dXi" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/underground/cave)
 "dXl" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/fullgrass{
@@ -3764,7 +3776,8 @@
 	melee_damage_upper = 20;
 	rapid_melee = 2;
 	health = 200;
-	maxHealth = 200
+	maxHealth = 200;
+	armour_penetration = 0.3
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -3826,6 +3839,18 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"eAw" = (
+/mob/living/simple_animal/hostile/renegade/meister{
+	retreat_distance = 1;
+	check_friendly_fire = 0;
+	aggro_vision_range = 14;
+	armour_penetration = 0.5;
+	extra_projectiles = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "eAI" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/f13{
@@ -4756,10 +4781,7 @@
 	},
 /area/f13/caves)
 "fHk" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/structure/nest/supermutant,
 /turf/open/floor/f13,
 /area/f13/city)
 "fHH" = (
@@ -4868,6 +4890,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"fOO" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/f13,
+/area/f13/city)
 "fPw" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/bunker)
@@ -5450,9 +5480,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "gCg" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/underground/cave)
 "gCl" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -5672,7 +5703,8 @@
 	melee_damage_upper = 20;
 	rapid_melee = 2;
 	health = 200;
-	maxHealth = 200
+	maxHealth = 200;
+	armour_penetration = 0.3
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -6299,6 +6331,10 @@
 "hyL" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
+"hzc" = (
+/obj/item/renegade_flag,
+/turf/closed/wall/mineral/wood,
+/area/f13/city)
 "hAm" = (
 /obj/machinery/hydroponics/soil/crafted,
 /mob/living/simple_animal/hostile/renegade/drifter{
@@ -7682,6 +7718,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"jcW" = (
+/obj/item/renegade_flag,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/city)
 "jda" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -8078,7 +8118,8 @@
 	melee_damage_upper = 20;
 	rapid_melee = 2;
 	health = 200;
-	maxHealth = 200
+	maxHealth = 200;
+	armour_penetration = 0.3
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -8092,6 +8133,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"jBC" = (
+/obj/machinery/porta_turret/syndicate{
+	faction = list("raider","hostile","ghoul","supermutant")
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/city)
 "jBP" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
@@ -8939,6 +8986,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"kCw" = (
+/obj/structure/nest/supermutant/ranged,
+/turf/open/floor/f13,
+/area/f13/city)
 "kCE" = (
 /obj/machinery/light{
 	dir = 8;
@@ -11136,7 +11187,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "nfN" = (
-/obj/machinery/porta_turret/syndicate,
+/obj/machinery/porta_turret/syndicate{
+	faction = list("raider","hostile","ghoul","supermutant")
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ngb" = (
@@ -11227,7 +11280,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "nlL" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
+/mob/living/simple_animal/hostile/ghoul/legendary{
+	obj_damage = 500
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "nlM" = (
@@ -12727,9 +12782,11 @@
 /area/f13/caves)
 "oPn" = (
 /mob/living/simple_animal/hostile/renegade/meister{
-	retreat_distance = 0;
+	retreat_distance = 1;
 	check_friendly_fire = 0;
-	aggro_vision_range = 14
+	aggro_vision_range = 14;
+	armour_penetration = 0.5;
+	extra_projectiles = 6
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -13616,6 +13673,18 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"pMm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/porta_turret/syndicate{
+	faction = list("raider","hostile","ghoul","supermutant")
+	},
+/turf/open/floor/f13{
+	dir = 1;
+	icon_state = "yellowsiding"
+	},
+/area/f13/city)
 "pMy" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -14230,7 +14299,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "qtm" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
+/mob/living/simple_animal/hostile/ghoul/legendary{
+	obj_damage = 500
+	},
 /turf/open/floor/f13,
 /area/f13/wasteland)
 "qtK" = (
@@ -14437,7 +14508,9 @@
 /area/f13/vault)
 "qHp" = (
 /obj/structure/chair/f13foldupchair,
-/mob/living/simple_animal/hostile/renegade/defender,
+/mob/living/simple_animal/hostile/renegade/defender{
+	armour_penetration = 0.4
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "qHs" = (
@@ -15202,7 +15275,9 @@
 	},
 /area/f13/ncr)
 "rFo" = (
-/mob/living/simple_animal/hostile/renegade/defender,
+/mob/living/simple_animal/hostile/renegade/defender{
+	armour_penetration = 0.4
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "rGK" = (
@@ -15540,9 +15615,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "sdU" = (
-/obj/structure/car/rubbish4,
+/obj/structure/window/fulltile/ruins,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/city)
 "sdW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -15595,6 +15670,16 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"sgd" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/obj/structure/nest/ghoul{
+	max_mobs = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/city)
 "sgg" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/f13/wood,
@@ -16189,6 +16274,10 @@
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"sTw" = (
+/obj/item/renegade_flag,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "sUw" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -16376,15 +16465,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
 "teJ" = (
-/mob/living/simple_animal/hostile/renegade/meister{
-	retreat_distance = 0;
-	check_friendly_fire = 0;
-	aggro_vision_range = 14
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
+/area/f13/underground/cave)
 "tfn" = (
 /obj/effect/turf_decal/caution,
 /turf/open/floor/f13/wood,
@@ -16802,7 +16886,9 @@
 /area/f13/vault)
 "tFv" = (
 /obj/structure/chair/office/dark,
-/mob/living/simple_animal/hostile/renegade/defender,
+/mob/living/simple_animal/hostile/renegade/defender{
+	armour_penetration = 0.4
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "tGF" = (
@@ -17039,7 +17125,8 @@
 	melee_damage_upper = 40;
 	maxHealth = 1000;
 	health = 1000;
-	environment_smash = 4
+	environment_smash = 4;
+	armour_penetration = 0.4
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -17167,7 +17254,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "uba" = (
-/mob/living/simple_animal/hostile/supermutant/legendary,
+/mob/living/simple_animal/hostile/supermutant/legendary{
+	obj_damage = 500
+	},
 /turf/open/floor/f13,
 /area/f13/city)
 "ubM" = (
@@ -17776,7 +17865,9 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /obj/effect/spawner/lootdrop/trash,
-/mob/living/simple_animal/hostile/renegade/defender,
+/mob/living/simple_animal/hostile/renegade/defender{
+	armour_penetration = 0.4
+	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -17810,6 +17901,10 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker)
+"uHG" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/city)
 "uHR" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
@@ -18562,10 +18657,11 @@
 	},
 /area/f13/vault)
 "vto" = (
-/obj/structure/debris/v4,
-/obj/effect/decal/cleanable/oil,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/underground/cave)
 "vty" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -19879,7 +19975,8 @@
 	melee_damage_upper = 20;
 	rapid_melee = 2;
 	health = 200;
-	maxHealth = 200
+	maxHealth = 200;
+	armour_penetration = 0.3
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -19925,6 +20022,9 @@
 	},
 /area/f13/bunker)
 "xaJ" = (
+/obj/machinery/porta_turret/syndicate{
+	faction = list("raider","hostile","ghoul","supermutant")
+	},
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "yellowsiding"
@@ -20408,6 +20508,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"xKA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/underground/cave)
 "xLo" = (
 /obj/machinery/door/airlock{
 	name = "Vault 223 storage"
@@ -23548,12 +23656,12 @@ bVH
 bVH
 bVH
 bVH
-vrM
 bVH
 bVH
 bVH
 bVH
-vrM
+bVH
+bVH
 xpR
 bVH
 bVH
@@ -24817,7 +24925,7 @@ bVH
 bVH
 bVH
 bVH
-bRc
+bVH
 bVH
 bVH
 bVH
@@ -25339,7 +25447,7 @@ akh
 akh
 akh
 akh
-gCg
+akh
 akh
 akh
 akh
@@ -26118,7 +26226,7 @@ bVH
 bVH
 bVH
 bVH
-uUX
+bVH
 bVH
 bVH
 bVH
@@ -26355,7 +26463,7 @@ wgF
 wgF
 bVH
 bVH
-bRc
+bVH
 bVH
 bVH
 bVH
@@ -26598,7 +26706,7 @@ bVH
 bVH
 bVH
 uhr
-bVH
+xpR
 xpR
 bVH
 aTA
@@ -26854,8 +26962,8 @@ bVH
 uhr
 bVH
 bVH
-bVH
-bVH
+xpR
+nfN
 xpR
 bVH
 aTA
@@ -27112,9 +27220,9 @@ xpR
 xpR
 xpR
 xpR
-bVH
 xpR
 bVH
+bVH
 aTA
 aTA
 aTA
@@ -27132,13 +27240,13 @@ tGX
 tGX
 tGX
 tGX
-tGX
+jcW
 rgF
 rgF
 rgF
 rgF
 tGX
-tGX
+jcW
 tGX
 tGX
 tGX
@@ -28200,8 +28308,8 @@ jdd
 jdd
 jdd
 jdd
-oQR
-oQR
+jdd
+jdd
 jdd
 jdd
 jdd
@@ -28452,7 +28560,7 @@ sQz
 jdd
 kFM
 sQz
-oQR
+jdd
 sQz
 sQz
 uba
@@ -28709,7 +28817,7 @@ sQz
 jdd
 kFM
 sQz
-oQR
+jdd
 sQz
 sQz
 sQz
@@ -29227,7 +29335,7 @@ jdd
 sQz
 vzd
 oFc
-sQz
+kCw
 sQz
 vzd
 sQz
@@ -29236,7 +29344,7 @@ drj
 sQz
 sQz
 sQz
-sQz
+fHk
 jVk
 sQz
 aJE
@@ -29446,13 +29554,13 @@ uLm
 uLm
 uLm
 uLm
-uLm
+hzc
 bed
 akh
 akh
 nph
 lkS
-bVH
+sTw
 lOD
 sfc
 sfc
@@ -30005,7 +30113,7 @@ xBo
 jdd
 dMF
 sQz
-uba
+sQz
 sQz
 sQz
 sQz
@@ -30252,10 +30360,10 @@ jdd
 kFM
 wqw
 jdd
+fOO
 sQz
 sQz
 sQz
-fHk
 sQz
 sQz
 sQz
@@ -30513,7 +30621,7 @@ jdd
 jdd
 jdd
 jdd
-jdd
+oQR
 jdd
 jdd
 jdd
@@ -30774,9 +30882,9 @@ sQz
 bKu
 jdd
 bKu
-uba
-jdd
 sQz
+jdd
+kCw
 sQz
 sQz
 sQz
@@ -31023,7 +31131,7 @@ jdd
 kFM
 wqw
 jdd
-uba
+sQz
 sQz
 sQz
 jdd
@@ -31031,7 +31139,7 @@ sQz
 ygP
 jdd
 fmO
-sQz
+uba
 oQR
 sQz
 sQz
@@ -32056,7 +32164,7 @@ sQz
 sQz
 nAt
 sQz
-sQz
+fHk
 jdd
 jdd
 jdd
@@ -32784,7 +32892,7 @@ mxj
 sfc
 uLm
 sfc
-wYa
+sfc
 qlG
 ati
 uLm
@@ -32799,7 +32907,7 @@ uLm
 sfc
 tJs
 sVs
-sfc
+wYa
 oOq
 sfc
 uLm
@@ -33041,7 +33149,7 @@ uLm
 uLm
 uLm
 sfc
-sfc
+wYa
 scE
 acf
 uLm
@@ -33056,7 +33164,7 @@ uLm
 hYX
 tJs
 tJs
-wYa
+sfc
 sfc
 sfc
 uLm
@@ -33847,7 +33955,7 @@ gXX
 sQz
 sQz
 jdd
-cIa
+pMm
 sQz
 bGK
 bGK
@@ -34560,7 +34668,7 @@ tvn
 gbD
 pEV
 lcW
-lcW
+jBC
 gbD
 vnO
 bVH
@@ -35614,13 +35722,13 @@ uLm
 uLm
 uLm
 uLm
-uLm
+hzc
 glJ
 rDA
 akh
 nph
 bVH
-bVH
+sTw
 lOD
 tJs
 sfc
@@ -36083,7 +36191,7 @@ uRL
 akh
 akh
 xrg
-xrg
+sdU
 xrg
 lcW
 lcW
@@ -36092,7 +36200,7 @@ pEV
 lcW
 lcW
 lcW
-nlL
+lcW
 lcW
 lcW
 lcW
@@ -36100,7 +36208,7 @@ pEV
 lcW
 xrg
 xrg
-xrg
+sdU
 xrg
 akh
 akh
@@ -37368,7 +37476,7 @@ uRL
 akh
 nGZ
 xrg
-iax
+sgd
 lcW
 lcW
 lcW
@@ -37634,7 +37742,7 @@ lcW
 mAT
 tWx
 svk
-lcW
+uHG
 tWx
 nxB
 lcW
@@ -37642,7 +37750,7 @@ lcW
 lcW
 lcW
 lcW
-hqv
+cZe
 xrg
 akh
 akh
@@ -38700,7 +38808,7 @@ bVH
 uRL
 khx
 rDA
-gLT
+akh
 vCf
 nph
 lOD
@@ -38910,24 +39018,24 @@ uRL
 akh
 akh
 xrg
+sdU
+xrg
+lcW
+lcW
+lcW
+lcW
+lcW
+lcW
+lcW
+lcW
+lcW
+lcW
+lcW
+lcW
+lcW
 xrg
 xrg
-lcW
-lcW
-lcW
-lcW
-lcW
-lcW
-lcW
-lcW
-lcW
-lcW
-lcW
-lcW
-lcW
-xrg
-xrg
-xrg
+sdU
 xrg
 akh
 akh
@@ -38963,8 +39071,8 @@ nph
 lOD
 pYx
 pYx
+eAw
 pYx
-teJ
 pYx
 pYx
 pYx
@@ -39176,7 +39284,7 @@ gbD
 lcW
 lcW
 lcW
-nlL
+lcW
 lcW
 lcW
 gbD
@@ -40239,13 +40347,13 @@ tGX
 tGX
 tGX
 tGX
-tGX
+jcW
 rgF
 rgF
 rgF
 rgF
 tGX
-tGX
+jcW
 tGX
 tGX
 tGX
@@ -40450,7 +40558,7 @@ bVH
 bVH
 qjs
 gbD
-lcW
+jBC
 lcW
 lcW
 gbD
@@ -40471,7 +40579,7 @@ tvn
 gbD
 lcW
 lcW
-pEV
+lcW
 gbD
 vnO
 bVH
@@ -41019,7 +41127,7 @@ nph
 bVH
 bVH
 bVH
-vrM
+bVH
 bVH
 bVH
 bVH
@@ -41522,7 +41630,7 @@ bVH
 bVH
 bVH
 bVH
-vrM
+bVH
 bVH
 uRL
 akh
@@ -42578,7 +42686,7 @@ wgF
 aTA
 bVH
 bVH
-xpR
+bVH
 xpR
 xpR
 xpR
@@ -42836,8 +42944,8 @@ aTA
 bVH
 bVH
 xpR
-uhr
-bVH
+nfN
+xpR
 bVH
 cQP
 bVH
@@ -43068,7 +43176,7 @@ bVH
 bVH
 uRL
 akh
-sdU
+akh
 akh
 akh
 nph
@@ -43093,7 +43201,7 @@ aTA
 bVH
 bVH
 xpR
-uhr
+xpR
 uhr
 bVH
 bVH
@@ -43350,8 +43458,8 @@ aTA
 bVH
 bVH
 vrM
-bVH
-bVH
+uhr
+uhr
 bVH
 bVH
 bVH
@@ -43829,9 +43937,9 @@ aTA
 aTA
 bVH
 bVH
-vrM
 bVH
-uUX
+bVH
+bVH
 bVH
 bVH
 tYp
@@ -44085,9 +44193,9 @@ bVH
 bVH
 bVH
 bVH
-uUX
 bVH
-vto
+bVH
+bVH
 bVH
 bVH
 cQP
@@ -45638,7 +45746,7 @@ bVH
 bVH
 bVH
 xpR
-bVH
+nfN
 bVH
 bVH
 bVH
@@ -45913,9 +46021,9 @@ aTA
 aTA
 aTA
 ldZ
-wgF
-wgF
-wgF
+iCX
+dXi
+xKA
 ldZ
 bVH
 bVH
@@ -46170,9 +46278,9 @@ aTA
 aTA
 aTA
 ldZ
-wgF
-wgF
-wgF
+dXi
+gCg
+gCg
 ldZ
 shC
 bVH
@@ -46409,7 +46517,7 @@ bVH
 bVH
 bVH
 xpR
-nfN
+bVH
 bVH
 bVH
 bVH
@@ -46427,9 +46535,9 @@ aTA
 aTA
 aTA
 ldZ
-wgF
-wgF
-wgF
+dXi
+teJ
+dXi
 ldZ
 shC
 shC
@@ -46684,9 +46792,9 @@ aTA
 aTA
 aTA
 ldZ
-wgF
-wgF
-wgF
+dXi
+teJ
+dXi
 ldZ
 shC
 shC
@@ -46941,9 +47049,9 @@ aTA
 aTA
 aTA
 ldZ
-wgF
-wgF
-wgF
+teJ
+dXi
+gCg
 huB
 wgF
 wgF
@@ -47198,9 +47306,9 @@ aTA
 aTA
 aTA
 ldZ
-wgF
-wgF
-wgF
+vto
+iCX
+iCX
 huB
 wgF
 wgF
@@ -47455,10 +47563,10 @@ aTA
 aTA
 aTA
 ldZ
-shC
+dTc
 tai
 tai
-shC
+dTc
 shC
 shC
 shC

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -53,7 +53,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "aba" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -118,7 +118,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "afe" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -134,6 +134,15 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/ahs)
+"afj" = (
+/obj/machinery/door/airlock/hatch{
+	req_access = null;
+	req_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/underground/cave)
 "afJ" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/floor/plasteel/barber{
@@ -554,7 +563,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain0"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "aGW" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/structure/closet,
@@ -585,6 +594,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13,
 /area/f13/city)
+"aKa" = (
+/obj/effect/decal/remains/human,
+/obj/item/pickaxe,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aKh" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -612,13 +626,13 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "aLT" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "aMa" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -655,7 +669,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "aOS" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13{
@@ -696,7 +710,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "aRv" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/barber{
@@ -842,13 +856,13 @@
 "bcC" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/f13/tentwall,
-/area/f13/underground/cave)
+/area/f13/caves)
 "bcE" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "bcQ" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13{
@@ -865,7 +879,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "bed" = (
 /obj/machinery/light{
 	dir = 1;
@@ -955,7 +969,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "bjR" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -963,7 +977,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault)
 "bke" = (
-/mob/living/simple_animal/hostile/renegade/grunt,
+/mob/living/simple_animal/hostile/renegade/grunt{
+	extra_projectiles = 4
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bks" = (
@@ -1103,7 +1119,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "brV" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -1154,7 +1170,7 @@
 	icon_state = "skin"
 	},
 /turf/closed/wall/f13/tentwall,
-/area/f13/underground/cave)
+/area/f13/caves)
 "bwj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1329,6 +1345,10 @@
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"bJq" = (
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bJL" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigpack_bigboss,
@@ -1432,7 +1452,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "bQv" = (
 /mob/living/simple_animal/hostile/handy/protectron{
 	health = 260;
@@ -1684,6 +1704,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"cex" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "ceB" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/r_wall/f13/vault,
@@ -1696,7 +1720,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "cfW" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -1781,7 +1805,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "ckb" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -1871,7 +1895,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "csq" = (
 /obj/structure/table/wood,
 /obj/machinery/light/broken{
@@ -1886,7 +1910,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "ctW" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small{
@@ -1899,7 +1923,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "cvV" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/light/small{
@@ -1942,6 +1966,13 @@
 /obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
+"cyB" = (
+/obj/machinery/cell_charger,
+/obj/structure/table/wood,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "cyQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/engineering,
@@ -2024,7 +2055,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "cEb" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/vaultdoor,
@@ -2174,13 +2205,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "cOf" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "cOs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -2255,6 +2286,14 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
+"cRE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/underground/cave)
 "cTL" = (
 /obj/structure/railing{
 	dir = 10
@@ -2373,7 +2412,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "cZa" = (
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -2430,7 +2469,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "dcP" = (
 /obj/item/storage/bag/books,
 /obj/structure/table/wood,
@@ -2441,7 +2480,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "ddW" = (
 /obj/item/stack/sheet/glass/fifty{
 	pixel_x = 3;
@@ -2599,7 +2638,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "djt" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/underground/cave)
@@ -2900,7 +2939,7 @@
 /area/f13/ahs)
 "dDC" = (
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "dDG" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -3022,7 +3061,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "dHM" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt,
@@ -3653,7 +3692,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "erh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -3711,6 +3750,17 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"euB" = (
+/obj/structure/chair/bench,
+/mob/living/simple_animal/hostile/renegade{
+	loot = list();
+	melee_damage_lower = 10;
+	melee_damage_upper = 20;
+	rapid_melee = 2;
+	health = 200
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "exi" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/barber{
@@ -3719,7 +3769,9 @@
 /area/f13/bunker)
 "exu" = (
 /obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/renegade/grunt,
+/mob/living/simple_animal/hostile/renegade/grunt{
+	extra_projectiles = 4
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "exE" = (
@@ -3766,7 +3818,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "eAI" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/f13{
@@ -3802,7 +3854,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "eBN" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt{
@@ -4005,7 +4057,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderlefttop"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "ePN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -4072,7 +4124,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "eUV" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -4099,7 +4151,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "eWx" = (
 /obj/structure/fence{
 	dir = 4
@@ -4108,7 +4160,7 @@
 	dir = 4;
 	icon_state = "outermaincornerinner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "eWA" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
@@ -4223,7 +4275,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "fdD" = (
 /obj/structure/table,
 /obj/effect/spawner/bundle/f13/m1911,
@@ -4337,7 +4389,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "fmf" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/tunnel{
@@ -4372,7 +4424,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "fow" = (
 /obj/structure/chair{
 	dir = 8
@@ -4396,7 +4448,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "frb" = (
 /obj/structure/railing{
 	dir = 1
@@ -4423,7 +4475,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "fsx" = (
 /obj/machinery/door/airlock/security{
 	name = "Gatehouse";
@@ -4491,11 +4543,9 @@
 	},
 /area/f13/bunker)
 "fxg" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "fxA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -4690,14 +4740,14 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "fHf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "fHk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -4803,7 +4853,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "fOu" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -4912,7 +4962,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "fVP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/f13,
@@ -4975,7 +5025,7 @@
 	color = "000000"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "fYh" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/vault,
@@ -5101,7 +5151,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "gdh" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/r_wall/f13vault{
@@ -5122,7 +5172,7 @@
 /obj/item/storage/fancy/cigarettes/cigars,
 /obj/item/lighter/greyscale,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "geZ" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5148,7 +5198,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "gfp" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
@@ -5207,7 +5257,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "gjT" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -5354,12 +5404,16 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "gyM" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
 /area/f13/vault)
+"gzu" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gAp" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -5460,13 +5514,18 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "gGr" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"gGG" = (
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gHb" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/dirt{
@@ -5594,13 +5653,19 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerinner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "gLR" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "gLT" = (
-/mob/living/simple_animal/hostile/renegade,
+/mob/living/simple_animal/hostile/renegade{
+	loot = list();
+	melee_damage_lower = 10;
+	melee_damage_upper = 20;
+	rapid_melee = 2;
+	health = 200
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gMj" = (
@@ -5627,7 +5692,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "gPg" = (
 /obj/structure/table/wood/bar,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -5709,7 +5774,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottomright"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "gWc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -6002,6 +6067,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/vault)
+"hnG" = (
+/obj/structure/debris/v1,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"hnW" = (
+/obj/structure/fence/cut/large{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hoe" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plating/tunnel,
@@ -6228,7 +6303,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "hAF" = (
 /obj/machinery/light/small{
 	light_color = "#ad1b1b"
@@ -6465,7 +6540,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
 "hQi" = (
-/mob/living/simple_animal/hostile/renegade/grunt,
+/mob/living/simple_animal/hostile/renegade/grunt{
+	extra_projectiles = 4
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hQs" = (
@@ -6499,6 +6576,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"hRQ" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "raidermb"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hSa" = (
 /obj/structure/rack,
 /obj/machinery/camera/autoname{
@@ -6673,7 +6757,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "ibQ" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight{
@@ -6895,7 +6979,7 @@
 	dir = 4;
 	icon_state = "outermaincornerouter"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "iqQ" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -6940,6 +7024,13 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"isq" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "isz" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "NCR No Mans Land Entrance";
@@ -7041,6 +7132,14 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
+"ixz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/underground/cave)
 "ixM" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13{
@@ -7092,10 +7191,10 @@
 	},
 /area/f13/bunker)
 "iCX" = (
-/obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/renegade,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/underground/cave)
 "iDb" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plasteel/barber{
@@ -7113,7 +7212,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "iDW" = (
 /obj/machinery/mineral/ore_redemption,
 /turf/open/floor/f13{
@@ -7240,7 +7339,7 @@
 	dir = 1;
 	icon_state = "outermaincornerinner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "iKT" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -7254,7 +7353,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "iLg" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/desert,
@@ -7472,13 +7571,13 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "jaa" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
 	},
 /turf/closed/wall/f13/tentwall,
-/area/f13/underground/cave)
+/area/f13/caves)
 "jai" = (
 /obj/structure/chair{
 	dir = 4
@@ -7595,7 +7694,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "jew" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/closet,
@@ -7720,7 +7819,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "jma" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
@@ -7950,11 +8049,17 @@
 	},
 /area/f13/bunker)
 "jBt" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
+/mob/living/simple_animal/hostile/renegade{
+	loot = list();
+	melee_damage_lower = 10;
+	melee_damage_upper = 20;
+	rapid_melee = 2;
+	health = 200
 	},
-/area/f13/bunker)
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "jBu" = (
 /obj/structure/closet,
 /obj/item/storage/box/gloves,
@@ -8036,7 +8141,7 @@
 	dir = 8;
 	icon_state = "horizontaltopborderbottom2left"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "jIv" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -8163,7 +8268,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "jON" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -8217,7 +8322,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "jRw" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -8322,7 +8427,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "kaG" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/desert,
@@ -8379,7 +8484,7 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "kdS" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = -10;
@@ -8498,7 +8603,7 @@
 "klN" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "kmf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8526,7 +8631,7 @@
 "kms" = (
 /obj/structure/sign/poster/prewar/poster75,
 /turf/closed/wall/f13/supermart,
-/area/f13/underground/cave)
+/area/f13/caves)
 "kmG" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8574,7 +8679,7 @@
 "kpc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "kpC" = (
 /obj/structure/closet/secure_closet/goodies{
 	anchorable = 0;
@@ -8718,14 +8823,14 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "kxw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "kxI" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/yellow,
@@ -8777,7 +8882,9 @@
 	},
 /obj/effect/spawner/lootdrop/f13/deadrodent_or_brainwashdisk,
 /obj/item/target/alien,
-/mob/living/simple_animal/hostile/renegade/grunt,
+/mob/living/simple_animal/hostile/renegade/grunt{
+	extra_projectiles = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -8942,7 +9049,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "kJL" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -9068,7 +9175,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainright"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "kPG" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9136,6 +9243,11 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"kVw" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "kVx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9176,7 +9288,7 @@
 "kWx" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "kWL" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/robot_debris,
@@ -9324,7 +9436,9 @@
 /area/f13/city)
 "ldm" = (
 /obj/machinery/hydroponics/soil/crafted,
-/mob/living/simple_animal/hostile/renegade/guardian,
+/mob/living/simple_animal/hostile/renegade/guardian{
+	extra_projectiles = 2
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ldJ" = (
@@ -9332,7 +9446,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "ldZ" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/indestructible/rock,
@@ -9435,6 +9549,18 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"llw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "ENCLAVENML"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/underground/cave)
 "llB" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/dirt,
@@ -9557,7 +9683,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "lrB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9579,7 +9705,7 @@
 	color = "000000"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "luA" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -9654,6 +9780,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
+"lzb" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lzJ" = (
 /obj/machinery/door/airlock{
 	name = "Gym"
@@ -9761,6 +9892,10 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"lFh" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lFv" = (
 /obj/structure/toilet,
 /turf/open/floor/f13/wood,
@@ -9830,7 +9965,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "lKi" = (
 /turf/closed/mineral/random/low_chance,
 /turf/closed/indestructible/rock,
@@ -9888,7 +10023,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "lNA" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -9984,7 +10119,9 @@
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
 	name = "prewar lounge chair"
 	},
-/mob/living/simple_animal/hostile/renegade/guardian,
+/mob/living/simple_animal/hostile/renegade/guardian{
+	extra_projectiles = 2
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "lTB" = (
@@ -9995,7 +10132,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "lUa" = (
 /obj/machinery/conveyor/inverted{
 	dir = 8;
@@ -10049,7 +10186,7 @@
 "lXc" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "lXp" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10107,7 +10244,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "maa" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -10136,7 +10273,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "mbB" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/barber{
@@ -10304,7 +10441,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "moJ" = (
 /obj/structure/table,
 /obj/machinery/light/fo13colored/Aqua{
@@ -10563,7 +10700,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "mCQ" = (
 /obj/structure/window/reinforced/spawner,
 /obj/item/stack/sheet/mineral/uranium{
@@ -10573,6 +10710,11 @@
 	icon_state = "plating"
 	},
 /area/f13/ahs)
+"mDr" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "mDs" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -10593,12 +10735,17 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "mFe" = (
 /obj/structure/table,
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"mFg" = (
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mGx" = (
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/bot,
@@ -10708,7 +10855,7 @@
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/item/trash/can,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "mON" = (
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -10749,7 +10896,7 @@
 "mRP" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "mRS" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/vault,
@@ -10815,7 +10962,9 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
 "mVL" = (
-/mob/living/simple_animal/hostile/renegade/soldier,
+/mob/living/simple_animal/hostile/renegade/soldier{
+	retreat_distance = null
+	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -10823,7 +10972,7 @@
 "mVU" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "mWk" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10839,7 +10988,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "mWO" = (
 /obj/machinery/sleeper,
 /obj/machinery/light{
@@ -10852,9 +11001,9 @@
 /turf/closed/wall/mineral/iron,
 /area/f13/legion)
 "mYP" = (
-/obj/structure/nest/ghoul,
+/obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/underground/cave)
+/area/f13/caves)
 "mZj" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10864,7 +11013,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "mZp" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -10895,7 +11044,7 @@
 	pixel_y = 25
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "naH" = (
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -10922,7 +11071,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "ncm" = (
 /obj/machinery/door/window/brigdoor{
 	icon_state = "rightsecure";
@@ -11084,7 +11233,7 @@
 /area/f13/ahs)
 "nmA" = (
 /turf/closed/wall/f13/tentwall,
-/area/f13/underground/cave)
+/area/f13/caves)
 "nmO" = (
 /turf/open/floor/plating/f13/inside/mountain,
 /area/f13/underground/cave)
@@ -11111,7 +11260,7 @@
 	color = "000000"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "noh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11160,7 +11309,7 @@
 "nqc" = (
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "nrb" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/barber{
@@ -11173,7 +11322,7 @@
 /obj/item/reagent_containers/food/snacks/f13/blamco,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "nsh" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -11189,7 +11338,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "nsN" = (
 /obj/item/target/alien,
 /obj/structure/chair/office/dark{
@@ -11493,6 +11642,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"nJB" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nJJ" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/barber{
@@ -11624,7 +11778,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "nSe" = (
 /obj/structure/table,
 /obj/item/reagent_containers/blood/radaway,
@@ -11676,7 +11830,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "nUK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -11750,12 +11904,12 @@
 	icon_state = "tall_grass_6"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "nYu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "nYX" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13{
@@ -11774,7 +11928,7 @@
 /area/f13/vault)
 "oaj" = (
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/underground/cave)
+/area/f13/caves)
 "oak" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd5";
@@ -11782,6 +11936,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"oao" = (
+/obj/item/trash/sosjerky,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oaQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11912,6 +12072,12 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
+"ogZ" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "ohL" = (
 /obj/structure/table,
 /obj/item/coin/diamond,
@@ -11920,7 +12086,7 @@
 "oiq" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "okr" = (
 /obj/structure/closet/cabinet{
 	name = "Vault 223 cabinet"
@@ -12103,7 +12269,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "osx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12212,14 +12378,14 @@
 /area/f13/vault)
 "oAj" = (
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "oAx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "oBe" = (
 /obj/item/storage/firstaid/emergency,
 /obj/item/storage/firstaid/emergency,
@@ -12248,6 +12414,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
+"oBR" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oCt" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	color = "#75705a";
@@ -12273,14 +12446,14 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "oDa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "oDp" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -12321,7 +12494,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "oFO" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/tunnel{
@@ -12414,7 +12587,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "oIS" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -12472,7 +12645,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "oNj" = (
 /obj/structure/chair/middle,
 /obj/item/radio/intercom{
@@ -12525,7 +12698,11 @@
 	},
 /area/f13/caves)
 "oPn" = (
-/mob/living/simple_animal/hostile/renegade/meister,
+/mob/living/simple_animal/hostile/renegade/meister{
+	retreat_distance = 0;
+	check_friendly_fire = 0;
+	aggro_vision_range = 14
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "oPw" = (
@@ -12699,7 +12876,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "oYB" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt,
@@ -12827,7 +13004,7 @@
 	icon_state = "skin"
 	},
 /turf/closed/wall/f13/tentwall,
-/area/f13/underground/cave)
+/area/f13/caves)
 "pdJ" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/barber{
@@ -12938,7 +13115,12 @@
 	},
 /area/f13/ahs)
 "phr" = (
-/mob/living/simple_animal/hostile/renegade/drifter,
+/mob/living/simple_animal/hostile/renegade/drifter{
+	vision_range = 15;
+	minimum_distance = 8;
+	health = 300;
+	check_friendly_fire = 0
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "phD" = (
@@ -13011,7 +13193,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "plV" = (
 /obj/structure/closet/crate/secure/engineering,
 /obj/effect/spawner/lootdrop/high_tools,
@@ -13131,12 +13313,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/ahs)
 "pth" = (
-/obj/structure/chair/left{
-	dir = 8
+/obj/machinery/workbench/advanced,
+/obj/structure/table/wood,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
-/mob/living/simple_animal/hostile/renegade,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/caves)
 "pub" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot,
@@ -13234,7 +13419,7 @@
 	color = "000000"
 	},
 /turf/closed/mineral/random/low_chance,
-/area/f13/underground/cave)
+/area/f13/caves)
 "pBa" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13246,7 +13431,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "pDe" = (
 /obj/effect/turf_decal/bot,
 /obj/item/gun/energy/laser/aer9,
@@ -13330,7 +13515,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "pHa" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/floorgrime,
@@ -13343,7 +13528,9 @@
 /area/f13/vault)
 "pIf" = (
 /obj/item/target/alien,
-/mob/living/simple_animal/hostile/renegade/soldier,
+/mob/living/simple_animal/hostile/renegade/soldier{
+	retreat_distance = null
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pIs" = (
@@ -13411,7 +13598,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "pMU" = (
 /obj/machinery/button/door{
 	id = "marx";
@@ -13433,7 +13620,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "pNc" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -13485,7 +13672,7 @@
 	dir = 4;
 	icon_state = "innermaincornerinner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "pPm" = (
 /obj/item/lightreplacer,
 /turf/open/floor/plasteel/f13{
@@ -13606,7 +13793,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "pVE" = (
 /obj/machinery/light{
 	dir = 4;
@@ -13671,7 +13858,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "pZi" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -13766,6 +13953,14 @@
 	icon_state = "plating"
 	},
 /area/f13/bunker)
+"qeM" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4"
+	},
+/obj/item/clothing/suit/armor/f13/combat/mk2/raider,
+/obj/item/clothing/head/helmet/f13/combat/mk2/raider,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qfg" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -13797,7 +13992,7 @@
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/effect/mob_spawn/human/corpse,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "qhb" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable{
@@ -13999,7 +14194,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "qtj" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/absinthe,
@@ -14036,14 +14231,14 @@
 	dir = 8;
 	icon_state = "horizontaltopborderbottom2right"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "quk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/pill/radx,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "quH" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13/wood,
@@ -14138,7 +14333,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "qCp" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Crematorium"
@@ -14158,7 +14353,7 @@
 "qCS" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "qDT" = (
 /obj/item/gun/ballistic/automatic/toy,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -14252,7 +14447,7 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "qIK" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -14290,7 +14485,7 @@
 	dir = 8;
 	icon_state = "outermaincornerinner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "qKN" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
@@ -14367,7 +14562,7 @@
 	dir = 8;
 	icon_state = "innermaincornerinner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "qQR" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/debris/v2{
@@ -14377,7 +14572,12 @@
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
 "qRg" = (
-/mob/living/simple_animal/hostile/renegade/drifter,
+/mob/living/simple_animal/hostile/renegade/drifter{
+	vision_range = 15;
+	minimum_distance = 8;
+	health = 300;
+	check_friendly_fire = 0
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qRo" = (
@@ -14416,7 +14616,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "qSS" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -14500,7 +14700,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "qWZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14518,7 +14718,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "qZq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14553,7 +14753,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "rcQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14583,7 +14783,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "rdF" = (
 /obj/structure/sink{
 	dir = 1;
@@ -14689,7 +14889,7 @@
 	icon_state = "skulls"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "rla" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14847,7 +15047,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "ryH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15110,7 +15310,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "rPD" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/desert,
@@ -15170,7 +15370,7 @@
 /area/f13/vault)
 "rST" = (
 /turf/open/floor/f13/wood,
-/area/f13/underground/cave)
+/area/f13/caves)
 "rSW" = (
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plasteel/f13{
@@ -15195,7 +15395,7 @@
 	color = "000000"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "rUl" = (
 /obj/machinery/computer/upload/ai{
 	dir = 8
@@ -15294,9 +15494,11 @@
 	},
 /area/f13/caves)
 "scm" = (
-/mob/living/simple_animal/hostile/renegade,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+	},
+/turf/closed/wall/f13/vault,
+/area/f13/underground/cave)
 "scE" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -15417,7 +15619,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/renegade/soldier,
+/mob/living/simple_animal/hostile/renegade/soldier{
+	retreat_distance = null
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "skf" = (
@@ -15462,7 +15666,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom3"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "smt" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -15616,7 +15820,7 @@
 "swe" = (
 /obj/structure/sign/poster/prewar/poster94,
 /turf/closed/wall/f13/tentwall,
-/area/f13/underground/cave)
+/area/f13/caves)
 "swf" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -15711,10 +15915,9 @@
 /area/f13/vault)
 "szL" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/plasteel/barber{
-	icon_state = "plating"
-	},
-/area/f13/bunker)
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "szO" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
@@ -15781,7 +15984,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "sFa" = (
 /obj/machinery/light{
 	dir = 8;
@@ -15853,7 +16056,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "sKU" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -15908,7 +16111,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "sQQ" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15963,7 +16166,7 @@
 "sTk" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "sUw" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -16151,7 +16354,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault)
 "teJ" = (
-/mob/living/simple_animal/hostile/renegade/meister,
+/mob/living/simple_animal/hostile/renegade/meister{
+	retreat_distance = 0;
+	check_friendly_fire = 0;
+	aggro_vision_range = 14
+	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -16186,6 +16393,10 @@
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"tgJ" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tgX" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13{
@@ -16301,7 +16512,9 @@
 /area/f13/bunker)
 "tpa" = (
 /obj/machinery/light,
-/mob/living/simple_animal/hostile/renegade/soldier,
+/mob/living/simple_animal/hostile/renegade/soldier{
+	retreat_distance = null
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "tpo" = (
@@ -16382,7 +16595,9 @@
 /area/f13/vault)
 "ttV" = (
 /obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/renegade/guardian,
+/mob/living/simple_animal/hostile/renegade/guardian{
+	extra_projectiles = 2
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "tub" = (
@@ -16401,7 +16616,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "tux" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/footprints{
@@ -16490,7 +16705,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "tAP" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/plasteel/f13{
@@ -16613,7 +16828,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "tIq" = (
 /obj/machinery/door/airlock{
 	name = "Vault 223 storage"
@@ -16643,7 +16858,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "tJs" = (
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/f13/wood,
@@ -16654,7 +16869,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "tJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
@@ -16704,17 +16919,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tNk" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/spawner/lootdrop/trash,
-/mob/living/simple_animal/hostile/renegade,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tNu" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/mountain_bunker)
+"tNJ" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "tNM" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "stockpilebunker";
@@ -16740,6 +16958,10 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/f13/ahs)
+"tPn" = (
+/obj/structure/debris/v4,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tPo" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/dirt{
@@ -16757,7 +16979,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "tQz" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/easel,
@@ -16847,7 +17069,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "tXf" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -17018,7 +17240,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "uiA" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -17064,7 +17286,7 @@
 "ujx" = (
 /obj/structure/sign/poster/prewar/poster61,
 /turf/closed/wall/f13/supermart,
-/area/f13/underground/cave)
+/area/f13/caves)
 "ujJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -17149,7 +17371,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "unj" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -17238,7 +17460,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "urs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17345,6 +17567,10 @@
 /obj/item/crafting/diode,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"uxp" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uyA" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -17439,7 +17665,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertopright"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "uCF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -17452,12 +17678,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "uDj" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "uDy" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
@@ -17493,6 +17719,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"uFp" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "uFs" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd2";
@@ -17641,6 +17871,9 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ahs)
+"uMb" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "uMw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17865,6 +18098,15 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"uYc" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/glass/ten{
+	amount = 25
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "uYg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18008,7 +18250,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "vil" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -18085,7 +18327,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vje" = (
 /obj/effect/decal/remains/human,
 /obj/item/kitchen/fork,
@@ -18131,7 +18373,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/underground/cave)
+/area/f13/caves)
 "vlI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -18156,7 +18398,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vnl" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -18167,7 +18409,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottomleft"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vnO" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden,
@@ -18187,7 +18429,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vpy" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /obj/structure/nest/supermutant,
@@ -18255,7 +18497,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vsL" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -18292,7 +18534,13 @@
 "vuu" = (
 /obj/structure/chair/office/dark,
 /mob/living/simple_animal/hostile/deathclaw/power_armor{
-	faction = list("raider","hostile","supermutant","deathclaw")
+	faction = list("raider","hostile","supermutant","deathclaw");
+	rapid_melee = 2;
+	melee_damage_lower = 20;
+	melee_damage_upper = 30;
+	obj_damage = 500;
+	name = "Kebab Kehmist";
+	desc = "A massive, reptilian creature with powerful muscles, razor-sharp claws, and aggression to match. Someone had managed to put power armor on him, alongside unusual gauntlets that seem to speed up his hands further"
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -18300,7 +18548,7 @@
 /area/f13/city)
 "vuT" = (
 /turf/closed/wall/f13/supermart,
-/area/f13/underground/cave)
+/area/f13/caves)
 "vuY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -18332,7 +18580,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vxU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/ore/blackpowder/five,
@@ -18341,7 +18589,7 @@
 	desc = "A large and advanced pre-war workbench to tackle any project! This one appears to be coated with numerous scratches of tribal markings, followed by a much more recent skull being scratched through all of them, presumably by a knife."
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "vyt" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/r_wall/f13vault{
@@ -18429,7 +18677,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "vCf" = (
-/mob/living/simple_animal/hostile/renegade/soldier,
+/mob/living/simple_animal/hostile/renegade/soldier{
+	retreat_distance = null
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vCq" = (
@@ -18540,7 +18790,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vLu" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
@@ -18558,6 +18808,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"vMJ" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "vMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18576,7 +18832,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vOS" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -18649,7 +18905,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vVk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
@@ -18703,7 +18959,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "vYb" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/dirt,
@@ -18777,7 +19033,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "wbO" = (
 /obj/structure/rack,
 /obj/item/storage/crayons,
@@ -18839,7 +19095,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "wfy" = (
 /obj/machinery/light{
 	dir = 8
@@ -18875,7 +19131,7 @@
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "wjh" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -18924,6 +19180,11 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"wnh" = (
+/obj/structure/debris/v2,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wnj" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
@@ -18955,10 +19216,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "wnM" = (
-/obj/structure/chair/f13foldupchair,
-/mob/living/simple_animal/hostile/renegade,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/caves)
 "woi" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/dirt{
@@ -19087,7 +19346,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "wxN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19104,7 +19363,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "wyr" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
@@ -19235,7 +19494,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "wFn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19266,7 +19525,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
+"wIV" = (
+/obj/item/storage/toolbox/emergency/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wJG" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/snacks/salad/fruit,
@@ -19293,7 +19556,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "wKJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -19326,7 +19589,7 @@
 "wNg" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "wNj" = (
 /obj/machinery/light{
 	dir = 4;
@@ -19403,7 +19666,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "wSm" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
@@ -19466,7 +19729,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "wUU" = (
 /obj/machinery/hydroponics/soil/crafted,
 /turf/open/indestructible/ground/outside/dirt,
@@ -19534,7 +19797,7 @@
 "wXe" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
-	id = "BOS"
+	id = "BOSNML"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -19580,10 +19843,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
 "wYa" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/obj/structure/reagent_dispensers/barrel/four,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker)
+/mob/living/simple_animal/hostile/renegade{
+	loot = list();
+	melee_damage_lower = 10;
+	melee_damage_upper = 20;
+	rapid_melee = 2;
+	health = 200
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "wYb" = (
 /obj/item/kirbyplants,
 /obj/machinery/light/small/broken{
@@ -19684,13 +19952,13 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xgO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xha" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -19748,6 +20016,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"xkn" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xko" = (
 /obj/effect/spawner/bundle/f13/m1911,
 /obj/structure/closet/secure_closet/goodies,
@@ -19763,7 +20035,7 @@
 	dir = 1;
 	icon_state = "innermaincornerouter"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xlW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -19825,7 +20097,7 @@
 "xqb" = (
 /obj/structure/simple_door,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/underground/cave)
+/area/f13/caves)
 "xqh" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -19936,7 +20208,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/spawner/bundle/f13/gauss,
+/obj/effect/spawner/lootdrop/weapons/experimental,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -19963,7 +20235,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xzM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -19990,7 +20262,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xBo" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -20065,6 +20337,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"xGR" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/underground/cave)
 "xHp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -20078,7 +20356,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xHM" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -20173,7 +20451,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xPL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -20183,7 +20461,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xPT" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/protectron{
@@ -20232,7 +20510,7 @@
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/item/trash/candy,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/underground/cave)
+/area/f13/caves)
 "xSG" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel{
@@ -20256,7 +20534,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xUE" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd6";
@@ -20280,7 +20558,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "xWB" = (
 /obj/structure/table/reinforced,
 /obj/item/defibrillator/compact/loaded,
@@ -20327,7 +20605,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/underground/cave)
+/area/f13/caves)
 "ydV" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21484,14 +21762,14 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+opi
+opi
+opi
+opi
+opi
+opi
+opi
+opi
 shC
 "}
 (5,1,1) = {"
@@ -21741,14 +22019,14 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+opi
+gvq
+gvq
+gvq
+gvq
+gvq
+gvq
+opi
 shC
 "}
 (6,1,1) = {"
@@ -21998,14 +22276,14 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+opi
+scm
+iCX
+cRE
+iCX
+iCX
+gvq
+opi
 shC
 "}
 (7,1,1) = {"
@@ -22253,16 +22531,16 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+fxg
+wgF
+huB
+afj
+iCX
+xGR
+iCX
+iCX
+gvq
+opi
 shC
 "}
 (8,1,1) = {"
@@ -22509,17 +22787,17 @@ bVH
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+wgF
+fxg
+wgF
+huB
+afj
+iCX
+xGR
+iCX
+iCX
+gvq
+opi
 shC
 "}
 (9,1,1) = {"
@@ -22765,18 +23043,18 @@ bVH
 bVH
 bVH
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+wgF
+wgF
+wgF
+wgF
+opi
+scm
+iCX
+ixz
+iCX
+iCX
+gvq
+opi
 shC
 "}
 (10,1,1) = {"
@@ -23022,18 +23300,18 @@ bVH
 bVH
 bVH
 bVH
+wgF
+fxg
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+opi
+gvq
+gvq
+gvq
+scm
+afj
+gvq
+opi
 shC
 "}
 (11,1,1) = {"
@@ -23283,14 +23561,14 @@ bVH
 bVH
 aTA
 aTA
+opi
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+gvq
+llw
+iCX
+gvq
+opi
 shC
 "}
 (12,1,1) = {"
@@ -23540,14 +23818,14 @@ bVH
 bVH
 bVH
 bVH
+opi
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+gvq
+gvq
+gvq
+gvq
+opi
 shC
 "}
 (13,1,1) = {"
@@ -23797,14 +24075,14 @@ bVH
 bVH
 bVH
 bVH
-bVH
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+fcd
+opi
+opi
+opi
+opi
+opi
+opi
+opi
 shC
 "}
 (14,1,1) = {"
@@ -27338,9 +27616,9 @@ wUU
 wUU
 akh
 eNS
-gLT
-pIf
 akh
+pIf
+gLT
 iEs
 lOD
 luX
@@ -27593,7 +27871,7 @@ akh
 akh
 xbi
 akh
-rDA
+akh
 oPX
 akh
 akh
@@ -28108,14 +28386,14 @@ wUU
 wUU
 wUU
 akh
-eNS
+hnW
 akh
 akh
 akh
 akh
 mxj
 sfc
-sfc
+wYa
 sfc
 pIZ
 nsN
@@ -28379,7 +28657,7 @@ sfc
 ciA
 tGX
 wba
-sfc
+wYa
 sfc
 gHL
 tGX
@@ -28621,7 +28899,7 @@ akh
 djm
 akh
 akh
-rDA
+akh
 oPX
 khx
 akh
@@ -29653,7 +29931,7 @@ lGS
 kml
 uLm
 akh
-akh
+qRg
 akh
 nph
 bVH
@@ -29662,7 +29940,7 @@ lOD
 uLm
 uLm
 uLm
-sfc
+wYa
 uLm
 uLm
 uLm
@@ -29910,7 +30188,7 @@ qlG
 mZp
 uLm
 akh
-qRg
+akh
 wmW
 nph
 bVH
@@ -30933,9 +31211,9 @@ uRG
 sfc
 huX
 kiI
-sfc
+wYa
 qlG
-pth
+ati
 uLm
 akh
 akh
@@ -31444,7 +31722,7 @@ qwP
 sfc
 sfc
 eGA
-scm
+sfc
 qtj
 kiI
 sfc
@@ -31958,10 +32236,10 @@ uLm
 uLm
 uLm
 uLm
-sfc
+wYa
 wEe
 kiI
-sfc
+wYa
 scE
 obq
 uLm
@@ -32475,7 +32753,7 @@ mxj
 sfc
 uLm
 sfc
-sfc
+wYa
 qlG
 ati
 uLm
@@ -32489,7 +32767,7 @@ itj
 uLm
 sfc
 tJs
-tNk
+sVs
 sfc
 oOq
 sfc
@@ -32553,7 +32831,7 @@ uHR
 nFX
 oqm
 mTW
-jBt
+mxC
 rvl
 xjm
 xjm
@@ -32726,7 +33004,7 @@ tGX
 tGX
 uLm
 lou
-sfc
+wYa
 nMj
 uLm
 uLm
@@ -32747,7 +33025,7 @@ uLm
 hYX
 tJs
 tJs
-sfc
+wYa
 sfc
 sfc
 uLm
@@ -34016,7 +34294,7 @@ sfc
 uLm
 tJs
 sfc
-sfc
+wYa
 bke
 kqt
 ati
@@ -34096,7 +34374,7 @@ shC
 shC
 jPx
 qpH
-fxg
+mxC
 rzH
 xjm
 oqm
@@ -34355,7 +34633,7 @@ shC
 xjm
 qer
 nNz
-fxg
+mxC
 oqm
 oqm
 gLf
@@ -34528,7 +34806,7 @@ sfc
 sfc
 ndM
 uLm
-wnM
+tJs
 sfc
 sfc
 sfc
@@ -34542,8 +34820,8 @@ nph
 bVH
 bVH
 puk
-wnM
-sfc
+tJs
+wYa
 pIZ
 sfc
 lQs
@@ -34782,7 +35060,7 @@ tGX
 tGX
 uLm
 lFv
-scm
+sfc
 sfc
 mxj
 sfc
@@ -36586,7 +36864,7 @@ sfc
 sfc
 vdm
 rWK
-iCX
+vdm
 uLm
 uLm
 gWc
@@ -36688,7 +36966,7 @@ gcp
 oMd
 hJk
 cQM
-szL
+mxC
 oqm
 shC
 shC
@@ -36855,7 +37133,7 @@ nph
 jcA
 pYx
 pYx
-pYx
+jBt
 pYx
 puk
 aOl
@@ -37357,7 +37635,7 @@ sfc
 sfc
 vdm
 ttV
-vdm
+euB
 uLm
 uLm
 cxK
@@ -37713,7 +37991,7 @@ xjm
 bPT
 oqm
 eim
-szL
+mxC
 shC
 shC
 shC
@@ -37886,7 +38164,7 @@ pYx
 pYx
 pYx
 pYx
-pYx
+jBt
 pYx
 pYx
 sMe
@@ -42778,8 +43056,8 @@ aTA
 aTA
 aTA
 wgF
-wgF
-wgF
+fxg
+fxg
 aTA
 bVH
 bVH
@@ -43548,8 +43826,8 @@ aTA
 aTA
 aTA
 aTA
-wgF
-wgF
+fxg
+fxg
 wgF
 aTA
 bVH
@@ -44577,7 +44855,7 @@ aTA
 aTA
 aTA
 wgF
-mYP
+wgF
 wgF
 aTA
 bVH
@@ -48699,7 +48977,7 @@ iVr
 iVr
 unj
 iVr
-wXe
+iVr
 dTc
 shC
 shC
@@ -67981,29 +68259,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iba
+iba
+iba
+iba
+iba
+iba
+iba
+hrZ
+hrZ
+hrZ
+iba
+iba
+iba
+iba
+iba
+hrZ
+hrZ
+hrZ
+iba
+iba
+iba
+iba
+iba
 shC
 shC
 shC
@@ -68238,29 +68516,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iba
+iba
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+iba
+iba
+iba
 shC
 shC
 shC
@@ -68495,29 +68773,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iba
+hrZ
+hrZ
+hrZ
+hrZ
+aKa
+xkn
+nlT
+nlT
+hrZ
+hrZ
+hrZ
+nJB
+nlT
+pBa
+nlT
+nlT
+mFg
+hrZ
+hrZ
+iba
+iba
+iba
 shC
 shC
 shC
@@ -68752,29 +69030,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iba
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+nlT
+nlT
+nlT
+nlT
+uxp
+nlT
+nlT
+nlT
+nlT
+nlT
+nlT
+nlT
+uxp
+hrZ
+hrZ
+iba
+iba
 shC
 shC
 shC
@@ -69009,29 +69287,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+nlT
+hrZ
+iba
+iba
+iba
+iba
+iba
+nlT
+tNk
+nlT
+gGG
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+nlT
+nlT
+nlT
+hrZ
+iba
+iba
 shC
 shC
 shC
@@ -69266,29 +69544,29 @@ hrZ
 hrZ
 kYl
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+nlT
+nlT
+iba
+kYl
+kYl
+kYl
+iba
+iba
+iba
+iba
+iba
+kYl
+kYl
+kYl
+kYl
+kYl
+hrZ
+tNk
+mFg
+hrZ
+iba
+iba
 shC
 shC
 shC
@@ -69523,29 +69801,29 @@ kYl
 kYl
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+tNk
+nlT
+hrZ
+hnG
+hrZ
+hrZ
+kYl
+kYl
+kYl
+wnM
+wnM
+wnM
+wnM
+wnM
+wnM
+wnM
+kYl
+hrZ
+nlT
+hrZ
+hrZ
+iba
 shC
 shC
 shC
@@ -69780,29 +70058,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+nlT
+tNJ
+ogZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+wnM
+cex
+cyB
+uYc
+isq
+pth
+wnM
+kYl
+hrZ
+oBR
+hrZ
+hrZ
+iba
 shC
 shC
 shC
@@ -70037,29 +70315,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+nlT
+uFp
+vMJ
+uMb
+hrZ
+hrZ
+hrZ
+hrZ
+nlT
+uMb
+uMb
+uMb
+kVw
+uMb
+mDr
+uMb
+hrZ
+kYl
+nlT
+tgJ
+hrZ
+iba
 shC
 shC
 shC
@@ -70294,29 +70572,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iba
+hrZ
+mYP
+nlT
+nlT
+nlT
+nlT
+nlT
+hrZ
+pBa
+uMb
+nlT
+uMb
+uMb
+uxp
+uFp
+uMb
+hrZ
+kYl
+nlT
+pBa
+nJB
+hrZ
 shC
 shC
 shC
@@ -70551,29 +70829,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iba
+hrZ
+hrZ
+wnh
+nlT
+nlT
+nlT
+nlT
+hrZ
+gzu
+hrZ
+bJq
+nlT
+lFh
+nlT
+nlT
+lzb
+hrZ
+kYl
+wIV
+nlT
+nlT
+nlT
 shC
 shC
 shC
@@ -70808,29 +71086,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iba
+iba
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+bJq
+tPn
+tPn
+qeM
+szL
+oao
+hrZ
+kYl
+iba
+nlT
+nlT
+hRQ
 shC
 shC
 shC
@@ -71065,29 +71343,29 @@ hrZ
 hrZ
 hrZ
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+iba
+iba
+iba
+iba
+iba
+hrZ
+hrZ
+iba
+iba
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+iba
+iba
+kYl
+iba
+iba
+iba
+iba
 shC
 shC
 shC
@@ -75247,7 +75525,7 @@ ekT
 bst
 jPN
 fjH
-wYa
+lDm
 sor
 shC
 shC
@@ -76719,29 +76997,29 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+kYl
 xSl
 oAj
-shC
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+kYl
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -76976,26 +77254,26 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 pdF
 nmA
 nmA
 jaa
 nmA
-aTA
+hrZ
 bQl
 qgK
 mVU
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 bds
 bje
 pMY
@@ -77233,7 +77511,7 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 nmA
 geL
 vfZ
@@ -77250,8 +77528,8 @@ bvK
 nmA
 bcC
 nmA
-aTA
-aTA
+hrZ
+hrZ
 oiq
 aLT
 gyu
@@ -77490,7 +77768,7 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 swe
 kdC
 cDS
@@ -77507,12 +77785,12 @@ fYg
 pYT
 gfl
 jaa
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
 aLT
 wKb
-aTA
+hrZ
 shC
 shC
 shC
@@ -77747,7 +78025,7 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 nmA
 wiK
 kpc
@@ -77764,12 +78042,12 @@ pYT
 rcx
 mWt
 nmA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
 aLT
 wKb
-aTA
+hrZ
 shC
 shC
 shC
@@ -78004,7 +78282,7 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 nmA
 nmA
 nqc
@@ -78021,12 +78299,12 @@ aLT
 oaj
 fkT
 nmA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
 aLT
 wKb
-aTA
+hrZ
 shC
 shC
 shC
@@ -78261,7 +78539,7 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 nmA
 wRy
 dDC
@@ -78278,12 +78556,12 @@ aLT
 gyu
 xBb
 nmA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
 aLT
 wKb
-aTA
+hrZ
 shC
 shC
 shC
@@ -78518,7 +78796,7 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 nmA
 qWD
 dDC
@@ -78535,12 +78813,12 @@ rcx
 wKb
 bvK
 nmA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
 aLT
 nce
-aTA
+hrZ
 shC
 shC
 shC
@@ -78775,7 +79053,7 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 nmA
 pCw
 dDC
@@ -78790,14 +79068,14 @@ mbA
 aLT
 oaj
 wKb
-aTA
-aTA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 ryy
 nUI
-aTA
+hrZ
 shC
 shC
 shC
@@ -79032,7 +79310,7 @@ hrZ
 iba
 hrZ
 shC
-aTA
+hrZ
 nmA
 pMF
 dDC
@@ -79048,13 +79326,13 @@ pVz
 ddz
 bcE
 crX
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
 iKT
 rcx
 wKb
-aTA
+hrZ
 shC
 shC
 shC
@@ -79289,7 +79567,7 @@ hrZ
 iba
 hrZ
 shC
-aTA
+hrZ
 nmA
 jOB
 pMF
@@ -79311,7 +79589,7 @@ urr
 rcx
 gyu
 ibA
-aTA
+hrZ
 shC
 shC
 shC
@@ -79546,16 +79824,16 @@ iba
 hrZ
 hrZ
 shC
-aTA
+hrZ
 pdF
 nmA
 nmA
 nmA
 jaa
-aTA
+hrZ
 wNg
 oAj
-aTA
+hrZ
 wbm
 fVl
 dDC
@@ -79567,8 +79845,8 @@ rkV
 tQs
 ddz
 osj
-aTA
-aTA
+hrZ
+hrZ
 shC
 shC
 shC
@@ -79803,29 +80081,29 @@ iba
 hrZ
 hrZ
 shC
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+kYl
 kWx
 aQG
-shC
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+kYl
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -81088,23 +81366,23 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 lTB
 djs
 aeH
@@ -81345,23 +81623,23 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 vuT
 vuT
 vuT
 vuT
 vuT
-aTA
-aTA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 vuT
 vuT
 vuT
 vuT
-aTA
-aTA
+hrZ
+hrZ
 nYu
 jIi
 lZm
@@ -81602,22 +81880,22 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 vuT
 dcJ
 cjZ
 gGg
 tWO
 aOO
-aTA
-aTA
+hrZ
+hrZ
 pAA
 iYv
 tWO
 lJR
 aaE
 vuT
-aTA
+hrZ
 oIw
 rdr
 eUO
@@ -81859,14 +82137,14 @@ hrZ
 hrZ
 nlT
 shC
-aTA
+hrZ
 vuT
 fqR
 wEY
 tWO
 uit
 eVY
-aTA
+hrZ
 pAA
 pAA
 vps
@@ -82116,14 +82394,14 @@ hrZ
 nlT
 nlT
 shC
-aTA
+hrZ
 vuT
 fGE
 xgO
 vNd
 oDa
 fHf
-aTA
+hrZ
 pAA
 vuT
 vuT
@@ -82373,7 +82651,7 @@ hrZ
 nlT
 dQf
 shC
-aTA
+hrZ
 vuT
 mBE
 tWO
@@ -82630,7 +82908,7 @@ nlT
 nlT
 nlT
 shC
-aTA
+hrZ
 vuT
 vuT
 vuT
@@ -82887,7 +83165,7 @@ hrZ
 nlT
 tLZ
 shC
-aTA
+hrZ
 vuT
 jQY
 cYm
@@ -83144,7 +83422,7 @@ hrZ
 nlT
 nlT
 shC
-aTA
+hrZ
 vuT
 xHx
 tIM
@@ -83401,7 +83679,7 @@ hrZ
 hrZ
 nlT
 shC
-aTA
+hrZ
 vuT
 oCW
 sJw
@@ -83658,7 +83936,7 @@ hrZ
 hrZ
 nlT
 shC
-aTA
+hrZ
 vuT
 tAB
 cOc
@@ -83915,7 +84193,7 @@ hrZ
 hrZ
 hrZ
 shC
-aTA
+hrZ
 vuT
 vuT
 vuT
@@ -83930,7 +84208,7 @@ kms
 vuT
 vuT
 vuT
-aTA
+hrZ
 lrm
 moH
 eUO
@@ -84172,23 +84450,23 @@ iba
 hrZ
 hrZ
 shC
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 uCj
 gVN
 xls

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -4037,11 +4037,6 @@
 /obj/structure/junk/small/table,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/mountain_area)
-"Gh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/f13,
-/area/f13/enclave)
 "Gj" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/structure/cable{
@@ -24805,7 +24800,7 @@ AW
 AW
 AW
 AW
-Gh
+KX
 Jx
 Jx
 Jx

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -2336,11 +2336,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/enclave)
 "sH" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "ENCLAVENML"
-	},
-/obj/effect/turf_decal/stripes/box,
+/obj/machinery/vending/games,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "sK" = (
@@ -2537,8 +2533,6 @@
 /area/f13/enclave)
 "tY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "ua" = (
@@ -2652,11 +2646,6 @@
 	icon_type_smooth = "vaultrwall";
 	name = "vault reinforced wall"
 	},
-/area/f13/enclave)
-"uR" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/f13,
 /area/f13/enclave)
 "uT" = (
 /obj/machinery/light/floor,
@@ -4049,9 +4038,8 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/mountain_area)
 "Gh" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "Gj" = (
@@ -4461,7 +4449,6 @@
 /obj/structure/decoration/cctv{
 	pixel_y = 32
 	},
-/obj/machinery/vending/games,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "Jq" = (
@@ -5366,12 +5353,6 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/f13/enclave)
-"RN" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/r_wall/f13/vault,
 /area/f13/enclave)
 "RO" = (
 /obj/effect/landmark/start/f13/usgysgt,
@@ -23285,7 +23266,7 @@ AW
 PC
 Jx
 At
-KX
+Jx
 AW
 SP
 SP
@@ -24567,7 +24548,7 @@ hG
 sO
 Jx
 AW
-zW
+Jx
 Jx
 Jx
 Ks
@@ -24824,10 +24805,10 @@ AW
 AW
 AW
 AW
-pv
-RN
-ml
-RN
+Gh
+Jx
+Jx
+Jx
 AW
 SP
 SP
@@ -25081,10 +25062,10 @@ Vy
 Jx
 Jb
 AW
+zW
 Jx
 Jx
-Jx
-Gh
+hq
 AW
 HT
 SP
@@ -25598,7 +25579,7 @@ og
 Jx
 wa
 Jx
-uR
+Jx
 AW
 SP
 kn

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -2336,7 +2336,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/enclave)
 "sH" = (
-/obj/machinery/vending/games,
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "ENCLAVENML"
+	},
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "sK" = (
@@ -2533,6 +2537,8 @@
 /area/f13/enclave)
 "tY" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "ua" = (
@@ -2648,8 +2654,8 @@
 	},
 /area/f13/enclave)
 "uR" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "uT" = (
@@ -4043,6 +4049,9 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/mountain_area)
 "Gh" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "Gj" = (
@@ -4452,6 +4461,7 @@
 /obj/structure/decoration/cctv{
 	pixel_y = 32
 	},
+/obj/machinery/vending/games,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "Jq" = (
@@ -5356,6 +5366,12 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
+/area/f13/enclave)
+"RN" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+	},
+/turf/closed/wall/r_wall/f13/vault,
 /area/f13/enclave)
 "RO" = (
 /obj/effect/landmark/start/f13/usgysgt,
@@ -23269,7 +23285,7 @@ AW
 PC
 Jx
 At
-Jx
+KX
 AW
 SP
 SP
@@ -24551,7 +24567,7 @@ hG
 sO
 Jx
 AW
-Jx
+zW
 Jx
 Jx
 Ks
@@ -24808,10 +24824,10 @@ AW
 AW
 AW
 AW
-uR
-Jx
-Jx
-Jx
+pv
+RN
+ml
+RN
 AW
 SP
 SP
@@ -25065,10 +25081,10 @@ Vy
 Jx
 Jb
 AW
-zW
 Jx
 Jx
-hq
+Jx
+Gh
 AW
 HT
 SP
@@ -25579,10 +25595,10 @@ yo
 Jx
 MV
 og
-Gh
+Jx
 wa
 Jx
-Jx
+uR
 AW
 SP
 kn

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -4042,6 +4042,9 @@
 /obj/structure/junk/small/table,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/mountain_area)
+"Gh" = (
+/turf/open/floor/f13,
+/area/f13/enclave)
 "Gj" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/structure/cable{
@@ -25576,7 +25579,7 @@ yo
 Jx
 MV
 og
-Jx
+Gh
 wa
 Jx
 Jx

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -2647,6 +2647,11 @@
 	name = "vault reinforced wall"
 	},
 /area/f13/enclave)
+"uR" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13,
+/area/f13/enclave)
 "uT" = (
 /obj/machinery/light/floor,
 /turf/open/floor/f13,
@@ -24800,7 +24805,7 @@ AW
 AW
 AW
 AW
-KX
+uR
 Jx
 Jx
 Jx

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -578,7 +578,7 @@
 /area/f13/tunnel/bighorn)
 "aky" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "akK" = (
@@ -8954,7 +8954,6 @@
 	anchored = 1
 	},
 /obj/effect/turf_decal/delivery/white,
-/obj/item/gun/chem,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -13784,6 +13783,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"sog" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/f13/wood,
+/area/f13/followers)
 "soi" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -33203,7 +33208,7 @@ aae
 aae
 aae
 bpQ
-boU
+sKa
 boU
 boU
 aae
@@ -34228,7 +34233,7 @@ aae
 aae
 aae
 bpQ
-boU
+sKa
 boU
 boU
 aae
@@ -36676,7 +36681,7 @@ yle
 yle
 yle
 fGZ
-rMH
+sog
 yjR
 wZj
 dyC

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -27066,6 +27066,12 @@
 	icon_state = "topshadowright"
 	},
 /area/f13/wasteland/museum)
+"dYA" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland/museum)
 "dYE" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -30436,6 +30442,12 @@
 	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland/train)
+"fFa" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/museum)
 "fFd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/bars{
@@ -31732,6 +31744,12 @@
 /obj/structure/railing/handrail,
 /turf/open/floor/plasteel/white/side,
 /area/f13/brotherhood)
+"gmw" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/bighornbunker)
 "gmB" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -33777,6 +33795,13 @@
 	name = "concrete wall"
 	},
 /area/f13/building/museum)
+"hlk" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "BOSNML"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood)
 "hlr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain0"
@@ -35636,6 +35661,7 @@
 /obj/structure/fence/wooden{
 	dir = 4
 	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
 "iln" = (
@@ -36464,6 +36490,10 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/quarry)
+"iDp" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland/heaven)
 "iDu" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/desert,
@@ -37996,6 +38026,11 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jjD" = (
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland/east)
 "jjG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -43748,6 +43783,12 @@
 /obj/item/melee/onehanded/machete/training,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"lVL" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2right"
+	},
+/area/f13/wasteland/west)
 "lVN" = (
 /obj/structure/table/reinforced,
 /obj/item/weldingtool/mini{
@@ -46428,6 +46469,12 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
+"njj" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
+	},
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/brotherhood)
 "njq" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
@@ -46800,6 +46847,10 @@
 "nqE" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"nqM" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/east)
 "nqR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerpavementcorner"
@@ -48157,6 +48208,12 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/city/bighorn)
+"nWr" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland/east)
 "nWA" = (
 /obj/structure/chair/stool/retro,
 /obj/effect/decal/cleanable/shreds,
@@ -48708,6 +48765,12 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/building/massfusion)
+"ojO" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland/bighornbunker)
 "ojS" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -52170,6 +52233,12 @@
 	icon_state = "verticalrightborderright1"
 	},
 /area/f13/wasteland/hospital)
+"pLm" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland/west)
 "pLo" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "hole"
@@ -54010,6 +54079,12 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
+"qEl" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland/bighornbunker)
 "qEH" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -55199,6 +55274,15 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building)
+"rfU" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/museum)
 "rge" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -55853,6 +55937,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/brotherhood)
+"rwb" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland/heaven)
 "rwg" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -59079,6 +59167,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
+"sYQ" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland/museum)
 "sYR" = (
 /obj/machinery/vending/clothing/heaven{
 	name = "Khan's Harem ClothesMate"
@@ -67959,6 +68053,12 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/hospital)
+"xbb" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/west)
 "xbq" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -68485,6 +68585,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"xnc" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland/east)
 "xnl" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/nanotrasen)
@@ -68559,6 +68663,13 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/village)
+"xqt" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland/bighornbunker)
 "xqw" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/bottle/champagne/empty{
@@ -75869,7 +75980,7 @@ qML
 qZu
 oLb
 ivb
-yeY
+qEl
 mSJ
 ozv
 lVH
@@ -76125,7 +76236,7 @@ icm
 qML
 qZu
 uNJ
-oLb
+ojO
 yeY
 mSJ
 ozv
@@ -77405,7 +77516,7 @@ aae
 bjV
 bjV
 eVt
-eVt
+xqt
 eVt
 qML
 bDA
@@ -80236,7 +80347,7 @@ tRk
 tRk
 tRk
 wxw
-wxw
+gmw
 wxw
 wxw
 bfI
@@ -87169,7 +87280,7 @@ hqc
 pjb
 fWZ
 bdX
-ibe
+iDp
 pBa
 ocq
 ocq
@@ -88711,7 +88822,7 @@ oRI
 pjb
 fWZ
 eMz
-ibe
+rwb
 ibe
 ibe
 ibe
@@ -95808,7 +95919,7 @@ ycB
 tKu
 dMb
 mbv
-itl
+lVL
 azd
 kZH
 daa
@@ -96065,7 +96176,7 @@ rma
 kyv
 kYj
 dMb
-nzp
+xbb
 rma
 azu
 azR
@@ -96323,7 +96434,7 @@ kyv
 kYj
 uxj
 nzp
-rma
+pLm
 kyv
 azS
 kmn
@@ -107768,7 +107879,7 @@ hDo
 hDo
 hDo
 bGA
-qpD
+dYA
 qOB
 frP
 kBk
@@ -108026,7 +108137,7 @@ izZ
 izZ
 izZ
 xZN
-xZN
+fFa
 cqC
 kBk
 wdP
@@ -110593,7 +110704,7 @@ jUo
 qpD
 xZN
 fUM
-xZN
+fFa
 xZN
 jOi
 xZN
@@ -110850,7 +110961,7 @@ jUo
 nRZ
 qIh
 bzp
-qIh
+rfU
 xZN
 xZN
 xZN
@@ -111106,7 +111217,7 @@ abP
 jUo
 dYy
 kSu
-kSu
+sYQ
 kSu
 kSu
 kSu
@@ -118775,8 +118886,8 @@ wyN
 cpx
 cpx
 cpx
-cpx
-cpx
+aTb
+nqM
 dny
 dYH
 grH
@@ -119291,7 +119402,7 @@ pxv
 pxv
 dYH
 eiK
-eiK
+nWr
 eiK
 ahQ
 pMY
@@ -120861,7 +120972,7 @@ pgy
 pgy
 ael
 pgy
-tfr
+jjD
 bdY
 pgy
 xvO
@@ -121117,7 +121228,7 @@ jPD
 wnj
 cwU
 pgy
-pgy
+xnc
 fUa
 mXl
 mXl
@@ -135037,7 +135148,7 @@ kOz
 kOz
 iky
 qJp
-eIg
+xja
 xKP
 xKP
 xKP
@@ -135294,10 +135405,10 @@ kOz
 kOz
 rWO
 nDh
-xja
-xKP
-xKP
-xKP
+eIg
+njj
+rcg
+rcg
 xKP
 xKP
 xKP
@@ -135550,11 +135661,11 @@ kOz
 kOz
 sFw
 rYF
-nDh
+qJp
 eIg
-xKP
-xKP
-xKP
+kxP
+hlk
+rcg
 xKP
 xKP
 xKP
@@ -135807,11 +135918,11 @@ kCg
 kCg
 rge
 tjK
-sGk
-sGk
-xKP
-xKP
-xKP
+qJp
+eIg
+njj
+rcg
+rcg
 xKP
 xKP
 xKP
@@ -136064,8 +136175,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+mMa
+mMa
 aaa
 aaa
 aaa

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -3031,6 +3031,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cUE" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/rocksprings)
 "cUF" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/decal/cleanable/dirt{
@@ -10031,6 +10037,12 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/building)
+"kdB" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/rocksprings)
 "kdH" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -11279,10 +11291,7 @@
 	},
 /area/f13/building)
 "lwU" = (
-/obj/structure/barricade/wooden/strong{
-	icon_state = "boarded";
-	opacity = 1
-	},
+/obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -11860,10 +11869,7 @@
 	},
 /area/f13/caves)
 "mdG" = (
-/obj/structure/barricade/wooden/strong{
-	icon_state = "boarded";
-	opacity = 1
-	},
+/obj/structure/simple_door/bunker/glass,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
 "meE" = (
@@ -14387,6 +14393,12 @@
 	icon_state = "greendirtysolid"
 	},
 /area/f13/building)
+"ouo" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2bottom"
+	},
+/area/f13/wasteland/rocksprings)
 "ouy" = (
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
@@ -16456,6 +16468,12 @@
 	icon_state = "common-broken4"
 	},
 /area/f13/building)
+"quO" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/rocksprings)
 "quY" = (
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 8
@@ -21682,12 +21700,12 @@
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland/rocksprings)
 "vvH" = (
-/obj/structure/barricade/wooden/strong{
-	icon_state = "boarded";
-	opacity = 1
+/obj/effect/decal/marking,
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/building)
+/area/f13/wasteland/rocksprings)
 "vvZ" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -23076,6 +23094,7 @@
 	icon_state = "floor5";
 	pixel_x = -17
 	},
+/obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerturn"
@@ -24438,6 +24457,13 @@
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
+"ydW" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland/rocksprings)
 "yej" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/decal/cleanable/dirt,
@@ -46737,7 +46763,7 @@ peo
 tEy
 frF
 kSK
-gfv
+ydW
 tjk
 peo
 cwx
@@ -55881,7 +55907,7 @@ gos
 hwx
 hwx
 hwx
-hwx
+hoG
 mkw
 jEL
 jEL
@@ -56134,12 +56160,12 @@ bWo
 dKc
 nUF
 nUF
-gos
+ouo
 edx
 hwx
 hwx
 hwx
-jEL
+quO
 jEL
 jEL
 gpA
@@ -57933,7 +57959,7 @@ bWo
 dKc
 tPI
 tPI
-tPI
+vvH
 tPI
 hwx
 hwx
@@ -58191,7 +58217,7 @@ olf
 hwx
 hwx
 yhR
-hwx
+jzi
 hwx
 nbp
 hwx
@@ -71307,7 +71333,7 @@ jEL
 jEL
 qYz
 jEL
-vQb
+cUE
 jEL
 hiG
 kcs
@@ -71821,7 +71847,7 @@ eCA
 jEL
 tKY
 jEL
-jEL
+kdB
 jEL
 xwn
 kcs
@@ -72077,7 +72103,7 @@ jEL
 bHt
 jEL
 tKY
-jEL
+mkw
 jEL
 jEL
 hiG
@@ -72331,7 +72357,7 @@ hgP
 fee
 efV
 jEL
-jEL
+mkw
 jEL
 tKY
 jEL
@@ -80092,8 +80118,8 @@ tgY
 xsC
 drm
 drm
-vvH
-vvH
+lzs
+lzs
 drm
 drm
 drm
@@ -85418,7 +85444,7 @@ hwx
 hwx
 hwx
 hwx
-tPI
+vvH
 tPI
 kcs
 hgP

--- a/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
@@ -296,6 +296,9 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/ncr)
+"ew" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland/warren)
 "eA" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -1358,7 +1361,7 @@
 "rr" = (
 /obj/machinery/workbench,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
+/obj/item/gun/ballistic/shotgun/police,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -26839,7 +26842,7 @@ ru
 ru
 ru
 Hd
-HW
+ew
 HW
 HW
 HW
@@ -27096,11 +27099,11 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
-HW
-HW
+ew
+ew
+ew
+ew
+ew
 HW
 HW
 HW
@@ -27353,11 +27356,11 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
-HW
-HW
+ew
+ew
+ew
+ew
+ew
 HW
 HW
 HW
@@ -27610,11 +27613,11 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
-HW
-HW
+ew
+ew
+Hd
+Hd
+ew
 HW
 HW
 HW
@@ -27867,11 +27870,11 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
-HW
-HW
+ew
+ew
+Hd
+Hd
+ew
 HW
 HW
 HW
@@ -28124,11 +28127,11 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
-HW
-HW
+ew
+ew
+Hd
+ew
+ew
 HW
 HW
 HW
@@ -28381,11 +28384,11 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
-HW
-HW
+ew
+ew
+Hd
+ew
+ew
 HW
 HW
 HW
@@ -28638,10 +28641,10 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
-HW
+ew
+ew
+Hd
+Hd
 HW
 HW
 HW
@@ -28895,10 +28898,10 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
-HW
+ew
+ew
+ew
+ew
 HW
 HW
 HW
@@ -29152,9 +29155,9 @@ ru
 ru
 ru
 Hd
-HW
-HW
-HW
+ew
+ew
+ew
 HW
 HW
 HW
@@ -29409,8 +29412,8 @@ ru
 ru
 ru
 Hd
-HW
-HW
+ew
+ew
 HW
 HW
 HW
@@ -29666,7 +29669,7 @@ ru
 ru
 ru
 Hd
-HW
+ew
 HW
 HW
 HW

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -394,6 +394,10 @@
 /area/f13/wasteland/warren)
 "api" = (
 /obj/structure/chair/stool/retro/backed,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = -32
+	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "apj" = (
@@ -1306,7 +1310,7 @@
 	},
 /area/f13/ncr)
 "bga" = (
-/obj/machinery/door/unpowered/securedoor/outlaw/boss,
+/obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "bgq" = (
@@ -1485,12 +1489,15 @@
 	},
 /area/f13/city)
 "bom" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/stack/sheet/mineral/wood/twenty,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/raiders)
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 4
+	},
+/area/f13/wasteland/warren)
 "boQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
@@ -3964,6 +3971,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/city)
+"dCy" = (
+/obj/structure/table,
+/obj/item/binoculars,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/raiders)
 "dCD" = (
 /obj/structure/fence/end,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4846,6 +4858,13 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland/warren)
+"eEF" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/wasteland/warren)
 "eEJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
@@ -5253,6 +5272,12 @@
 	dir = 1
 	},
 /area/f13/wasteland/ncr)
+"eXF" = (
+/obj/machinery/chem_master,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/raiders)
 "eXQ" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	dir = 9;
@@ -5426,10 +5451,7 @@
 	},
 /area/f13/ncr)
 "fgU" = (
-/obj/machinery/chem_heater{
-	pixel_x = -6;
-	pixel_y = 12
-	},
+/obj/machinery/chem_heater,
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
@@ -7161,10 +7183,7 @@
 "gFW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/ammo_box/magazine/d12g,
-/obj/item/ammo_box/magazine/d12g,
-/obj/item/ammo_box/magazine/d12g,
-/obj/item/gun/ballistic/automatic/shotgun/riot/boss,
+/obj/item/twohanded/baseball/louisville,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "gHK" = (
@@ -8415,6 +8434,11 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland/warren)
+"hOM" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "hPg" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -9520,8 +9544,10 @@
 /area/f13/raiders)
 "iRl" = (
 /obj/structure/rack/shelf_metal,
-/obj/item/clothing/suit/armored/heavy/salvaged_pa/t45b/raider,
-/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/raider,
+/obj/effect/spawner/bundle/f13/armor/badlands,
+/obj/effect/spawner/bundle/f13/armor/blastmaster,
+/obj/effect/spawner/bundle/f13/armor/supafly,
+/obj/effect/spawner/bundle/f13/armor/yankee,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/raiders)
 "iRp" = (
@@ -9565,6 +9591,13 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
+	},
+/area/f13/wasteland/warren)
+"iUv" = (
+/obj/effect/decal/marking,
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/warren)
 "iUx" = (
@@ -9766,6 +9799,14 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/warren)
+"jgk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "jgp" = (
 /obj/item/storage/toolbox/electrical,
 /obj/structure/table,
@@ -9840,6 +9881,15 @@
 /obj/effect/landmark/start/f13/ncrcorporal,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/ncr)
+"jkU" = (
+/obj/structure/table/wood/fancy,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "jla" = (
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
@@ -9915,6 +9965,10 @@
 /obj/item/reagent_containers/glass/bottle/napalm,
 /obj/item/reagent_containers/food/drinks/bottle/molotov,
 /obj/item/reagent_containers/food/drinks/bottle/molotov,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = -32
+	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "jpP" = (
@@ -9978,6 +10032,14 @@
 "juF" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/city)
+"juH" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 8;
+	icon_state = "graveldirtedge"
+	},
+/area/f13/raiders)
 "juT" = (
 /obj/structure/bookshelf{
 	icon_state = "book-2"
@@ -12352,7 +12414,7 @@
 /turf/open/floor/wood/wood_wide,
 /area/f13/city)
 "lMI" = (
-/obj/structure/junk/small/tv,
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
@@ -13031,6 +13093,15 @@
 	name = "bathroom tiles"
 	},
 /area/f13/city)
+"mva" = (
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_y = -32
+	},
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 8
+	},
+/area/f13/raiders)
 "mvf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass{
@@ -13322,6 +13393,11 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland/warren)
+"mHo" = (
+/obj/structure/table/wood/poker,
+/obj/item/storage/box/dice,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "mHu" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_5"
@@ -14111,6 +14187,17 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/warren)
+"noX" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
+/obj/structure/car/rubbish3{
+	pixel_x = -5
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/warren)
 "nqk" = (
 /turf/open/indestructible/ground/outside/savannah/toprightcorner,
 /area/f13/wasteland/ncr)
@@ -14316,9 +14403,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ncr)
 "nBY" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/wasteland/warren)
 "nCF" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14864,6 +14951,15 @@
 	pixel_y = 9
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/warren)
+"odu" = (
+/obj/structure/car/rubbish1{
+	pixel_x = -7;
+	pixel_y = -14
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
 /area/f13/wasteland/warren)
 "odK" = (
 /obj/structure/wreck/trash/brokenvendor,
@@ -18484,6 +18580,13 @@
 	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/city)
+"rxf" = (
+/obj/effect/decal/marking,
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/warren)
 "rxE" = (
 /obj/structure/fence/cut/large{
 	dir = 4
@@ -18530,6 +18633,10 @@
 /obj/item/ammo_box/m44box/improvised,
 /obj/item/ammo_box/shotgun/improvised,
 /obj/item/ammo_box/shotgun/improvised,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = -32
+	},
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "ryu" = (
@@ -19733,6 +19840,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/rust,
 /area/f13/raiders)
+"sFQ" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/strong,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/wasteland/warren)
 "sHc" = (
 /obj/item/chair/greyscale{
 	pixel_x = 8;
@@ -19795,6 +19909,7 @@
 /area/f13/wasteland/warren)
 "sKf" = (
 /obj/structure/junk/locker,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
@@ -20674,13 +20789,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
 "tGj" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/mineral/uranium{
-	icon_state = "plating_rust";
-	name = "corroded metal floor covered in goo";
-	slowdown = 2
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
-/area/f13/caves)
+/area/f13/wasteland/warren)
 "tGs" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -20876,6 +20989,15 @@
 /obj/effect/spawner/lootdrop/wastelootgood,
 /turf/open/floor/wood/wood_common,
 /area/f13/city)
+"tNh" = (
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_y = -32
+	},
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 1
+	},
+/area/f13/raiders)
 "tNj" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -21000,13 +21122,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "tRq" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/mineral/uranium{
-	icon_state = "plating_rust";
-	name = "corroded metal floor covered in goo";
-	slowdown = 2
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "raidermb"
 	},
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 4
+	},
+/area/f13/wasteland/warren)
 "tRt" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
@@ -22523,6 +22646,12 @@
 /obj/structure/janitorialcart,
 /turf/open/floor/plasteel/darkpurple,
 /area/f13/ncr)
+"vht" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland/warren)
 "vhJ" = (
 /obj/structure/fence{
 	dir = 4
@@ -24602,9 +24731,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
 /area/f13/city)
 "wWL" = (
-/obj/effect/decal/cleanable/greenglow/radioactive,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "wXr" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -24825,6 +24957,7 @@
 /obj/structure/closet,
 /obj/item/clothing/gloves/f13/crudemedical,
 /obj/item/reagent_containers/pill/patch/jet,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
@@ -24892,6 +25025,12 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/city)
+"xjp" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/raiders)
 "xjr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -25960,12 +26099,7 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland/warren)
 "yfO" = (
-/obj/structure/car/rubbish3{
-	pixel_x = -5
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland/warren)
 "yfP" = (
 /obj/structure/railing/corner{
@@ -35210,7 +35344,7 @@ hZy
 nTE
 pGE
 pGE
-wWL
+jIy
 wAO
 pGE
 hZy
@@ -35469,7 +35603,7 @@ pGE
 vtc
 ycy
 nNH
-nBY
+jIy
 hZy
 pLS
 pLS
@@ -37014,7 +37148,7 @@ pLS
 hZy
 nHI
 wAO
-tRq
+brf
 pGE
 pGE
 poQ
@@ -39583,7 +39717,7 @@ hZy
 pGE
 hZy
 hZy
-tGj
+brf
 hZy
 jOK
 tsy
@@ -40347,7 +40481,7 @@ jLg
 jLg
 qZx
 pcK
-tGj
+brf
 pcK
 vtc
 hZy
@@ -41760,9 +41894,9 @@ yfE
 wXB
 uch
 mdW
-bwc
-bwc
-tjK
+iUv
+rxf
+noX
 pbp
 pbp
 lMO
@@ -42274,7 +42408,7 @@ rZI
 wXB
 ipp
 lHY
-yfO
+pbp
 pbp
 lMO
 pbp
@@ -45516,8 +45650,8 @@ pLS
 pLS
 pLS
 vol
-uch
-nFf
+gRk
+vVp
 jfK
 suN
 vuD
@@ -49600,8 +49734,8 @@ jLg
 qZx
 dlr
 lez
-lez
-lez
+eEF
+bom
 lez
 wXB
 gIo
@@ -49857,8 +49991,8 @@ jLg
 qZx
 lez
 lez
-lez
-lez
+yfO
+tRq
 lez
 wXB
 nEk
@@ -50114,7 +50248,7 @@ jLg
 qZx
 lez
 lez
-lez
+yfO
 lez
 lez
 wXB
@@ -50371,7 +50505,7 @@ jLg
 qZx
 lez
 lez
-lez
+nBY
 lez
 mQE
 qzI
@@ -50628,7 +50762,7 @@ jLg
 qZx
 dlr
 lez
-lez
+nBY
 lez
 hNx
 sKf
@@ -50885,10 +51019,10 @@ jLg
 qZx
 dlr
 lez
-lez
-lez
+yfO
+sFQ
 lMI
-sfe
+tGj
 vgk
 sfe
 uch
@@ -52188,7 +52322,7 @@ jfK
 wXB
 wvb
 bQk
-sfe
+vht
 sfe
 sfe
 sfe
@@ -52445,7 +52579,7 @@ snq
 wXB
 cjT
 ttq
-wvb
+odu
 sfe
 sfe
 sfe
@@ -53477,7 +53611,7 @@ xph
 pLS
 qZx
 sfe
-sfe
+qHF
 wIM
 ceg
 avr
@@ -53718,10 +53852,10 @@ jAI
 ttA
 vVX
 nhk
+wWL
 wUT
-wUT
-wUT
-wUT
+wWL
+wWL
 dXE
 lhG
 gzs
@@ -53734,8 +53868,8 @@ jla
 pLS
 qZx
 sfe
-sfe
-uch
+vht
+nqM
 ceg
 ceg
 ceg
@@ -54233,7 +54367,7 @@ mfU
 vVX
 wUT
 sBE
-sBE
+mHo
 sBE
 wUT
 rAJ
@@ -54490,7 +54624,7 @@ mfU
 xuB
 wUT
 sBE
-sBE
+hOM
 sBE
 sNb
 wUT
@@ -54739,7 +54873,7 @@ jLg
 jLg
 qZx
 xqa
-mfU
+dCy
 unF
 unF
 unF
@@ -54997,7 +55131,7 @@ jLg
 qZx
 xqa
 iRl
-bom
+mfU
 mfU
 rmz
 rmz
@@ -56294,10 +56428,10 @@ nxO
 snh
 lRa
 vsO
-wOg
+xjp
 fgU
 oaU
-wOg
+eXF
 njw
 xph
 xph
@@ -59111,7 +59245,7 @@ isU
 swo
 kEw
 xbI
-eqS
+juH
 hYD
 pKl
 cNe
@@ -59633,7 +59767,7 @@ nxO
 snh
 nxO
 nxO
-snh
+tNh
 wCg
 oOo
 unF
@@ -59890,7 +60024,7 @@ snh
 lRa
 eqS
 nbD
-nxO
+mva
 wCg
 iuQ
 unF
@@ -60399,11 +60533,11 @@ xJu
 jpD
 ryp
 sNb
-sNb
+jgk
 wUT
-sNb
+jgk
 api
-eQt
+jkU
 mSs
 yln
 rXL

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -19843,8 +19843,8 @@
 "sFQ" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland/warren)
 "sHc" = (

--- a/code/modules/fallout/f13lootdrop.dm
+++ b/code/modules/fallout/f13lootdrop.dm
@@ -798,32 +798,33 @@
 	icon_state = "egunlow_loot"
 	name = "low tier energy gun"
 	loot = list(/obj/effect/spawner/bundle/f13/wattz = 40,
-				/obj/effect/spawner/bundle/f13/wattzm = 25
+				/obj/effect/spawner/bundle/f13/wattzm = 5,
+				/obj/effect/spawner/bundle/f13/laserpistol = 20,
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid
 	icon_state = "egunmid_loot"
 	name = "mid tier energy gun"
-	loot = list(/obj/effect/spawner/bundle/f13/aer9 = 26,
-				/obj/effect/spawner/bundle/f13/laserpistol = 15,
-				/obj/effect/spawner/bundle/f13/ionrifle = 5
+	loot = list(/obj/effect/spawner/bundle/f13/aer9 = 40,
+				/obj/effect/spawner/bundle/f13/plasmapistol = 20,
+				/obj/effect/spawner/bundle/f13/wattz2k = 5,
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh //overlaps with midtier
 	name = "mid-high tier energy gun"
 	icon_state = "egunmidhigh_loot"
-	loot = list(/obj/effect/spawner/bundle/f13/aer12,
-				/obj/effect/spawner/bundle/f13/ionrifle,
-				/obj/effect/spawner/bundle/f13/aer14
+	loot = list(/obj/effect/spawner/bundle/f13/aer9 = 40,
+				/obj/effect/spawner/bundle/f13/ionrifle = 5,
+				/obj/effect/spawner/bundle/f13/aer12 = 20,
 				)
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high
 	name = "high tier energy gun"
 	icon_state = "egunhigh_loot"
-	loot = list(/obj/effect/spawner/bundle/f13/tribeam = 10,
+	loot = list(/obj/effect/spawner/bundle/f13/tribeam = 20,
 				/obj/effect/spawner/bundle/f13/rcw = 20,
-				/obj/effect/spawner/bundle/f13/aer14 = 20,
-				/obj/effect/spawner/bundle/f13/wattz2k = 26,
-				/obj/effect/spawner/bundle/f13/wattz2kext = 15,
+				/obj/effect/spawner/bundle/f13/aer14 = 10,
+				/obj/effect/spawner/bundle/f13/plasmarifle = 20,
+				/obj/effect/spawner/bundle/f13/wattz2kext = 20,
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/superhigh

--- a/code/modules/fallout/themed_loot_tables.dm
+++ b/code/modules/fallout/themed_loot_tables.dm
@@ -316,7 +316,6 @@
 		/obj/item/gun/ballistic/revolver/m29/peacekeeper = 10,
 		/obj/item/encminigunpack = 10,
 		/obj/item/gun/ballistic/automatic/smg/p90 = 10,
-		/obj/item/gun/ballistic/automatic/xl70e3 = 10,
 		)
 
 

--- a/code/modules/fallout/themed_loot_tables.dm
+++ b/code/modules/fallout/themed_loot_tables.dm
@@ -312,13 +312,11 @@
 /obj/effect/spawner/lootdrop/weapons/experimental
 	name = "weaponspawner experimental"
 	loot = list(
-		/obj/item/gun/ballistic/automatic/g11 = 15,
-		/obj/effect/spawner/bundle/f13/needler = 10,
-		/obj/item/gun/energy/laser/rcw = 10,
-		/obj/item/gun/ballistic/automatic/m72 =10,
-		/obj/item/melee/f13powerfist/moleminer = 10,
-		/obj/item/melee/transforming/energy/axe/protonaxe = 10,
-		/obj/item/gun/ballistic/revolver/ballisticfist = 5,
+		/obj/item/gun/ballistic/automatic/m72 = 10,
+		/obj/item/gun/ballistic/revolver/m29/peacekeeper = 10,
+		/obj/item/encminigunpack = 10,
+		/obj/item/gun/ballistic/automatic/smg/p90 = 10,
+		/obj/item/gun/ballistic/automatic/xl70e3 = 10,
 		)
 
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -267,7 +267,7 @@
 	icon_state = "mysterious_m29"
 	icon = 'icons/obj/guns/gunfruits2022/pistols.dmi'
 	automatic = 1
-	autofire_shot_delay = 1
+	autofire_shot_delay = 2.8
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	can_scope = FALSE
 


### PR DESCRIPTION
## About The Pull Request
Long list of fixes, edits and other things. Check the changelog for a full list!

## Why It's Good For The Game
Less dumb spawners, better spawners for e-weapons, more cars, less setup time, harder dungeon, more fun :)

![Screenshot 2023-12-04 142647](https://github.com/f13babylon/f13babylon/assets/76122712/468a97b4-c78d-4c92-8fcf-43d18c841db2)
![Screenshot 2023-12-04 142707](https://github.com/f13babylon/f13babylon/assets/76122712/b7d8a748-3e80-4c04-8af3-f9f660eb55ef)

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑
remove: the 2 unique spawns on the surface/underground that can be rushed 
remove: the 'Left Hand' riot shotgun force-spawner (and Raider T-45b spawner)
add: a chemlab, basic raider armor, louisville slugger and bino spawners to Raider Town
add: a few more carpiles around the map
add: a Raiders minidungeon for books 1-3, since everyone else gets it now it seems 
fix: the new Kebab Town (Mobs are harder now. Beware..!) 
remove: the followers Reagent Gun (AGAIN. I did this before and someone RE-MAPPED IT IN.) 
remove: that one dumb as shit rad-puddle from infront of the BOS base 
remove: the force-spawn gauss rifle in no mans land (replaced with experimental spawner)
add: bodybags for followers
edit: the E-Weapon spawners to the following - | Low = AEP7, Wattz, (low chance) Wattz Magneto (someone made the AEP7 midtier for some bullshit reason) | Mid = AER9, Plaspistol, (low chance) Wattz 2k | Mid-High = AER12, AER9, (low chance) Ion Rifle | High = Plasrifle, Wattz 2kE, RCW, Tribeam,(low chance) AER14 
edit: the Experimental Spawner to the following: M72 Gauss | Peacekeeper | P90 | Gatling Laser
edit: the Peacekeepers stats (Applied auto-fire shot delay of 2.8 from 1)
fix: Fixed the Remnant Bunker shoot-through wall things by replacing them
fix: Fixed BOS NML entrance and Enclave NML Entrance
fix: Replaces NML PA claw with an edited Junker Boss (he is hard)
fix: Fixes the boss not firing
remove: the invincible interior walls in kebab, replacing them with r_walls
fix: NML Turrets shooting NML mobs
tweak: NML kebab melee mobs and boss mobs have melee AP
add: 2 ghoul spawners to north nml + static glowing one
remove: 2 legendary ghouls from north nml
add: 4 ranged mutant spawners to south nml
remove: 2 legendary super mutants from south nml
add: 6 more turrets throughout NML (3 north, 3 south - 2 at each building, 1 for each exterior melee weapon spawn)
add: renegade flags to kebab
🆑 