### PR TITLE
Adds the ability to construct (non-radioactive) water turfs, adjusts crafting code to allow the crafting of turfs.

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -210,6 +210,12 @@
 			if(!check_tools(a, R, contents))
 				return ", missing tool."
 			var/list/parts = del_reqs(R, a)
+
+			if(ispath(R.result, /turf))
+				var/turf/T = usr.drop_location()
+				T.PlaceOnTop(R.result, flags = CHANGETURF_INHERIT_AIR)
+				return R.result
+
 			var/atom/movable/I = new R.result (get_turf(a.loc))
 			I.CheckParts(parts, R)
 			if(send_feedback)
@@ -425,7 +431,7 @@
 			if(!istext(result)) //We made an item and didn't get a fail message
 				if(ismob(user) && isitem(result)) //In case the user is actually possessing a non mob like a machine
 					user.put_in_hands(result)
-				else
+				else if(!ispath(result, /turf))
 					result.forceMove(user.drop_location())
 				to_chat(user, "<span class='notice'>[TR.name] constructed.</span>")
 			else

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -13,7 +13,7 @@
 /////////////////
 
 /datum/crafting_recipe/river_water
-	name = "river water"
+	name = "River water"
 	result = /turf/open/indestructible/ground/outside/water
 	reqs = list(/datum/reagent/water = 200)
 	tools = list(TOOL_SHOVEL)

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -17,7 +17,7 @@
 	result = /turf/open/indestructible/ground/outside/water/no_rads
 	reqs = list(/datum/reagent/water = 200)
 	tools = list(TOOL_SHOVEL)
-	time = 200
+	time = 20 SECONDS
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -14,7 +14,7 @@
 
 /datum/crafting_recipe/river_water
 	name = "River water"
-	result = /turf/open/indestructible/ground/outside/water
+	result = /turf/open/indestructible/ground/outside/water/no_rads
 	reqs = list(/datum/reagent/water = 200)
 	tools = list(TOOL_SHOVEL)
 	time = 400

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -17,7 +17,7 @@
 	result = /turf/open/indestructible/ground/outside/water/no_rads
 	reqs = list(/datum/reagent/water = 200)
 	tools = list(TOOL_SHOVEL)
-	time = 400
+	time = 200
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -12,6 +12,15 @@
 //Large Objects//
 /////////////////
 
+/datum/crafting_recipe/river_water
+	name = "river water"
+	result = /turf/open/indestructible/ground/outside/water
+	reqs = list(/datum/reagent/water = 200)
+	tools = list(TOOL_SHOVEL)
+	time = 400
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+
 /datum/crafting_recipe/ncrgate
 	name = "NCR reinforced door"
 	result = /obj/machinery/door/unpowered/secure_NCR

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -363,6 +363,7 @@
 	barefootstep = FOOTSTEP_WATER
 	clawfootstep = FOOTSTEP_WATER
 	heavyfootstep = FOOTSTEP_WATER
+	var/apply_rads = TRUE
 
 /turf/open/indestructible/ground/outside/water/running
 	gender = PLURAL
@@ -379,6 +380,11 @@
 	clawfootstep = FOOTSTEP_WATER
 	heavyfootstep = FOOTSTEP_WATER
 
+/turf/open/indestructible/ground/outside/water/no_rads
+	name = "constructed river water"
+	desc = "Shallow river water. The water appears cleaner than normal."
+	apply_rads = FALSE
+
 /turf/open/indestructible/ground/outside/water/Initialize(mapload)
 	. = ..()
 	update_icon()
@@ -387,7 +393,8 @@
 	if(istype(AM, /mob/living))
 		var/mob/living/L = AM
 		L.update_water()
-		L.apply_damage(2, RADIATION)
+		if(apply_rads)
+			L.apply_damage(2, RADIATION)
 		if(L.check_submerged() <= 0)
 			return
 		if(!istype(oldloc, /turf/open/indestructible/ground/outside/water))
@@ -399,7 +406,8 @@
 	if(istype(AM, /mob/living))
 		var/mob/living/L = AM
 		L.update_water()
-		L.apply_damage(2, RADIATION)
+		if(apply_rads)
+			L.apply_damage(2, RADIATION)
 		if(L.check_submerged() <= 0)
 			return
 		if(!istype(newloc, /turf/open/indestructible/ground/outside/water))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Adds the ability to construct water turfs by adding a new recipe (200u of water and a shovel tool) and adjusts construction code to support the creation of turfs. This could be used in the future if people want to create recipes for turfs this way.

EDIT: @mazzinsanity asked for the water turfs to apply no rads, so a variant water turf was added.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can cover water tiles up but never build them yourself. This allows you to replenish water tiles or build your own moats. Requested by @panzer1944.

![create water tiles](https://github.com/f13babylon/f13babylon/assets/62829927/c1d12156-2fff-4c4e-992f-2611b21d1700)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Added the ability to construct water turfs
tweak: tweaked construction code to allow for the creation of turfs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
