### PR TITLE
This adds the smithed javelin to the spear quiver

### DIFF
--- a/code/modules/fallout/storage/backpack.dm
+++ b/code/modules/fallout/storage/backpack.dm
@@ -13,7 +13,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 7
-	CANHOLD_STATIC(STR, typecacheof(list(/obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola)))
+	CANHOLD_STATIC(STR, typecacheof(list(/obj/item/throwing_star/spear, /obj/item/melee/smith/javelin, /obj/item/restraints/legcuffs/bola)))
 
 /obj/item/storage/backpack/spearquiver/PopulateContents()
 	new /obj/item/throwing_star/spear(src)
@@ -36,7 +36,13 @@
 	if(L)
 		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_TAKE, L, user)
 		user.put_in_hands(L)
-		to_chat(user, "<span class='notice'>You take a spear out of the quiver.</span>")
+		to_chat(user, "<span class='notice'>You take a throwing spear out of the quiver.</span>")
+		return TRUE
+	var/obj/item/melee/smith/javelin/J = locate() in contents
+	if(J)
+		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_TAKE, J, user)
+		user.put_in_hands(J)
+		to_chat(user, "<span class='notice'>You take a javelin out of the quiver.</span>")
 		return TRUE
 	var/obj/item/restraints/legcuffs/W = locate() in contents
 	if(W && contents.len > 0)


### PR DESCRIPTION
## About The Pull Request

I make it so the spear quiver can hold the smithed javelin and alt+click also works for it.

## Why It's Good For The Game

Throwing is a valid strat

## Pre-Merge Checklist

- [Y] You tested this on a local server.
- [Y] This code did not runtime during testing.
- [Y] You documented all of your changes.

:cl:
tweak: Makes the javelin fit in the spear quiver
![image](https://github.com/f13babylon/f13babylon/assets/37029722/0a3d8876-a132-4353-9e1c-9a94ad9ba329)

:cl:
