### PR TITLE
Fixes Welding Helmet Variants

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -10775,6 +10775,17 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/raiders)
+"keU" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/welding/f13/japan,
+/turf/open/floor/f13{
+	color = "#818181";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/city)
 "keZ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/suit/bio_suit/f13/hazmat,
@@ -11695,11 +11706,11 @@
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
 	},
-/obj/item/clothing/head/welding/f13/fire,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/item/clothing/head/welding/f13/fire,
 /turf/open/floor/f13{
 	color = "#818181";
 	icon_state = "floorrustysolid"
@@ -28429,7 +28440,7 @@ uUe
 wPk
 vaY
 aUa
-vHx
+keU
 laX
 abG
 eQA

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -11695,7 +11695,7 @@
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
 	},
-/obj/item/clothing/head/welding/weldingfire,
+/obj/item/clothing/head/welding/f13/fire,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -315,9 +315,19 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
-/datum/crafting_recipe/salvageweld
-	name = "Salvaged Welding Mask"
+/datum/crafting_recipe/salvageweldfire
+	name = "Salvaged Welding Mask - Cremator"
 	result = /obj/item/clothing/head/welding/f13/fire
+	time = 600
+	reqs = list(/obj/item/stack/sheet/metal = 4,
+				/obj/item/stack/sheet/cloth = 1)
+	tools = list(TOOL_FORGE)
+	category = CAT_CLOTHING
+	subcategory = CAT_ARMOR
+
+/datum/crafting_recipe/salvageweldjapan
+	name = "Salvaged Welding Mask - Oriental"
+	result = /obj/item/clothing/head/welding/f13/japan
 	time = 600
 	reqs = list(/obj/item/stack/sheet/metal = 4,
 				/obj/item/stack/sheet/cloth = 1)

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -870,12 +870,21 @@
 	icon_state = "jasonmask"
 	item_state = "jasonmask"
 
+/obj/item/clothing/head/welding/f13 //dont use
+	icon_state = ""
+	mutantrace_variation = null
+
 /obj/item/clothing/head/welding/f13/fire
 	name = "cremator welding helmet"
 	desc = "A welding helmet with flames painted on it.<br>It sure is creepy but also badass."
 	icon_state = "welding_fire"
-	item_state = "welding"
-	tint = 1
+	item_state = "welding_fire"
+
+/obj/item/clothing/head/welding/f13/japan
+	name = "oriental welding helmet"
+	desc = "A welding helmet with a white and red oriental design."
+	icon_state = "welding_japan"
+	item_state = "welding_japan"
 
 /obj/item/clothing/head/helmet/f13/atombeliever
 	name = "believer headdress"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -107,7 +107,7 @@
 		src.item_state = "ushankadown"
 		earflaps = 1
 		to_chat(user, "<span class='notice'>You lower the ear flaps on the ushanka.</span>")
-	
+
 /*
  * Black Ushanka
  */
@@ -204,15 +204,6 @@
 /obj/item/clothing/head/cardborg/dropped(mob/living/user)
 	..()
 	user.remove_alt_appearance("standard_borg_disguise")
-
-
-/obj/item/clothing/head/welding/weldingfire
-	icon_state = "weldingfire"
-	item_state = "weldingfire"
-
-/obj/item/clothing/head/welding/weldingjapan
-	icon_state = "weldingjapan"
-	item_state = "weldingjapan"
 
 /obj/item/clothing/head/wig
 	name = "wig"


### PR DESCRIPTION
## About The Pull Request
Fixed some issues with the two variant skins for the welding helmet.

- They both had no sprite when you were a furry, fixed.
- They both existed under two different file paths, so the non-F13 ones were removed.
- The one with the japanese skin was completely unobtainable, now it has a recipe like the flame version. Also added an instance of it to the map next to one of the flame ones.
- They didn't have the obscuring vision effect of the regular welding helmet, but still had the same flash protection, which made them (probably unintentionally) much superior versions. Now they're the same as their parent.

## Why It's Good For The Game
We kill bugs around here.+

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
add: New oriental welding helmet recipe.
fix: Fixed some visual bugs with welding helmet sprites.
/:cl: