### PR TITLE
Restores A Costume

### DIFF
--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -90,17 +90,21 @@
 	icon_state = "bunnyhead"
 	item_state = "bunnyhead"
 	desc = "Considerably more cute than 'Frank'."
-	slowdown = -1
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+
+/obj/item/clothing/head/bunnyhead/fast
+	slowdown = -1
 
 /obj/item/clothing/suit/bunnysuit
 	name = "Easter Bunny Suit"
 	desc = "Hop Hop Hop!"
 	icon_state = "bunnysuit"
 	item_state = "bunnysuit"
-	slowdown = -1
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
+
+/obj/item/clothing/suit/bunnysuit/fast
+	slowdown = -1
 
 //Egg prizes and egg spawns!
 /obj/item/reagent_containers/food/snacks/egg

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -51,6 +51,8 @@
 						/obj/item/clothing/under/costume/griffin = 1,
 						/obj/item/clothing/shoes/griffin = 1,
 						/obj/item/clothing/head/griffin = 1,
+						/obj/item/clothing/suit/bunnysuit = 1,
+						/obj/item/clothing/head/bunnyhead = 1,
 						/obj/item/clothing/neck/apron/labor = 1,
 						/obj/item/clothing/under/suit/waiter = 1,
 						/obj/item/clothing/suit/jacket/miljacket = 1,


### PR DESCRIPTION
## About The Pull Request
![easter](https://github.com/f13babylon/f13babylon/assets/132588088/026f6361-e8c6-4e94-bad0-f58563a355af)

The Easter Bunny costume was lazily removed from costume vendors servers ago as it makes you really fast. What a shame for people who just enjoyed the costume (me) – this PR restores it without the speed, but adds a subtype that still has it if admins want to spawn it in and do that.

## Why It's Good For The Game
More content is good! The costume existed anyway.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog

:cl:
add: Restored a deleted costume to costume vendors.
/:cl: