### PR TITLE
The Great Shotgun Debacle (+ AMR tweaks)

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -510,7 +510,6 @@
 /obj/item/storage/backpack/duffelbag/syndie/ammo/shotgun/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/ammo_box/magazine/m12g(src)
-	new /obj/item/ammo_box/magazine/m12g/stun(src)
 	new /obj/item/ammo_box/magazine/m12g/slug(src)
 	new /obj/item/ammo_box/magazine/m12g/dragon(src)
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -757,16 +757,6 @@
 	for(var/i in 1 to 7)
 		new /obj/item/ammo_casing/shotgun(src)
 
-/obj/item/storage/box/stunslug
-	name = "box of stun slugs"
-	desc = "A box full of stun 12g slugs."
-	icon_state = "stunslug_box"
-	illustration = null
-
-/obj/item/storage/box/stunslug/PopulateContents()
-	for(var/i in 1 to 7)
-		new /obj/item/ammo_casing/shotgun/stunslug(src)
-
 /obj/item/storage/box/techsslug
 	name = "box of tech shotgun shells"
 	desc = "A box full of tech shotgun shells."

--- a/code/modules/fallout/f13lootdrop.dm
+++ b/code/modules/fallout/f13lootdrop.dm
@@ -1284,7 +1284,7 @@
 	name = "Neostead 2000 shotgun and ammo spawner"
 	items = list(
 				/obj/item/gun/ballistic/shotgun/automatic/combat/neostead_noalt,
-				/obj/item/ammo_box/shotgun/flechette
+				/obj/item/ammo_box/shotgun/buck
 	)
 
 /obj/effect/spawner/bundle/f13/auto5

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -33,59 +33,19 @@
 	projectile_type = /obj/item/projectile/bullet/shotgun_beanbag
 	custom_materials = list(/datum/material/iron=250, /datum/material/blackpowder=70)
 
-
-/obj/item/ammo_casing/shotgun/executioner
-	name = "executioner slug"
-	desc = "A 12 gauge lead slug purpose built to annihilate flesh on impact."
-	icon_state = "stunshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_slug/executioner
-
-/obj/item/ammo_casing/shotgun/pulverizer
-	name = "pulverizer slug"
-	desc = "A 12 gauge lead slug purpose built to annihilate bones on impact."
-	icon_state = "stunshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_slug/pulverizer
-
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
-	desc = "An incendiary-coated shotgun slug."
+	desc = "A 12 gauge incendiary slug."
 	icon_state = "ishell"
 	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun
 
 /obj/item/ammo_casing/shotgun/dragonsbreath
 	name = "dragonsbreath shell"
-	desc = "A shotgun shell which fires a spread of incendiary pellets."
+	desc = "A 12 gauge magnesium buckshot shell."
 	icon_state = "ishell2"
 	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
 	pellets = 4
 	variance = 35
-
-/obj/item/ammo_casing/shotgun/stunslug
-	name = "taser slug"
-	desc = "A stunning taser slug."
-	icon_state = "stunshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_stunslug
-	custom_materials = list(/datum/material/iron=250, /datum/material/blackpowder=75)
-
-/obj/item/ammo_casing/shotgun/meteorslug
-	name = "meteorslug shell"
-	desc = "A shotgun shell rigged with CMC technology, which launches a massive slug when fired."
-	icon_state = "mshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_meteorslug
-
-/obj/item/ammo_casing/shotgun/pulseslug
-	name = "pulse slug"
-	desc = "A delicate device which can be loaded into a shotgun. The primer acts as a button which triggers the gain medium and fires a powerful \
-	energy blast. While the heat and power drain limit it to one use, it can still allow an operator to engage targets that ballistic ammunition \
-	would have difficulty with."
-	icon_state = "pshell"
-	projectile_type = /obj/item/projectile/beam/pulse/shotgun
-
-/obj/item/ammo_casing/shotgun/frag12
-	name = "FRAG-12 slug"
-	desc = "A high explosive breaching round for a 12 gauge shotgun."
-	icon_state = "heshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_frag12
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
@@ -166,30 +126,6 @@
 	pellets = 12//double the pellets, but half the stun power of each, which makes this best for just dumping right in someone's face.
 	variance = 25
 	custom_materials = list(/datum/material/iron=4000)
-
-/obj/item/ammo_casing/shotgun/magnumshot
-	name = "12 gauge magnum buckshot shell"
-	desc = "A 12 gauge magnum buckshot shell."
-	icon_state = "magshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/magnum_buckshot
-	pellets = 7
-	variance = 15
-
-/obj/item/ammo_casing/shotgun/trainshot
-	name = "12 gauge trainshot shell"
-	desc = "It's a 12-gauge, 3-pellet tungsten trainshot shotgun shell. Sometimes referred to as the tungsten trinity."
-	icon_state = "magshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/trainshot
-	pellets = 3
-	variance = 15
-
-/obj/item/ammo_casing/shotgun/flechette
-	name = "12 gauge flechette shell"
-	desc = "It's a 12-gauge flechette shell."
-	icon_state = "magshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/flechette
-	pellets = 24
-	variance = 24
 
 
 // BETA STUFF // Obsolete

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -26,12 +26,6 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	icon_state = "gbox"
 
-/obj/item/ammo_box/shotgun/magnum
-	name = "Magnum buckshot shotgun ammo box"
-	desc = "A box full of shotgun shells."
-	ammo_type = /obj/item/ammo_casing/shotgun/magnumshot
-	icon_state = "mbox"
-
 /obj/item/ammo_box/shotgun/bean
 	name = "Beanbag shotgun ammo box"
 	desc = "A box full of shotgun shells."
@@ -56,18 +50,6 @@
 	desc = "A box full of incendiary shotgun shells."
 	ammo_type = /obj/item/ammo_casing/shotgun/incendiary
 	icon_state = "mbox"
-
-/obj/item/ammo_box/shotgun/trainshot
-	name = "trainshot shotshell ammo box"
-	desc = "A box full of trainshot shells. For hunting trains, you suppose."
-	ammo_type = /obj/item/ammo_casing/shotgun/trainshot
-	icon_state = "trainshotbox"
-
-/obj/item/ammo_box/shotgun/flechette
-	name = "flechette shotshell ammo box"
-	desc = "A box full of flechette shells. Point at wall."
-	ammo_type = /obj/item/ammo_casing/shotgun/flechette
-	icon_state = "trainshotbox"
 
 //.22 LR
 /obj/item/ammo_box/m22
@@ -759,14 +741,6 @@
 
 /obj/item/ammo_box/clip/shotgun/loaded
 	start_empty = FALSE
-
-/obj/item/ammo_box/clip/shotgun/loaded/flechette
-	name = "stripper clip (flechette)"
-	ammo_type = /obj/item/ammo_casing/shotgun/flechette
-
-/obj/item/ammo_box/clip/shotgun/loaded/magnum
-	name = "stripper clip (magnum)"
-	ammo_type = /obj/item/ammo_casing/shotgun/magnumshot
 
 /obj/item/ammo_box/clip/shotgun/loaded/rubbershot
 	name = "stripper clip (rubbershot)"

--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -10,11 +10,6 @@
 	..()
 	icon_state = "[initial(icon_state)]-[CEILING(ammo_count(0)/8, 1)*8]"
 
-/obj/item/ammo_box/magazine/m12g/stun
-	name = "shotgun magazine (12g taser slugs)"
-	icon_state = "m12gs"
-	ammo_type = /obj/item/ammo_casing/shotgun/stunslug
-
 /obj/item/ammo_box/magazine/m12g/slug
 	name = "shotgun magazine (12g slugs)"
 	icon_state = "m12gsl"
@@ -30,23 +25,13 @@
 	icon_state = "m12gt"
 	ammo_type = /obj/item/ammo_casing/shotgun/dart/bioterror
 
-/obj/item/ammo_box/magazine/m12g/meteor
-	name = "shotgun magazine (12g meteor slugs)"
-	icon_state = "m12gbc"
-	ammo_type = /obj/item/ammo_casing/shotgun/meteorslug
-
-/obj/item/ammo_box/magazine/m12g/scatter
-	name = "shotgun magazine (12g scatter laser shot slugs)"
-	icon_state = "m12gb"
-	ammo_type = /obj/item/ammo_casing/shotgun/laserslug
-
 /*
 ---Fallout 13---
 */
 
 /obj/item/ammo_box/magazine/d12g
-	name = "shotgun drum magazine (12g slugs)"
-	desc = "A 12g drum magazine."
+	name = "shotgun drum magazine"
+	desc = "A 12 gauge drum magazine."
 	icon_state = "riotmag"
 	ammo_type = /obj/item/ammo_casing/shotgun
 	caliber = "shotgun"

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -20,12 +20,12 @@
 
 /obj/item/ammo_box/magazine/internal/shot/tube
 	name = "dual feed shotgun internal tube"
-	ammo_type = /obj/item/ammo_casing/shotgun/trainshot
+	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/shot/tube_noalt
 	name = "dual feed shotgun internal tube"
-	ammo_type = /obj/item/ammo_casing/shotgun/flechette
+	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 12
 
 /obj/item/ammo_box/magazine/internal/shot/lethal

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -111,8 +111,6 @@
 	sawn_desc = "Short and concealable, terribly uncomfortable to fire, but worse on the other end."
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
 	recoil = 1.55
-	extra_damage = 3
-	extra_penetration = 0.05
 
 /obj/item/gun/ballistic/revolver/caravan_shotgun/attackby(obj/item/A, mob/user, params)
 	..()
@@ -151,8 +149,6 @@
 	sawn_desc = "Someone took the time to chop the last few inches off the barrel and stock of this shotgun. Now, the wide spread of this hand-cannon's short-barreled shots makes it perfect for short-range crowd control."
 	fire_sound = 'sound/f13weapons/max_sawn_off.ogg'
 	recoil = 0.55
-	extra_damage = 2
-	extra_penetration = 0.15
 
 /obj/item/gun/ballistic/revolver/widowmaker/attackby(obj/item/A, mob/user, params)
 	..()
@@ -188,6 +184,7 @@
 	force = 10
 	slowdown = 0.1
 	extra_damage = 4
+	extra_penetration = 0.05
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 
 /obj/item/gun/ballistic/revolver/singleshotgun/axe

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -148,6 +148,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 /obj/item/projectile/bullet/a50MG
 	name = ".50 MG bullet"
 	damage = 50
+	stamina = 45
 	armour_penetration = 0.75
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -146,13 +146,14 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 /////////			-Very heavy rifle round.
 
 /obj/item/projectile/bullet/a50MG
-	damage = 40
-	armour_penetration = 0.85
+	name = ".50 MG bullet"
+	damage = 50
+	armour_penetration = 0.75
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100
-	wound_bonus = 30
-	bare_wound_bonus = 40//Same as the HMG.
-	supereffective_damage = 60
+	wound_bonus = 50
+	bare_wound_bonus = 80
+	supereffective_damage = 150
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/a50MG/incendiary

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -152,7 +152,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	armour_penetration = 0.75
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100
-	wound_bonus = 50
+	wound_bonus = 35
 	bare_wound_bonus = 80
 	supereffective_damage = 150
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,25 +1,15 @@
+//SLUGS
 /obj/item/projectile/bullet/shotgun_slug
-	name = "12g shotgun slug"
-	damage = 40
-	stamina = 15
+	name = "shotgun slug"
+	damage = 35
 	sharpness = SHARP_POINTY
 	wound_bonus = 45
-	bare_wound_bonus = 30
-	armour_penetration = 0.3
+	bare_wound_bonus = 0
+	armour_penetration = 0.1
 	spread = 2
 	wound_falloff_tile = -7.5
-	supereffective_damage = 50
-	supereffective_faction = list("supermutant", "deathclaw", "raider", "wastebot", "radscorpion") //Slugs HATE armor.
-
-/obj/item/projectile/bullet/shotgun_slug/executioner
-	name = "executioner slug" // admin only, can dismember limbs
-	sharpness = SHARP_EDGED
-	wound_bonus = 80
-
-/obj/item/projectile/bullet/shotgun_slug/pulverizer
-	name = "pulverizer slug" // admin only, can crush bones
-	sharpness = SHARP_NONE
-	wound_bonus = 80
+	supereffective_damage = 35
+	supereffective_faction = list("supermutant", "deathclaw", "raider", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
@@ -29,11 +19,12 @@
 	sharpness = SHARP_NONE
 	embedding = null
 
+//INCENDIARY AMMO
 /obj/item/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"
 	damage = 20
 	supereffective_damage = 80
-	supereffective_faction = list("ant", "cazador", "radscorpion") //Bugs HATE fire.
+	supereffective_faction = list("ant", "cazador", "radscorpion")
 
 /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
@@ -58,72 +49,18 @@
 		M.adjust_fire_stacks(3)
 		M.IgniteMob()
 
-/obj/item/projectile/bullet/shotgun_stunslug
-	name = "stunslug"
-	damage = 5
-	stamina = 30
-	stutter = 5
-	jitter = 20
-	range = 7
-	icon_state = "spark"
-	color = "#FFFF00"
-	var/tase_duration = 50
-
-/obj/item/projectile/bullet/shotgun_stunslug/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
-		do_sparks(1, TRUE, src)
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "tased", /datum/mood_event/tased)
-		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
-		C.IgniteMob()
-		if(C.dna && C.dna.check_mutation(HULK))
-			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
-		else if(tase_duration && (C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE) && !HAS_TRAIT(C, TRAIT_TASED_RESISTANCE))
-			C.electrocute_act(15, src, 1, SHOCK_NOSTUN)
-			C.apply_status_effect(STATUS_EFFECT_TASED_WEAK, tase_duration)
-
-/obj/item/projectile/bullet/shotgun_meteorslug
-	name = "meteorslug"
-	icon = 'icons/obj/meteor.dmi'
-	icon_state = "dust"
-	damage = 20
-	knockdown = 80
-	hitsound = 'sound/effects/meteorimpact.ogg'
-
-/obj/item/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(ismovable(target))
-		var/atom/movable/M = target
-		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
-		M.safe_throw_at(throw_target, 3, 2)
-
-/obj/item/projectile/bullet/shotgun_meteorslug/Initialize(mapload)
-	. = ..()
-	SpinAnimation()
-
-/obj/item/projectile/bullet/shotgun_frag12
-	name ="frag12 slug"
-	damage = 25
-	knockdown = 50
-
-/obj/item/projectile/bullet/shotgun_frag12/on_hit(atom/target, blocked = FALSE)
-	..()
-	explosion(target, -1, 0, 1)
-	return BULLET_ACT_HIT
-
+//PELLET SHELLS
 /obj/item/projectile/bullet/pellet
 	var/tile_dropoff = 0.45
 	var/tile_dropoff_s = 1.25
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 11.5
-	wound_bonus = 35
+	damage = 12
+	wound_bonus = 40
 	bare_wound_bonus = 90
-	wound_falloff_tile = -15.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
-	supereffective_damage = 9.5
+	wound_falloff_tile = -20 // low damage + additional dropoff will already curb wounding potential anything past point blank
+	supereffective_damage = 3
 	supereffective_faction = list("hostile", "ant", "supermutant", "cazador", "raider", "gecko", "radscorpion")
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
@@ -156,37 +93,6 @@
 	do_sparks(1, TRUE, src)
 	..()
 
-/obj/item/projectile/bullet/pellet/trainshot
-	damage = 15
-	stamina = 10
-	armour_penetration = 0.45
-	wound_bonus = 15
-	bare_wound_bonus = 15
-	sharpness = SHARP_NONE //crunch
-	tile_dropoff = 0
-	tile_dropoff_s = 0
-	supereffective_damage = 15 //same damage vs mobs as regular slugs, epic
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "gecko", "wastebot", "radscorpion")
-
-/obj/item/projectile/bullet/pellet/trainshot/on_hit(atom/target)
-	. = ..()
-	if(ismovable(target) && prob(8))
-		var/atom/movable/M = target
-		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
-		M.safe_throw_at(throw_target, 2, 3)
-
-/obj/item/projectile/bullet/pellet/flechette
-	name = "flechette"
-	damage = 2
-	stamina = 2
-	armour_penetration = 0.95
-	wound_bonus = 15
-	bare_wound_bonus = 15
-	sharpness = SHARP_POINTY //whoosh
-	tile_dropoff = 0
-	tile_dropoff_s = 0
-	hitsound = 'sound/effects/wounds/pierce1.ogg'
-
 // Mech Scattershots
 
 /obj/item/projectile/bullet/scattershot
@@ -204,13 +110,6 @@
 	name = "incapacitating pellet"
 	damage = 1
 	stamina = 6
-
-/obj/item/projectile/bullet/pellet/magnum_buckshot
-	name = "magnum buckshot pellet"
-	damage = 13
-	armour_penetration = 0.10
-	wound_bonus = 10
-	bare_wound_bonus = 10
 
 // BETA STUFF // Obsolete
 /obj/item/projectile/bullet/pellet/shotgun_buckshot/test

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -5,7 +5,7 @@
 	sharpness = SHARP_POINTY
 	wound_bonus = 45
 	bare_wound_bonus = 0
-	armour_penetration = 0.1
+	armour_penetration = 0.15
 	spread = 2
 	wound_falloff_tile = -7.5
 	supereffective_damage = 35

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -315,13 +315,6 @@
 	build_path = /obj/item/ammo_box/shotgun/slug
 	category = list("initial", "Basic Ammo")
 
-/datum/design/ammolathe/trainshot
-	name = "trainshot shotgun box"
-	id = "trainshot"
-	materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 1800)
-	build_path = /obj/item/ammo_box/shotgun/trainshot
-	category = list("initial", "Advanced Ammo")
-
 /datum/design/ammolathe/a762
 	name = "7.62 FMJ ammo box"
 	id = "a762_lathe"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -186,16 +186,6 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 */
 
-/datum/design/stunshell
-	name = "Stun Shell"
-	desc = "A stunning shell for a shotgun."
-	id = "stunshell"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 200)
-	build_path = /obj/item/ammo_casing/shotgun/stunslug
-	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
-
 /datum/design/techshell
 	name = "Unloaded Technological Shotshell"
 	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."


### PR DESCRIPTION
### The Summary
This PR cleans up shotgun code some by getting rid of unused ammo, removes trainshot, nerfs slugs, substantially nerfs double barrel shotguns, and buffs the AMR slightly.

### The Why
_**The slug nerf**_
Literally outclasses most mid-high tier guns. Does more damage than 7.62 with more AP yet it's infinitely easier to find, make, and store. Does insane damage to literally fucking everything.

_**YOU REMOVED TRAINSHOT I FUCKING HATE THIS, THIS IS THE WORST THING EVER, THE GAME IS RUINED, SHOTGUNS ARE USELESS, I'M GONNA KILL MYSELF**_
Trainshot has all the benefits of slugs, and all the benefits of buckshot, on top of being better in literally every way imaginable, locked behind a magazine. It completely kills any niche you obtain by switching ammo types on your shotguns.

_**The AMR buff**_
It's currently too weak to justify its terrible handling. The buff isn't substantial, but it helps it shine more, especially in PVE.

**_The DB nerf_**
They literally had up to 15% bonus AP. I don't know what the fuck I was thinking one year ago but this created the most hilariously broken shit ever. Now the only shotgun with AP and damage bonuses is, rightfully, the single-shot.

### Show me the numbers.

_**Slugs**_
_DAMAGE 40 > 35_
_STAMINA DAMAGE 15 > 0_
_BARE WOUND BONUS 30 > 0_
_ARMOR PENETRATION 30% > 15%_
_SUPERFFECTIVE DAMAGE 50 > 35_

_**Buckshot**_
_DAMAGE 11.5 > 12_
_WOUND BONUS 35 > 40_
_WOUND BONUS FALLOFF 15.5/Tile > 20/Tile_
_SUPEREFFECTIVE DAMAGE 9.5 > 3_

_**.50 MG**_
_DAMAGE 45 > 50_
_STAMINA DAMAGE 0 > 45_
_WOUND BONUS 30 > 35_
_BARE WOUND BONUS 40 > 80_
_SUPEREFFECTIVE DAMAGE 60 > 150_