### PR TITLE
Fixes Representative Safe Cash

### DIFF
--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -216,5 +216,5 @@
 /obj/item/storage/secure/safe/ncr_rep/New()
 	..()
 	new /obj/item/documents/ncr_rep(src)
-	new /obj/item/stack/f13Cash/onezerozerozero(src)
+	new /obj/item/stack/f13Cash/ncr/onezerozerozero(src)
 	new /obj/item/melee/baton/loaded(src)

--- a/code/modules/fallout/obj/stack/f13Cash.dm
+++ b/code/modules/fallout/obj/stack/f13Cash.dm
@@ -285,9 +285,8 @@
 	min_qty = HIGH_MIN / CASH_NCR
 	max_qty = HIGH_MAX / CASH_NCR
 
-/obj/item/stack/f13Cash/onezerozerozero
+/obj/item/stack/f13Cash/ncr/onezerozerozero
 	amount = 1000
-	merge_type = /obj/item/stack/f13Cash/ncr
 
 #undef maxCoinIcon
 #undef CASH_CAP


### PR DESCRIPTION
## About The Pull Request
A pile of cash in the NCR Rep safe had some messy code that made it appear as caps even though it was stacked with NCR dollars. It should presumably be NCR dollars, so now it is.

_(I have a feeling this was some more shitcode from me last year when I helped build that base.)_
## Why It's Good For The Game
Bugfix good. Another Discord report. : )

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed NCR Rep safe contents.
/:cl: