### PR TITLE
Sunlit plating attempt number two. (Place tiles in harm intent to keep sunlight)

### DIFF
--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -23,6 +23,7 @@
 
 /turf/open/indestructible/ground/attack_paw(mob/user)
 	return src.attack_hand(user)
+
 /turf/open/indestructible/ground/attackby(obj/item/C, mob/user, params)
 	if(istype(C,/obj/item/stack/tile/plasteel))
 		var/obj/item/stack/tile/plasteel/S = C

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -23,14 +23,24 @@
 
 /turf/open/indestructible/ground/attack_paw(mob/user)
 	return src.attack_hand(user)
-
 /turf/open/indestructible/ground/attackby(obj/item/C, mob/user, params)
 	if(istype(C,/obj/item/stack/tile/plasteel))
 		var/obj/item/stack/tile/plasteel/S = C
 		if(S.use(1))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			to_chat(user, "<span class='notice'>You build a floor.</span>")
+			var/atom/movable/sunlight/copy_light
+			var/copy_state
+			if(src.vis_contents)
+				for(var/I in vis_contents)
+					if(istype(I, /atom/movable/sunlight))
+						copy_light = I
+						copy_state = sunlight_state
 			ChangeTurf(/turf/open/floor/plating)
+			if(user.a_intent == INTENT_HARM) //This will result in a tile that has sunlight. Place in any other intent if you wish for darkness.
+				if(copy_light != null)
+					sunlight_state = copy_state
+					vis_contents += copy_light
 		else
 			to_chat(user, "<span class='warning'>You need one floor tile to build a floor!</span>")
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Attempt number two of #323 after errors came up during testing. This time the sunlight atom and sunlight state is copied from the previous turf and applied to the plating. The errors that appeared during my first attempt did not appear this time.

Placing a floor tile while in harm intent will keep the sunlight already present on the tile. Any other intent will not.


**EDIT: Further testing has revealed that any time a turf is updated/another turf is placed on top _(e.g. placing a new floor, building a wall, etc)_ the sunlight is ignored and not copied over. I'm going to leave this as a draft until I can figure out a better way of saving the sunlight of a turf, or determine if the only way is to edit every turf "place on top" changing proc** 

If I were to go ahead with my regular solution it would mean changing:
- proc for turning girders to walls
- proc for placing tiles (material tiles, regular tiles, pouring concrete, etc etc)
- any other proc involving the construction of walls (e.g. Rapid Construction Device)
- anything else that uses PlaceOnTop()


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When you are building outside, you don't always want to remove natural light or place lighting everywhere just for a new flooring. 

![Screenshot 2023-12-07 180246](https://github.com/f13babylon/f13babylon/assets/62829927/fc8a5069-a56a-46b6-9d72-6994cfa564b0)
Here you can see the areas which have kept the sunlight and those that haven't. The areas not in sunlight near the top are brighter as they are closer to a light on a wall.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
tweak: placing a floor tile while in harm intent will try and keep any natural sunlight present
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
