### PR TITLE
Makes Flypeople Viable

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -182,18 +182,14 @@
 	random_icon_states = list("vomit_1", "vomit_2", "vomit_3", "vomit_4")
 	beauty = -150
 
+
 /obj/effect/decal/cleanable/vomit/on_attack_hand(mob/user, act_intent = user.a_intent, unarmed_attack_flags)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(isflyperson(H))
 			playsound(get_turf(src), 'sound/items/drink.ogg', 50, 1) //slurp
 			H.visible_message("<span class='alert'>[H] extends a small proboscis into the vomit pool, sucking it with a slurping sound.</span>")
-			if(reagents)
-				for(var/datum/reagent/consumable/R in reagents.reagent_list)
-					if(R.nutriment_factor > 0)
-						H.adjust_nutrition(R.nutriment_factor * R.volume)
-						reagents.del_reagent(R.type)
-			reagents.trans_to(H, reagents.total_volume)
+			H.adjust_nutrition(10)
 			qdel(src)
 
 /obj/effect/decal/cleanable/vomit/old

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -500,7 +500,7 @@
 	if(HAS_TRAIT(src, TRAIT_NOHUNGER))
 		return 1
 
-	if(nutrition < 100 && !blood)
+	if(nutrition < 100 && !blood && !isflyperson(src))
 		if(message)
 			visible_message("<span class='warning'>[src] dry heaves!</span>", \
 							"<span class='userdanger'>You try to throw up, but there's nothing in your stomach!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -24,9 +24,6 @@
 		if(nutri_check.nutriment_factor > 0)
 			var/turf/pos = get_turf(H)
 			H.vomit(0, FALSE, FALSE, 2, TRUE)
-			var/obj/effect/decal/cleanable/vomit/V = locate() in pos
-			if(V)
-				H.reagents.trans_id_to(V, chem.type, chem.volume)
 			playsound(pos, 'sound/effects/splat.ogg', 50, 1)
 			H.visible_message("<span class='danger'>[H] vomits on the floor!</span>", \
 						"<span class='userdanger'>You throw up on the floor!</span>")


### PR DESCRIPTION
## About The Pull Request
The flyperson race was basically a death sentence for two reasons:
1. Flypeople gain no nutrients and just vomit upon eating normal food, but eating the vomit then gets the nutrients they need. _Or is supposed to._ Despite a lot of fancy code vomit gave them no nutrients at all.
2. When flypeople begin (due to the first issue, inevitably) starving to death, they can't vomit at all and can only dry heave, which means that even if vomit did give nutrients they'd be unable to make any and would be in deep trouble. This led to a dry heaving death spiral that was hilarious but silly.
![image](https://github.com/f13babylon/f13babylon/assets/132588088/f19bdbdb-e566-4b0c-9f6d-09c0cf051db4)

The new code is much less elegant but actually works. tl;dr vomit now gives a flat nutrient amount (only flypeople can eat it anyway) and the dry heave mechanic is skipped if you're a flyperson.

## Why It's Good For The Game
This race is actually playable now. I imagine this would have been caught sooner but only one weirdo wants to play them. Well I hope they are happy. : )

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixes flyperson hunger mechanics.
/:cl:
