### PR TITLE
Adjusts build times of shutters and blast doors to be more reasonable, adds in a (WEAK) buildable gate shutter.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -252,7 +252,7 @@
 				)
 	result = /obj/machinery/door/poddoor/shutters/old/preopen
 	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WIRECUTTER, TOOL_WELDER)
-	time = 120 SECONDS
+	time = 60 SECONDS
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 
@@ -264,7 +264,19 @@
 				)
 	result = /obj/machinery/door/poddoor/preopen
 	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WIRECUTTER, TOOL_WELDER)
-	time = 160 SECONDS
+	time = 120 SECONDS
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+
+/datum/crafting_recipe/city_gate
+	name = "City Gate"
+	reqs = list(/obj/item/stack/sheet/plasteel = 30, //Three times as wide as a shutter, so 3x the cost. STILL ACTS AS A SINGLE SHUTTER THOUGH
+				/obj/item/stack/cable_coil = 30,
+				/obj/item/electronics/airlock = 1
+				)
+	result = /obj/machinery/door/poddoor/gate/buildable
+	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WIRECUTTER, TOOL_WELDER)
+	time = 120 SECONDS
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 

--- a/code/game/machinery/doors/city_gate.dm
+++ b/code/game/machinery/doors/city_gate.dm
@@ -37,3 +37,16 @@
 	icon_state = "open"
 	density = FALSE
 	opacity = FALSE
+
+/obj/machinery/door/poddoor/gate/buildable
+	name = "weak city gate"
+	desc = "A heavy duty gate that opens mechanically. This one looks newly built and not as strong as a standard gate."
+	icon_state = "open"
+	armor = list("melee" = 30, "bullet" = 25, "laser" = 25, "energy" = 75, "bomb" = 25, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70) //same armor as regular, basic shutters. Can be adjusted later if need be.
+	damage_deflection = 25 //How much force a melee weapon needs to damage it.
+	proj_resist = 16
+	max_integrity = 200 //Health is the same as a shutter. Can be changed later if need be.
+	id = 451
+	ertblast = FALSE //Can be hooked up to remote signalers and button frames.
+	density = FALSE
+	opacity = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Adjusts the build times for shutters and blast doors, halving the time to create a shutter from 120 seconds to 60 seconds as two minutes to build a single weak door was insane. Also shaved 40 seconds off the blast doors, reducing it to 120 seconds.

Additionally, added a craftable city gate that has the same defences and health as a regular shutter.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The time to build shutters was absolutely stupid and just building five shutters would take you ten real life minutes. These shutters are easy to destroy and even easier to hack and take control of when they are left open. Two minutes for these didn't make any sense. 

![Screenshot 2023-12-05 211735](https://github.com/f13babylon/f13babylon/assets/62829927/1b8eba06-f132-4788-a85e-4331a4001768)

Additionally, the city gate helps enhance custom buildings and bases. They are as weak as a shutter and can still be hacked to work with a blast door controller, unlike the city gates present already in the map. They are meant more for RP than actually protecting your base. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Added a buildable (weak) city gate.
tweak: Tweaked the build time for shutters and blast doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
