### PR TITLE
Fixes Sprite Issues

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -266,6 +266,7 @@
 	name = "telescopic shield"
 	desc = "An advanced riot shield made of lightweight materials that collapses for easy storage."
 	icon_state = "teleriot0"
+	item_state = "teleriot0"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	slot_flags = null
@@ -287,6 +288,7 @@
 /obj/item/shield/riot/tele/attack_self(mob/living/user)
 	active = !active
 	icon_state = "teleriot[active]"
+	item_state = "teleriot[active]"
 	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, TRUE)
 	if(active)
 		force = 8

--- a/code/modules/clothing/shoes/f13.dm
+++ b/code/modules/clothing/shoes/f13.dm
@@ -103,7 +103,7 @@
 /obj/item/clothing/shoes/f13/military/desert
 	name = "desert combat boots"
 	desc = "An old pair of desert combat boots. This one seems to have a tighter fit, and a padded interior."
-	icon_state = "erin_boot"
+	icon_state = "laced"
 	item_state = "erin_boot"
 
 /obj/item/clothing/shoes/f13/military/oldserviceboots

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -242,11 +242,12 @@
 	desc = "My star, my perfect silence."
 	icon = 'icons/fallout/clothing/hats.dmi'
 	icon_state = "hazmat"
-	item_state = "hazmat_helmet"
+	item_state = "hazmat"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	resistance_flags = ACID_PROOF
 	armor = list("melee" = 30, "bullet" = 10, "laser" = 30, "energy" = 25, "bomb" = 16, "bio" = 100, "rad" = 100, "fire" = 35, "acid" = 100)
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	mutantrace_variation = null
 
 //Fallout 13 toggle apparel directory
 /obj/item/clothing/suit/toggle/labcoat/f13/emergency

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -230,7 +230,7 @@
 	can_remove = 0
 	can_charge = 0
 	selfcharge = 1
-	icon_state = "rechargerpistol"
+	icon_state = "wattz1000"
 	icon = 'icons/obj/guns/gunfruits2022/energy.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 	weapon_weight = WEAPON_MEDIUM
@@ -297,7 +297,7 @@
 	slowdown = 0.05
 	equipsound = 'sound/f13weapons/equipsounds/aer14equip.ogg'
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/hitscan/pewpew)
-	
+
 ////////////////
 //LASER RIFLES//
 ////////////////

--- a/modular_citadel/code/modules/custom_loadout/custom_items.dm
+++ b/modular_citadel/code/modules/custom_loadout/custom_items.dm
@@ -94,6 +94,7 @@
 	item_state = "stalker"
 	mob_overlay_icon = 'icons/mob/clothing/custom_w.dmi'
 	icon_state = "stalker"
+	mutantrace_variation = null
 
 /obj/item/reagent_containers/food/drinks/flask/steel
 	name = "The End"


### PR DESCRIPTION
## About The Pull Request
Fixes some sprite issues, some of which have existed since the start of Sunset, to my shame.

- Hazmat hood now has working worn sprites.
- STALKER mask now has a working worn sprite when furry.
- Telescopic riot shield now has working worn sprites (that change on tele toggle as well, like the icon).
- Recharger Pistol now has an icon. @Draganfrukts I'm unsure if there's a missing recharger pistol sprite in your update - as a placeholder(?) it has the sprite of the Wattz.
- Desert combat boots now have an icon. (Reuses the laced one, which I notice some other codebases have done - there isn't an original icon state for this like the item state)

## Why It's Good For The Game
Working sprites are great, these were the source of a few bug reports.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed sprite issues with a few objects.
/:cl:
