### PR TITLE
POWERGAME-B-GONE | FALLOUT CHEMS NO LONGER STACK WITH BASE SS13 HEALING CHEMS

### DIFF
--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -11,7 +11,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 	var/affecting_intolerant_mob = FALSE	//If it is affecting a mob with TRAIT_STIM_INTOLERANCE
 	var/damage_offset = 3	//Value to offset damage by
 	var/clot_rate = 0.35	//35% as effective as Hydra at clotting bleeding wounds
@@ -115,7 +115,7 @@
 	description = "A chemical which aims to replicate the effects of the fluid found in pre-war stimpaks, albeit less effective."
 	color = "#df5342"
 	value = REAGENT_VALUE_UNCOMMON
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 	damage_offset = 2.25	//How much damage will be offset in one tick
 	clot_rate = 0.26	//26% as effective as Hydra at clotting bleeding wounds
 
@@ -126,7 +126,7 @@
 	name = "Super stimpak fluid"
 	description = "A powerful pre-war cocktail of healing agents and stimulants which bolster the body's natural regenerative abilities. Injecting this leads to near instant recovery from most injuries."
 	value = REAGENT_VALUE_VERY_RARE
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/superimitation, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/superimitation, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 	damage_offset = 6.75	//How much damage will be offset in one tick
 	clot_rate = 0.65	//65% as effective as Hydra at clotting bleeding wounds
 
@@ -137,7 +137,7 @@
 	name = "Imitation super stimpak fluid"
 	description = "A chemical which aims to replicate the effects of the fluid found in pre-war super stimpaks, albeit less effective."
 	color = "#df5342"
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 	value = REAGENT_VALUE_RARE
 	damage_offset = 5	//How much damage will be offset in one tick
 	clot_rate = 0.49	//49% as effective as Hydra at clotting bleeding wounds
@@ -185,7 +185,7 @@
 	taste_description = "heaven."
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30 //hard to OD on, besides if you use too much it kills you when it wears off
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 
 /datum/reagent/medicine/berserker_powder/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_BERSERKER))
@@ -261,7 +261,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_VERY_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder,  /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder,  /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 
@@ -347,7 +347,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 
@@ -434,7 +434,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -11,7 +11,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/imitation)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 	var/affecting_intolerant_mob = FALSE	//If it is affecting a mob with TRAIT_STIM_INTOLERANCE
 	var/damage_offset = 3	//Value to offset damage by
 	var/clot_rate = 0.35	//35% as effective as Hydra at clotting bleeding wounds
@@ -115,7 +115,7 @@
 	description = "A chemical which aims to replicate the effects of the fluid found in pre-war stimpaks, albeit less effective."
 	color = "#df5342"
 	value = REAGENT_VALUE_UNCOMMON
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 	damage_offset = 2.25	//How much damage will be offset in one tick
 	clot_rate = 0.26	//26% as effective as Hydra at clotting bleeding wounds
 
@@ -126,7 +126,7 @@
 	name = "Super stimpak fluid"
 	description = "A powerful pre-war cocktail of healing agents and stimulants which bolster the body's natural regenerative abilities. Injecting this leads to near instant recovery from most injuries."
 	value = REAGENT_VALUE_VERY_RARE
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/superimitation, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/superimitation, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 	damage_offset = 6.75	//How much damage will be offset in one tick
 	clot_rate = 0.65	//65% as effective as Hydra at clotting bleeding wounds
 
@@ -137,7 +137,7 @@
 	name = "Imitation super stimpak fluid"
 	description = "A chemical which aims to replicate the effects of the fluid found in pre-war super stimpaks, albeit less effective."
 	color = "#df5342"
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 	value = REAGENT_VALUE_RARE
 	damage_offset = 5	//How much damage will be offset in one tick
 	clot_rate = 0.49	//49% as effective as Hydra at clotting bleeding wounds
@@ -185,7 +185,7 @@
 	taste_description = "heaven."
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30 //hard to OD on, besides if you use too much it kills you when it wears off
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 
 /datum/reagent/medicine/berserker_powder/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_BERSERKER))
@@ -261,7 +261,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_VERY_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder,  /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder,  /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 
@@ -347,7 +347,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 
@@ -434,7 +434,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 
@@ -921,7 +921,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 21
 	self_consuming = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
 	var/clot_rate = 0	//The rate at which blood_flow will be reduced for pierce/slash wounds
 	var/affecting_tribal = FALSE
 	var/nth_cycle = 0	//On which cycle should Hydra trigger its effects

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -11,7 +11,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	var/affecting_intolerant_mob = FALSE	//If it is affecting a mob with TRAIT_STIM_INTOLERANCE
 	var/damage_offset = 3	//Value to offset damage by
 	var/clot_rate = 0.35	//35% as effective as Hydra at clotting bleeding wounds
@@ -115,7 +115,7 @@
 	description = "A chemical which aims to replicate the effects of the fluid found in pre-war stimpaks, albeit less effective."
 	color = "#df5342"
 	value = REAGENT_VALUE_UNCOMMON
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	damage_offset = 2.25	//How much damage will be offset in one tick
 	clot_rate = 0.26	//26% as effective as Hydra at clotting bleeding wounds
 
@@ -126,7 +126,7 @@
 	name = "Super stimpak fluid"
 	description = "A powerful pre-war cocktail of healing agents and stimulants which bolster the body's natural regenerative abilities. Injecting this leads to near instant recovery from most injuries."
 	value = REAGENT_VALUE_VERY_RARE
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/superimitation, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/superimitation, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	damage_offset = 6.75	//How much damage will be offset in one tick
 	clot_rate = 0.65	//65% as effective as Hydra at clotting bleeding wounds
 
@@ -137,7 +137,7 @@
 	name = "Imitation super stimpak fluid"
 	description = "A chemical which aims to replicate the effects of the fluid found in pre-war super stimpaks, albeit less effective."
 	color = "#df5342"
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	value = REAGENT_VALUE_RARE
 	damage_offset = 5	//How much damage will be offset in one tick
 	clot_rate = 0.49	//49% as effective as Hydra at clotting bleeding wounds
@@ -185,7 +185,7 @@
 	taste_description = "heaven."
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30 //hard to OD on, besides if you use too much it kills you when it wears off
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 
 /datum/reagent/medicine/berserker_powder/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_BERSERKER))
@@ -261,7 +261,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_VERY_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder,  /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder,  /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 
@@ -347,7 +347,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 
@@ -434,7 +434,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	var/damage_offset = 0
 	var/affecting_tribal = FALSE
 
@@ -921,7 +921,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 21
 	self_consuming = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve)
 	var/clot_rate = 0	//The rate at which blood_flow will be reduced for pierce/slash wounds
 	var/affecting_tribal = FALSE
 	var/nth_cycle = 0	//On which cycle should Hydra trigger its effects

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -11,7 +11,7 @@
 	overdose_threshold = 31
 	value = REAGENT_VALUE_RARE
 	ghoulfriendly = TRUE
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	var/affecting_intolerant_mob = FALSE	//If it is affecting a mob with TRAIT_STIM_INTOLERANCE
 	var/damage_offset = 3	//Value to offset damage by
 	var/clot_rate = 0.35	//35% as effective as Hydra at clotting bleeding wounds
@@ -115,7 +115,7 @@
 	description = "A chemical which aims to replicate the effects of the fluid found in pre-war stimpaks, albeit less effective."
 	color = "#df5342"
 	value = REAGENT_VALUE_UNCOMMON
-	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
+	reagent_blacklist = list(/datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder, /datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
 	damage_offset = 2.25	//How much damage will be offset in one tick
 	clot_rate = 0.26	//26% as effective as Hydra at clotting bleeding wounds
 
@@ -185,7 +185,7 @@
 	taste_description = "heaven."
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30 //hard to OD on, besides if you use too much it kills you when it wears off
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/bitterdrink)
 
 /datum/reagent/medicine/berserker_powder/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_BERSERKER))

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -185,7 +185,7 @@
 	taste_description = "heaven."
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30 //hard to OD on, besides if you use too much it kills you when it wears off
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/medx, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/sal_acid, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/morphine, /datum/reagent/medicine/mine_salve, /datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/bitterdrink, /datum/reagent/medicine/healingpoultice, /datum/reagent/medicine/healingpowder)
 
 /datum/reagent/medicine/berserker_powder/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_BERSERKER))
@@ -709,7 +709,7 @@
 	color = "#6D6374"
 	metabolization_rate = 0.7 * REAGENTS_METABOLISM
 	overdose_threshold = 14
-	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation)
+	var/list/reagent_blacklist = list(/datum/reagent/medicine/stimpak/super, /datum/reagent/medicine/stimpak/superimitation ,/datum/reagent/medicine/stimpak, /datum/reagent/medicine/stimpak/imitation, /datum/reagent/medicine/berserker_powder)
 
 /datum/reagent/medicine/naturalpainkiller/on_mob_add(mob/M)
 	if(isliving(M))


### PR DESCRIPTION
### You've gotten a lot farther than you should have, but that is until you met someone that can make PRs. Your ride's over, powergamer. Time to get mogged.

**Most Fallout chems no longer stack with Med-X, Bicaridine, Salicylic Acid, Kelotane, Tricordrazine, Miner's Salve, Morphine or Oxandrolone.**

**Med-X may still stack with Imitation Stimfluid and Stimpaks, on top of the aforementioned chemicals.**

**Natural Painkillers don't stack with Berserker Powder. Berserker Powder doesn't stack with bitter drink.**