### PR TITLE
Fixes Some Planes and Boundaries

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -10,6 +10,7 @@
 	density = TRUE
 	pixel_x = -16
 	layer = FLY_LAYER
+	plane = MOB_PLANE
 	var/log_amount = 10
 
 /obj/structure/flora/tree/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -24,6 +24,7 @@
 	buckle_lying = FALSE
 	buckle_prevents_pull = TRUE
 	layer = ABOVE_MOB_LAYER
+	plane = MOB_PLANE
 	var/blade_status = GUILLOTINE_BLADE_RAISED
 	var/blade_sharpness = GUILLOTINE_BLADE_MAX_SHARP // How sharp the blade is
 	var/kill_count = 0

--- a/code/modules/fallout/obj/misc.dm
+++ b/code/modules/fallout/obj/misc.dm
@@ -150,7 +150,8 @@
 	anchored = 1
 	w_class = 4
 
-	layer = 4.1
+	layer = ABOVE_MOB_LAYER
+	plane = MOB_PLANE
 	icon = 'icons/obj/flags.dmi'
 	icon_state = "emptyflag"
 	item_state = "emptyflag"

--- a/code/modules/fallout/obj/structures/billboard.dm
+++ b/code/modules/fallout/obj/structures/billboard.dm
@@ -6,7 +6,8 @@
 	icon_state = "null"
 	density = 1
 	anchored = 1
-	layer = 5
+	layer = FLY_LAYER
+	plane = MOB_PLANE
 	icon = 'icons/obj/Ritas.dmi'
 	bound_width = 64
 	resistance_flags = INDESTRUCTIBLE

--- a/code/modules/fallout/obj/structures/execution.dm
+++ b/code/modules/fallout/obj/structures/execution.dm
@@ -10,7 +10,8 @@
 	buckle_lying = 0
 	can_buckle = 1
 	max_integrity = 250
-	bound_height = 64
+	layer = ABOVE_MOB_LAYER
+	plane = MOB_PLANE
 
 /obj/structure/cross/crowbar_act(mob/living/user, obj/item/I)
 	if(has_buckled_mobs())
@@ -40,6 +41,7 @@
 			playsound(src.loc, "sound/effects/crossed.ogg", 20, 1) // thanks hippie
 			L.visible_message("<span class='danger'>[user] ties [L] to the cross!</span>", "<span class='userdanger'>[user] ties you to the cross!</span>")
 			L.forceMove(drop_location())
+			L.plane = -2
 			L.emote("scream")
 			if(iscarbon(L))
 				var/mob/living/carbon/C = L
@@ -60,7 +62,7 @@
 
 /obj/structure/cross/user_buckle_mob(mob/living/M, mob/living/user)
 	return
-	
+
 /obj/structure/cross/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)
 	if(buckled_mob && buckled_mob.buckled == src)
 		var/mob/living/M = buckled_mob
@@ -95,6 +97,7 @@
 	M.adjustBruteLoss(15)
 	src.visible_message(text("<span class='danger'>[M] falls free of [src]!</span>"))
 	unbuckle_mob(M,force=1)
+	M.plane = -3
 	INVOKE_ASYNC(M, /mob/proc/emote, "collapse")
 	M.overlays -= image('icons/obj/cross.dmi', "lashing")
 

--- a/code/modules/fallout/obj/structures/lamp_post.dm
+++ b/code/modules/fallout/obj/structures/lamp_post.dm
@@ -11,6 +11,7 @@
 
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = GASFIRE_LAYER
+	plane = MOB_PLANE
 	anchored = TRUE
 	max_integrity = 750
 	opacity = 0
@@ -47,6 +48,7 @@
 	opacity = 0
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = GASFIRE_LAYER
+	plane = MOB_PLANE
 
 	pixel_x = -32
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -42,6 +42,7 @@
 	icon_state = "tube-construct-stage1"
 	anchored = TRUE
 	layer = WALL_OBJ_LAYER
+	plane = MOB_PLANE
 	max_integrity = 200
 	armor = list("melee" = 50, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 50)
 
@@ -184,6 +185,7 @@
 	icon_state = "tube"
 	desc = "A lighting fixture."
 	layer = WALL_OBJ_LAYER
+	plane = MOB_PLANE
 	max_integrity = 100
 	use_power = ACTIVE_POWER_USE
 	idle_power_usage = 6
@@ -836,7 +838,8 @@
 	icon_state = "floor"
 	brightness = 5
 	nightshift_brightness = 4
-	layer = 2.5
+	layer = LOW_OBJ_LAYER
+	plane = GAME_PLANE
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"
 
@@ -850,7 +853,6 @@
 	brightness = 8
 	active_power_usage = 0
 	density = 0
-	layer = WALL_OBJ_LAYER
 	nightshift_allowed = FALSE
 	start_with_cell = FALSE
 	no_emergency = TRUE
@@ -861,41 +863,29 @@
 
 //F13 COLORED LIGHTS
 /obj/machinery/light/fo13colored/Pink
-	name = "Arcade Light"
-	icon = 'icons/obj/lighting.dmi'
-	icon_state = "tube"
+	name = "pink light"
 	desc = "A lighting fixture with pink lighting."
 	nightshift_allowed = FALSE
 	no_emergency = TRUE
 	brightness = 5
-	density = 0
-	layer = WALL_OBJ_LAYER
 	bulb_colour = "#FF5ABF"
 	light_color = "#FF00FF"
 
 /obj/machinery/light/fo13colored/Aqua
-	name = "Novelty Store Light"
-	icon = 'icons/obj/lighting.dmi'
-	icon_state = "tube"
+	name = "green light"
 	desc = "A lighting fixture with green lighting."
 	nightshift_allowed = FALSE
 	no_emergency = TRUE
 	brightness = 5
-	density = 0
-	layer = WALL_OBJ_LAYER
 	bulb_colour = "#00FFFF"
 	light_color = "#00FFFF"
 
 /obj/machinery/light/fo13colored/Red
-	name = "Red Light"
-	icon = 'icons/obj/lighting.dmi'
-	icon_state = "tube"
+	name = "red light"
 	desc = "A lighting fixture with red lighting."
 	nightshift_allowed = FALSE
 	no_emergency = TRUE
-	brightness = 4
-	density = 0
-	layer = WALL_OBJ_LAYER
+	brightness = 5
 	bulb_colour = "#8B0000"
 	light_color = "#FF0000"
 
@@ -930,4 +920,3 @@
 		bulb_colour = initial(bulb_colour)
 		update(FALSE)
 	flickering = FALSE
-

--- a/modular_sunset/code/game/objects/sunsetmisc.dm
+++ b/modular_sunset/code/game/objects/sunsetmisc.dm
@@ -124,6 +124,7 @@
 	anchored = 1
 	w_class = 4
 	layer = 5
+	bound_width = 64
 
 /obj/item/trade_sign
 	name = "Trade sign"
@@ -135,6 +136,7 @@
 	anchored = 1
 	w_class = 4
 	layer = 5
+	bound_width = 64
 
 /datum/weather/ash_storm/sandstorm
 	telegraph_message = "<span class='userdanger'>A sandstorm is coming to the area, decreasing overall visibility outside.</span>"


### PR DESCRIPTION
## About The Pull Request
These are some more ancient errors with the codebase.
![image](https://github.com/f13babylon/f13babylon/assets/132588088/9d5cd783-e0dd-418e-9f26-171a012c2f24)
- Fixed boundaries for Bighorn Sign and Trade Sign so you can’t walk through part of them.
- Fixed boundaries for Cross so you can walk behind it.

![image](https://github.com/f13babylon/f13babylon/assets/132588088/08711194-a2b7-443b-918c-88250490cc84)
- Fixed planes for lights, streetlights, billboards, trees, guillotines, and crosses so objects and mobs appear under them, rather than over.
- This is totally unrelated but while I was in lighting.dm I fixed the fo13colored lights having many duplicated lines from the parent.

## Why It's Good For The Game
Aside from fixing some visual oddities, this might have fun gameplay implications as items can now be concealed behind objects like billboards and trees.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed some sprite errors.
/:cl:
