### PR TITLE
Slightly Less Grindset/Anti-Skinwalker Patch for Followers: Some Map Changes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -2836,7 +2836,7 @@
 /obj/machinery/light/small,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full/engi,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
 "uv" = (

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -273,6 +273,9 @@
 "cs" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /obj/effect/turf_decal/bot,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/ore/blackpowder/five,
+/obj/item/stack/ore/blackpowder/five,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave/armory)
 "ct" = (
@@ -536,6 +539,10 @@
 /obj/item/clothing/shoes/combat/coldres,
 /obj/item/clothing/shoes/combat/coldres,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
+/obj/item/storage/belt/holster,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave/armory)
 "ej" = (
@@ -888,6 +895,7 @@
 /obj/item/clothing/head/helmet/f13/combat/enclave,
 /obj/item/storage/belt/military,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/belt/military,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave/armory)
 "gY" = (
@@ -2054,6 +2062,7 @@
 /obj/item/clothing/head/helmet/f13/combat/enclave,
 /obj/item/storage/belt/military,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/belt/military,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave/armory)
 "pd" = (
@@ -2382,9 +2391,12 @@
 /area/f13/enclave)
 "ry" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/metal/ten,
-/obj/item/stack/sheet/glass/ten,
 /obj/item/storage/part_replacer,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/glass/ten,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/enclave/rnd)
 "rB" = (
@@ -2822,6 +2834,9 @@
 "uu" = (
 /obj/structure/rack,
 /obj/machinery/light/small,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
 "uv" = (
@@ -3802,7 +3817,6 @@
 "Bw" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/abductor/ten,
-/obj/item/storage/belt/utility/full/engi,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
 "BC" = (
@@ -4447,6 +4461,8 @@
 "GG" = (
 /obj/machinery/autolathe/hacked,
 /obj/effect/turf_decal/bot,
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave/armory)
 "GH" = (
@@ -4861,8 +4877,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
 "Jx" = (
+/obj/item/storage/money_stack,
 /turf/open/floor/f13,
-/area/f13/enclave)
+/area/f13/enclave/armory)
 "Jy" = (
 /obj/structure/decoration/clock{
 	pixel_y = 30
@@ -5553,6 +5570,14 @@
 "Pr" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Ps" = (
+/obj/structure/table,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -32;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/area/f13/enclave/medbay)
 "Pt" = (
 /obj/structure/table/reinforced,
 /obj/item/cigbutt/cigarbutt,
@@ -5597,6 +5622,21 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/enclave/prison)
+"PK" = (
+/obj/machinery/button/door{
+	id = "pneumatic_door2";
+	name = "Primary Blastdoor";
+	pixel_x = 30;
+	pixel_y = -5
+	},
+/obj/machinery/button/door{
+	id = "pneumatic_door2t";
+	name = "Outer Blastdoor";
+	pixel_x = 30;
+	pixel_y = 5
+	},
+/turf/open/floor/f13,
+/area/f13/enclave/command)
 "PM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/junk/small/table,
@@ -15059,10 +15099,10 @@ TI
 TI
 AW
 Tm
-Jx
+Gh
 Qx
-Jx
-Jx
+Gh
+Gh
 AW
 mH
 tI
@@ -15072,11 +15112,11 @@ tI
 tI
 RW
 mA
-Jx
-Jx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
+Gh
+Gh
 mA
 mA
 mA
@@ -15315,11 +15355,11 @@ TI
 TI
 TI
 AW
-Jx
+Gh
 oO
 oO
 oO
-Jx
+Gh
 AW
 hT
 tI
@@ -15329,11 +15369,11 @@ tI
 tI
 ks
 mA
-Jx
+Gh
 Sx
 Sx
 Sx
-Jx
+Gh
 SB
 of
 mA
@@ -15572,11 +15612,11 @@ Rb
 Rb
 vX
 AW
-Jx
+Gh
 WT
 UX
 JE
-Jx
+Gh
 AW
 hs
 tI
@@ -15586,11 +15626,11 @@ tI
 tI
 zL
 mA
-Jx
-Jx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
+Gh
+Gh
 Jw
 of
 mA
@@ -15829,11 +15869,11 @@ TI
 TI
 TI
 AW
-Jx
+Gh
 wI
 Pt
 zG
-Jx
+Gh
 AW
 vG
 tI
@@ -15843,11 +15883,11 @@ OZ
 tI
 zq
 mA
-Jx
+Gh
 Sx
 Sx
 Sx
-Jx
+Gh
 mA
 mA
 mA
@@ -16086,25 +16126,25 @@ Rb
 Rb
 TI
 AW
-Jx
+Gh
 oO
 PO
 oO
-Jx
+Gh
 AW
 nb
 Bf
 DJ
-Jx
+Gh
 Pa
 Bf
 yJ
 mA
-Jx
-Jx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
+Gh
+Gh
 mA
 uo
 cl
@@ -16343,25 +16383,25 @@ TI
 TI
 TI
 AW
-Jx
-Jx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
+Gh
+Gh
 AW
 fq
 Sx
-Jx
+Gh
 Ko
-Jx
+Gh
 Sx
 HP
 mA
-Jx
+Gh
 Sx
 Sx
 Sx
-Jx
+Gh
 mA
 Ny
 Ny
@@ -16608,17 +16648,17 @@ AW
 AW
 fq
 Sx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
 Sx
 HP
 mA
-Jx
-Jx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
+Gh
+Gh
 mA
 KA
 Ny
@@ -16865,17 +16905,17 @@ FX
 AW
 fq
 Sx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
 Sx
 HP
 mA
-Jx
+Gh
 Sx
 Sx
 Sx
-Jx
+Gh
 mA
 Su
 Ny
@@ -17129,9 +17169,9 @@ PF
 zE
 mA
 DU
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
 DU
 mA
 yE
@@ -18417,7 +18457,7 @@ JF
 JF
 AW
 vH
-Jx
+Gh
 AW
 Yg
 AW
@@ -18665,7 +18705,7 @@ AW
 Dz
 dz
 Dz
-Jx
+Gh
 At
 qI
 lk
@@ -18922,8 +18962,8 @@ AW
 oO
 oO
 oO
-Jx
-Jx
+Gh
+Gh
 kh
 bw
 AW
@@ -18931,14 +18971,14 @@ JF
 JF
 AW
 vH
-Jx
+Gh
 gp
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
 At
-Jx
-Jx
+Gh
+Gh
 gp
 JF
 JF
@@ -19170,11 +19210,11 @@ TI
 TI
 TI
 AW
-Jx
-Jx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
+Gh
+Gh
 AW
 oO
 im
@@ -19188,14 +19228,14 @@ JF
 JF
 AW
 vH
-Jx
+Gh
 AW
 ox
 ox
 ox
 ox
-Jx
-Jx
+Gh
+Gh
 tw
 JF
 JF
@@ -19427,11 +19467,11 @@ iA
 UU
 TI
 AW
-Jx
+Gh
 oO
 Sy
 oO
-Jx
+Gh
 AW
 oO
 oO
@@ -19684,11 +19724,11 @@ TI
 TI
 TI
 AW
-Jx
+Gh
 wI
 ax
 mx
-Jx
+Gh
 AW
 oO
 ay
@@ -19941,11 +19981,11 @@ tk
 XD
 vX
 AW
-Jx
+Gh
 WT
 hP
 kz
-Jx
+Gh
 AW
 oO
 oO
@@ -20198,11 +20238,11 @@ TI
 TI
 TI
 AW
-Jx
+Gh
 oO
 oO
 oO
-Jx
+Gh
 AW
 oO
 ay
@@ -20455,19 +20495,19 @@ LU
 sa
 TI
 AW
-Jx
-Jx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
+Gh
+Gh
 AW
 oO
 oO
 oO
-Jx
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
+Gh
 ml
 JF
 Id
@@ -20716,15 +20756,15 @@ Tm
 ax
 sh
 ax
-Jx
+Gh
 AW
-Jx
+Gh
 It
 uq
-Jx
+Gh
 TX
 oj
-Jx
+Gh
 AW
 JF
 IE
@@ -23834,9 +23874,9 @@ Zx
 AW
 AW
 PC
-Jx
+Gh
 At
-Jx
+Gh
 AW
 SP
 SP
@@ -24091,8 +24131,8 @@ JF
 np
 AW
 Jm
-Jx
-Jx
+Gh
+Gh
 Ks
 AW
 kn
@@ -24347,9 +24387,9 @@ JF
 JF
 JF
 Gr
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
 uL
 FG
 SP
@@ -24605,8 +24645,8 @@ JF
 JF
 AW
 Rj
-Jx
-Jx
+Gh
+Gh
 Vd
 gk
 CK
@@ -24861,9 +24901,9 @@ JF
 JF
 JF
 Gr
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
 yr
 FG
 SP
@@ -25118,9 +25158,9 @@ hG
 sO
 JF
 AW
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
 Ks
 AW
 SP
@@ -25343,7 +25383,7 @@ sg
 FJ
 zK
 AW
-fl
+Jx
 Ot
 vJ
 AW
@@ -25363,7 +25403,7 @@ Qp
 rf
 hp
 hR
-Se
+Ps
 AW
 AW
 JF
@@ -25376,9 +25416,9 @@ AW
 AW
 AW
 uR
-Jx
-Jx
-Jx
+Gh
+Gh
+Gh
 AW
 SP
 SP
@@ -25633,8 +25673,8 @@ hz
 Jb
 AW
 zW
-Jx
-Jx
+Gh
+Gh
 hq
 AW
 HT
@@ -25890,8 +25930,8 @@ RF
 DI
 AW
 sH
-Jx
-Jx
+Gh
+Gh
 tY
 AW
 uv
@@ -26148,8 +26188,8 @@ MV
 og
 Gh
 wa
-Jx
-Jx
+Gh
+Gh
 AW
 SP
 kn
@@ -27419,7 +27459,7 @@ AW
 Yv
 Ii
 hz
-hz
+PK
 hz
 Ir
 JF

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -4769,6 +4769,9 @@
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = 32
 	},
+/obj/item/radio/headset/headset_followers,
+/obj/item/radio/headset/headset_followers,
+/obj/item/radio/headset/headset_followers,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -6563,14 +6566,14 @@
 	},
 /area/f13/tunnel)
 "emK" = (
-/obj/structure/rack/shelf_metal,
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/machinery/light,
+/obj/structure/guncase{
+	anchored = 1
+	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -7139,7 +7142,8 @@
 "fqy" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/medical1{
-	anchored = 1
+	anchored = 1;
+	req_one_access_txt = "124"
 	},
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/o2,
@@ -8551,7 +8555,7 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 1
 	},
-/obj/machinery/mineral/wasteland_vendor/pipboy,
+/obj/machinery/vending/snack/blue,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -8950,10 +8954,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/guncase{
-	anchored = 1
-	},
 /obj/effect/turf_decal/delivery/white,
+/obj/item/storage/money_stack,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -8998,6 +9000,8 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
@@ -9899,6 +9903,10 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
+/obj/item/stack/ore/blackpowder/five,
+/obj/item/stack/ore/blackpowder/five,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/sheet/metal/five,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
@@ -10275,11 +10283,19 @@
 /area/f13/tunnel)
 "lDM" = (
 /obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
+/obj/effect/spawner/bundle/f13/n99,
+/obj/effect/spawner/bundle/f13/n99,
+/obj/effect/spawner/bundle/f13/n99,
+/obj/effect/spawner/bundle/f13/n99,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -10589,7 +10605,11 @@
 	dir = 1;
 	light_color = "#706891"
 	},
-/obj/item/kirbyplants/random,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 2
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -10763,6 +10783,10 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -13815,7 +13839,7 @@
 /area/f13/building)
 "spx" = (
 /obj/machinery/door/airlock/medical{
-	name = "Clinic Morgue";
+	name = "Clinic Research";
 	req_one_access_txt = "124"
 	},
 /obj/effect/turf_decal/stripes/white/corner{
@@ -13946,6 +13970,8 @@
 /obj/item/stack/sheet/glass/ten,
 /obj/item/stack/sheet/mineral/wood/twenty,
 /obj/item/storage/belt/utility/full,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/ten,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -15635,6 +15661,12 @@
 	dir = 8
 	},
 /obj/structure/closet,
+/obj/item/clothing/under/f13/followers,
+/obj/item/clothing/under/f13/followers,
+/obj/item/clothing/under/f13/followers,
+/obj/item/clothing/suit/hooded/followerlight,
+/obj/item/clothing/suit/hooded/followerlight,
+/obj/item/clothing/suit/hooded/followerlight,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -15656,24 +15688,6 @@
 /obj/machinery/reagentgrinder/constructed,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
-"vPI" = (
-/obj/structure/guncase{
-	anchored = 1
-	},
-/obj/effect/spawner/bundle/f13/smg10mm,
-/obj/effect/spawner/bundle/f13/n99,
-/obj/effect/spawner/bundle/f13/n99,
-/obj/effect/spawner/bundle/f13/n99,
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
 	},
 /area/f13/followers)
 "vQn" = (
@@ -16014,8 +16028,8 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -36419,7 +36433,7 @@ qkc
 jsU
 yle
 yle
-vPI
+yle
 wml
 yle
 yle

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -361,9 +361,6 @@
 /area/f13/wasteland)
 "abp" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
@@ -814,9 +811,6 @@
 /area/f13/city/bighorn)
 "acZ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
@@ -862,9 +856,6 @@
 /area/f13/building/hospital)
 "adx" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
@@ -1795,9 +1786,6 @@
 /area/f13/city/bighorn)
 "bEx" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -5388,9 +5376,6 @@
 /area/f13/building/mall)
 "icS" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -7232,9 +7217,6 @@
 /area/f13/building/hospital)
 "lqH" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
@@ -12659,9 +12641,6 @@
 /area/f13/followers)
 "ulq" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
@@ -14401,9 +14380,6 @@
 /area/f13/building/mall)
 "xzm" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -14522,12 +14498,9 @@
 	},
 /area/f13/followers)
 "xGw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "floorrusty"
 	},
 /area/f13/followers)
 "xGW" = (
@@ -30543,8 +30516,8 @@ reH
 kse
 reH
 reH
-reH
-reH
+deg
+vfQ
 rqH
 oez
 oez
@@ -30799,8 +30772,8 @@ rqH
 rqH
 rqH
 reH
+reH
 deg
-vfQ
 vfQ
 rqH
 oez
@@ -31056,9 +31029,9 @@ reH
 mpI
 rqH
 reH
-deg
-vfQ
-vfQ
+reH
+qBC
+aED
 rqH
 oez
 vqz
@@ -31313,8 +31286,8 @@ nnr
 reH
 kse
 reH
-qBC
-aED
+reH
+reH
 rqH
 rqH
 oez
@@ -34650,13 +34623,13 @@ oez
 rqH
 adx
 kpx
-xGw
+xzm
 kpx
-xGw
+xzm
 kpx
-xGw
+xzm
 kpx
-xGw
+xzm
 rqH
 abc
 abc
@@ -35425,7 +35398,7 @@ dQN
 iVC
 reH
 rnx
-reH
+xGw
 dfn
 weR
 rqH

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -27455,6 +27455,15 @@
 	icon_state = "topshadowleft"
 	},
 /area/f13/wasteland/east)
+"ejT" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/followers)
 "ekc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 9;
@@ -86823,7 +86832,7 @@ jgV
 yjm
 lsP
 blo
-lsP
+ifH
 gZn
 sub
 ydE
@@ -88621,7 +88630,7 @@ aoK
 ubz
 yjm
 lsP
-lsP
+vwZ
 yjm
 bXI
 aZp
@@ -89135,7 +89144,7 @@ dFh
 dFh
 bwB
 lsP
-vwZ
+lsP
 yjm
 yjm
 pat
@@ -89648,8 +89657,8 @@ dFh
 dFh
 vgM
 yjm
-lsP
-lsP
+ejT
+vwZ
 yjm
 yjm
 pat

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -4411,6 +4411,8 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/waster,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "arx" = (
@@ -13626,6 +13628,13 @@
 "aWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/metal/five,
 /turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
 "aWE" = (
@@ -17969,7 +17978,10 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "blo" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/door/airlock/medical{
+	name = "Clinic Upper Levels";
+	req_one_access_txt = "124"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -18040,6 +18052,7 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
+/obj/item/stack/f13Cash/random/med,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "blG" = (
@@ -21419,17 +21432,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
-"bRQ" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "followersdeskshutters";
-	name = "followers shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "bRT" = (
 /obj/machinery/door/airlock/hatch{
 	req_access_txt = "120"
@@ -21821,13 +21823,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/bighorn)
-"bWT" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "bXc" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -21900,14 +21895,6 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland/bighorn)
-"bYc" = (
-/obj/structure/curtain{
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "bluerustysolid"
-	},
-/area/f13/followers)
 "bYh" = (
 /obj/item/candle/tribal_torch{
 	anchored = 1;
@@ -24473,6 +24460,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/junk,
+/obj/item/stack/f13Cash/random/med,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "cKT" = (
@@ -24549,11 +24537,9 @@
 	},
 /area/f13/building/mall)
 "cMS" = (
-/obj/machinery/door/airlock/glass_large{
-	id_tag = "followersfrontdoor";
-	name = "Followers Clinic";
-	req_one_access_txt = "124";
-	unres_sides = 2
+/obj/machinery/door/airlock/medical{
+	name = "Clinic Reception";
+	req_one_access_txt = "124"
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "followershutters";
@@ -28233,7 +28219,9 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood)
 "eCZ" = (
-/obj/structure/stairs/west,
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -35430,6 +35418,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"idV" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "iea" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -36765,13 +36761,9 @@
 	},
 /area/f13/wasteland/massfusion)
 "iJL" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
-	},
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "followersdeskshutters";
-	name = "followers shutters"
+/obj/machinery/door/airlock/medical{
+	name = "Clinic Lower Levels";
+	req_one_access_txt = "124"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -37900,15 +37892,13 @@
 	},
 /area/f13/wasteland/quarry)
 "jgV" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = -30
 	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -40371,6 +40361,9 @@
 "kxn" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/autolathe/ammo/unlocked,
+/obj/item/stack/ore/blackpowder/five,
+/obj/item/stack/ore/blackpowder/five,
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -40837,6 +40830,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/ore/blackpowder/five,
+/obj/item/stack/ore/blackpowder/five,
 /turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
 "kHQ" = (
@@ -42205,7 +42201,6 @@
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_red,
 /obj/item/storage/belt/utility/full,
@@ -43357,9 +43352,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/museum)
 "lNs" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "followershutters";
-	name = "followers shutters"
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/obj/structure/decoration/smokeold{
+	pixel_y = -30
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -43834,9 +43831,6 @@
 /area/f13/wasteland/west)
 "lWu" = (
 /obj/structure/chair/office,
-/obj/structure/curtain{
-	pixel_y = 32
-	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -45468,6 +45462,8 @@
 "mJb" = (
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
 "mJh" = (
@@ -48425,6 +48421,12 @@
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
+"ocw" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "ocG" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -55491,9 +55493,14 @@
 	},
 /area/f13/brotherhood)
 "rky" = (
-/obj/structure/table,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters{
+	id = "followershutters";
+	name = "followers shutters"
+	},
 /turf/open/floor/f13{
-	icon_state = "bluerustysolid"
+	icon_state = "floorrusty"
 	},
 /area/f13/followers)
 "rkB" = (
@@ -58276,6 +58283,11 @@
 /area/f13/radiation)
 "sCm" = (
 /obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/item/stack/ore/blackpowder/five,
+/obj/item/stack/ore/blackpowder/five,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "sCp" = (
@@ -62479,9 +62491,6 @@
 	},
 /area/f13/wasteland/massfusion)
 "uxW" = (
-/obj/structure/curtain{
-	pixel_x = 32
-	},
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
@@ -63980,6 +63989,12 @@
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/west)
+"vgM" = (
+/obj/structure/bed/roller,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/followers)
 "vhp" = (
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland/quarry)
@@ -67828,15 +67843,7 @@
 	},
 /area/f13/wasteland/east)
 "wTH" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = "followersdeskshutters";
-	name = "followers shutters"
-	},
+/obj/structure/stairs/west,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -68835,14 +68842,6 @@
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
-"xuD" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/followers)
 "xuH" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -69584,6 +69583,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
+/obj/item/stack/sheet/glass/ten,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "xLT" = (
@@ -86045,10 +86045,10 @@ ykl
 bUV
 puU
 oyS
+eCZ
 xuj
 xuj
-xuj
-xuj
+lNs
 yjm
 bsL
 yjm
@@ -86309,7 +86309,7 @@ lsP
 cMS
 lsP
 yjm
-yjm
+wTH
 yjm
 ydE
 ydE
@@ -86563,10 +86563,10 @@ lsP
 qrc
 qrc
 lsP
-lNs
+rky
 lsP
-eCZ
-eCZ
+yjm
+lsP
 yjm
 gbX
 ydE
@@ -86822,7 +86822,7 @@ lsP
 jgV
 yjm
 lsP
-lsP
+blo
 lsP
 gZn
 sub
@@ -87079,8 +87079,8 @@ aqa
 yjm
 hDC
 lsP
-lsP
-xuD
+yjm
+yjm
 yjm
 bVI
 puU
@@ -88357,7 +88357,7 @@ bwj
 sub
 byg
 haK
-bWT
+yjm
 lWu
 qop
 dFh
@@ -89129,13 +89129,13 @@ rrO
 aoI
 bzd
 yjm
-dFh
+ocw
 qpv
-rky
-rky
-yjm
+dFh
+dFh
+bwB
 lsP
-lsP
+vwZ
 yjm
 yjm
 pat
@@ -89386,13 +89386,13 @@ rrO
 twV
 bze
 yjm
+ocw
 dFh
 dFh
 dFh
-dFh
-bwB
-lsP
-vwZ
+yjm
+iJL
+iJL
 yjm
 yjm
 pat
@@ -89642,12 +89642,12 @@ bta
 sub
 byt
 bze
-bRQ
-bYc
+yjm
+idV
 dFh
 dFh
-dFh
-blo
+vgM
+yjm
 lsP
 lsP
 yjm
@@ -89899,8 +89899,8 @@ boY
 sub
 twV
 qqG
-bRQ
-bYc
+yjm
+idV
 dFh
 dFh
 dFh
@@ -91186,8 +91186,8 @@ bWS
 ydE
 yjm
 yjm
-wTH
-iJL
+yjm
+yjm
 yjm
 yjm
 rjo

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -294,6 +294,8 @@
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/glass/ten,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
 "amr" = (
@@ -22676,6 +22678,13 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
+"wpg" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/waster,
+/obj/item/storage/belt/utility/waster,
+/turf/open/floor/plasteel/f13/stone/rugged,
+/area/f13/legion)
 "wps" = (
 /obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -41923,7 +41932,7 @@ lvP
 fCY
 jLa
 kEh
-hAL
+wpg
 gtX
 hAL
 jLa

--- a/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
@@ -2474,6 +2474,9 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "FF" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Adds a bit more metal and glass to round-start for the factions, along with a bit of gunpowder.

Adds a couple of full tool-belts to factions (Tech-level respected, Khans get a shit belt and a good belt, Legion get 2 shit belts and a good one, etc.)

Adds a defib to Enclave medical, along with a couple of shoulder holsters and a pay-safe to the armory.

Implemented Praxis' suggestions for Followers to counteract shitters and improve QoL.

New map won't be for some time, so this should alleviate some problems that have been observed/reported.

![strongdmm-v2 11 0 alpha-x86_64-pc-windows-gnu_gHjFUVGF7y](https://github.com/f13babylon/f13babylon/assets/93478960/9c9c7b40-fa51-4294-b541-c581d4a588ad)
![strongdmm-v2 11 0 alpha-x86_64-pc-windows-gnu_FCHqBGSq8a](https://github.com/f13babylon/f13babylon/assets/93478960/b1df400f-c44c-425b-be2c-1dc2b617c91d)
![dreamseeker_VEyVpkVgoC](https://github.com/f13babylon/f13babylon/assets/93478960/72cb320f-5363-45ec-8acd-e358a32e43b7)
![strongdmm-v2 11 0 alpha-x86_64-pc-windows-gnu_ECWrh3wjWW](https://github.com/f13babylon/f13babylon/assets/93478960/10ca9d48-40cd-437d-b646-a80a59666f63)


## Why It's Good For The Game

Less round-start rush for some resources, able to get some ammo. Good for factions that may have no pop, and people late-join to find all their usual salvaging/mining gone.

If the designated engineers don't join for factions, the tool-belts along with the extra metal/glass can be a big help.

Enclave didn't have a defib for some reason, weird. Added pay-safe because money is cool. Shoulder holsters incase people who go undercover don't feel like getting metafucked because someone looked at their leg holster and screamed Enclave.

Followers getting shit on by Piggerton Fuckerson III because they have a giant double door can get old, and random raiders rushing in to steal stuff by abusing game mechanics is bad. QoL changes are always good.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: A lot of map changes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
