### PR TITLE
Removes One Handed Lever Action Shotgun Firing

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -330,7 +330,7 @@
 	slowdown = 0.25
 	recoil = 2.1
 	w_class = WEIGHT_CLASS_NORMAL
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_HEAVY
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	fire_sound = 'sound/f13weapons/shotgun.ogg'
 	can_bayonet = TRUE


### PR DESCRIPTION
A short-lived change now being reverted due to its over-useful nature.