### PR TITLE
Clicking on a filled in sand pit that has nothing in it will now remove the sand pit.

### DIFF
--- a/code/modules/pits/pits.dm
+++ b/code/modules/pits/pits.dm
@@ -80,6 +80,11 @@
 			storedindex--
 			I.forceMove(get_turf(M))
 
+	if(mypit && !dug && !length(mypit.contents))
+		to_chat(M, "<span class='notice'>You smooth the sand, removing the sand mound.</span>")
+		qdel(mypit)
+		mypit = null
+
 /turf/open/indestructible/ground/outside/desert/proc/finishBury(mob/user)
 	if(!(gravebody in src.loc))
 		gravebody = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
When clicking on a desert tile that has a pit object in it with an empty hand, if the pit has nothing in it's contents, it will be deleted. I have tested this with tiles that have salvage (salvage is not duplicated), pits that have contents, and digging new pits after the first is removed, and all works well with no runtime errors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Over the course of a round the desert becomes an ugly pockmarked mess as people continue to dig pits for sand to turn into sandbags and glass, salvage, or just to bury dead bodies. This would be all fine and dandy if not for the fact that once a pit is dug, there is no way to EVER remove them. Want to build a base where a pit lays? Have fun having a sand mound in your sleeping quarters! 
This PR aims to fix this issue, while still making sure we aren't doing anything messed up like deleting somebody who happens to be sitting inside a mound.

![Screenshot 2023-12-19 204652](https://github.com/f13babylon/f13babylon/assets/62829927/4bf183c0-bdbf-4b1f-997a-b86b019cec8b)
Before smoothing the mound.

![Screenshot 2023-12-19 204718](https://github.com/f13babylon/f13babylon/assets/62829927/5833ef09-9443-4531-8181-61f0d0ab9804)
After smoothing the mound.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
tweak: Empty sand mounds can now be "smoothed" and removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
