### PR TITLE
Glowing Ghoul Name Change

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -114,7 +114,7 @@
 
 
 /datum/species/ghoul/glowing
-	name = "Glowing Ghoul"
+	name = "Glowing One"
 	id = "glowing ghoul"
 	limbs_id = "glowghoul"
 	armor = -30

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -166,7 +166,7 @@
 
 //Glowing Ghoul
 /mob/living/simple_animal/hostile/ghoul/glowing
-	name = "glowing feral ghoul"
+	name = "glowing one"
 	desc = "A feral ghoul that has absorbed massive amounts of radiation, causing them to glow in the dark and radiate constantly."
 	icon_state = "glowinghoul"
 	icon_living = "glowinghoul"


### PR DESCRIPTION
## About The Pull Request
Pretty much every official source knows them as 'glowing ones' rather than 'glowing ghouls' so it feels more appropriate.

## Why It's Good For The Game
Useless fluff but immersion good...

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
tweak: Glowing Ghouls are now Glowing Ones.
/:cl:
