### PR TITLE
Fixes Broken Hairstyle

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/hair_head.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/hair_head.dm
@@ -905,10 +905,6 @@
 	name = "Ponytail 8 (Thin)"
 	icon_state = "hair_thin_ponytail"
 
-/datum/sprite_accessory/hair/ponytail9
-	name = "Ponytail 9"
-	icon_state = "hair_"
-
 /datum/sprite_accessory/hair/highponytail
 	name = "Ponytail (High)"
 	icon_state = "hair_highponytail"


### PR DESCRIPTION
## About The Pull Request
Removes 'Ponytail 9', an error hairstyle added in #279 which has no sprite and isn't referenced in the changelog so was probably just an easy mistake.

## Why It's Good For The Game
Another Discord bug report closed. Error hairstyle is still not in vogue.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixes a broken hairstyle.
/:cl:
