### PR TITLE
fishing fix

### DIFF
--- a/code/modules/fishing/fishingrod.dm
+++ b/code/modules/fishing/fishingrod.dm
@@ -1,5 +1,6 @@
 GLOBAL_LIST_INIT(fish_rates, list(
 	/obj/item/fishy/carp		=15,
+	/obj/item/fishy/lobster		=15,
 	/obj/item/fishy/salmon		=15
 ))
 //I have tried to have variables be highly influential so that customization can happen
@@ -94,7 +95,7 @@ GLOBAL_LIST_INIT(fish_rates, list(
 				new /obj/item/salvage/low(current_turf)
 				if(prob(5))
 					new /obj/item/salvage/high(current_turf)
-				return 1			
+				return 1
 			return 2
 		if(TRUE)
 			var/pick_fish = pickweight(GLOB.fish_rates) //add your in the global list


### PR DESCRIPTION


## About The Pull Request

Re-adds lobster to the loot list of the fishing rod so several cooking recipes are usable again. I added this to other sunset forks and it works fine.

## Why It's Good For The Game

Makes several recipes accessible again

## Pre-Merge Checklist
- [ X] You tested this on a local server.
- [ X] This code did not runtime during testing.
- [ X] You documented all of your changes.

For the love of god don't make me take a screenshot when I changed a single line of code

## Changelog

:cl:

tweak: tweaked a few things
/:cl:

