### PR TITLE
Small Casper + Dungeons map fixes (+Enclave NML entry)

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -103,7 +103,8 @@
 /area/f13/bunker)
 "adl" = (
 /mob/living/simple_animal/hostile/renegade/guardian{
-	extra_projectiles = 2
+	extra_projectiles = 2;
+	melee_queue_distance = 2
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -9472,7 +9473,8 @@
 "ldm" = (
 /obj/machinery/hydroponics/soil/crafted,
 /mob/living/simple_animal/hostile/renegade/guardian{
-	extra_projectiles = 2
+	extra_projectiles = 2;
+	melee_queue_distance = 2
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -10157,7 +10159,8 @@
 	name = "prewar lounge chair"
 	},
 /mob/living/simple_animal/hostile/renegade/guardian{
-	extra_projectiles = 2
+	extra_projectiles = 2;
+	melee_queue_distance = 2
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -16645,7 +16648,8 @@
 "ttV" = (
 /obj/structure/chair/bench,
 /mob/living/simple_animal/hostile/renegade/guardian{
-	extra_projectiles = 2
+	extra_projectiles = 2;
+	melee_queue_distance = 2
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -194,9 +194,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault)
 "ahT" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
+/obj/machinery/door/unpowered/secure_bos,
 /turf/open/floor/plating/tunnel,
 /area/f13/underground/cave)
 "aiH" = (
@@ -1411,6 +1409,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"bNM" = (
+/obj/machinery/door/unpowered/secure_NCR,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "bNV" = (
 /obj/structure/cargocrate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -2565,6 +2567,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"dgI" = (
+/obj/structure/timeddoor/sixtyminute,
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "dgM" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -3341,6 +3348,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"ebu" = (
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/underground/cave)
 "ebv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
 /turf/open/indestructible/ground/outside/dirt,
@@ -6268,6 +6281,11 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
 /area/f13/bunker)
+"hyk" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/indestructible/rock,
+/area/f13/underground/cave)
 "hyK" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/barber{
@@ -6472,6 +6490,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
+"hLo" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/cave)
 "hLv" = (
 /obj/effect/decal/remains/human,
 /obj/structure/closet,
@@ -6482,7 +6504,7 @@
 	},
 /area/f13/bunker)
 "hLU" = (
-/obj/structure/simple_door/bunker,
+/obj/machinery/door/unpowered/securedoor/legion,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "hNR" = (
@@ -8795,6 +8817,7 @@
 /obj/machinery/computer/shuttle/southbunkerelevator{
 	dir = 4
 	},
+/obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/green/corner{
 	dir = 4
 	},
@@ -10773,6 +10796,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "mHk" = (
+/obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 4
 	},
@@ -11221,6 +11245,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"nlP" = (
+/obj/structure/timeddoor/sixtyminute,
+/turf/closed/wall/f13/vault,
+/area/f13/underground/cave)
 "nlT" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -11255,6 +11283,7 @@
 	dir = 1;
 	light_color = "#706891"
 	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
 "nnM" = (
@@ -12267,9 +12296,11 @@
 	},
 /area/f13/ahs)
 "orZ" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/machinery/door/unpowered/secure_steeldoor{
+	req_access_txt = "134"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "osj" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt{
@@ -12317,6 +12348,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"ovo" = (
+/obj/machinery/door/unpowered/secure_steeldoor{
+	req_access_txt = "134"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/underground/cave)
 "ovp" = (
 /obj/item/clothing/under/patriotsuit,
 /obj/effect/decal/cleanable/cobweb,
@@ -12354,6 +12393,11 @@
 	icon_state = "showroomfloor"
 	},
 /area/f13/ahs)
+"oyK" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "oyW" = (
 /obj/item/stack/sheet/glass/ten,
 /obj/structure/rack,
@@ -13304,6 +13348,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/ahs)
+"prO" = (
+/obj/machinery/door/unpowered/secure_NCR,
+/turf/open/floor/plasteel/grimy,
+/area/f13/ncr)
 "pte" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
@@ -16044,6 +16092,13 @@
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"sIJ" = (
+/obj/structure/simple_door/metal/barred,
+/obj/structure/timeddoor/sixtyminute,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/mountain_bunker)
 "sIR" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/effect/decal/cleanable/blood/old,
@@ -16629,6 +16684,7 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
 	},
+/obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 4
 	},
@@ -18871,6 +18927,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/caves)
+"vQX" = (
+/obj/machinery/door/unpowered/securedoor/legion,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "vRa" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -19636,6 +19696,7 @@
 /area/f13/bunker)
 "wQG" = (
 /obj/structure/reagent_dispensers/barrel/three,
+/obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/green/corner,
 /area/f13/bunker)
 "wRn" = (
@@ -19946,6 +20007,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"xfd" = (
+/obj/machinery/door/unpowered/secure_NCR,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/ncr)
 "xgO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -20138,6 +20206,13 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/ahs)
+"xrN" = (
+/obj/structure/timeddoor/sixtyminute,
+/obj/machinery/door/unpowered/secure_steeldoor{
+	req_access_txt = "134"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/underground/cave)
 "xsb" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "vaultd3";
@@ -20606,6 +20681,9 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"yde" = (
+/turf/closed/wall/mineral/wood,
+/area/f13/underground/cave)
 "ydV" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21698,6 +21776,18 @@ gRX
 dFr
 shC
 shC
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+shC
 shC
 aTA
 aTA
@@ -21739,25 +21829,13 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+shC
+wgF
+wgF
+fxg
+wgF
+wgF
+wgF
 aTA
 aTA
 aTA
@@ -21941,10 +22019,10 @@ bVH
 aTA
 aTA
 aTA
-aTA
-shC
-shC
-shC
+wgF
+wgF
+wgF
+huB
 lix
 kHC
 vmb
@@ -21953,6 +22031,21 @@ xHM
 lix
 tNu
 lix
+huB
+wgF
+wgF
+wgF
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+shC
+wgF
+wgF
+wgF
 shC
 aTA
 aTA
@@ -21987,35 +22080,20 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+orZ
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
 aTA
 aTA
 aTA
@@ -22167,9 +22245,9 @@ shC
 shC
 aTA
 aTA
-aTA
-aTA
-aTA
+shC
+shC
+shC
 aTA
 bVH
 bVH
@@ -22198,10 +22276,10 @@ bVH
 bVH
 bVH
 bVH
-aTA
-shC
-shC
-shC
+ehW
+wgF
+wgF
+huB
 lix
 uFK
 vmb
@@ -22210,6 +22288,9 @@ xHM
 xHM
 xHM
 lix
+huB
+wgF
+shC
 shC
 aTA
 aTA
@@ -22219,13 +22300,10 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+shC
+shC
+ehW
+shC
 aTA
 aTA
 aTA
@@ -22258,24 +22336,24 @@ aTA
 aTA
 aTA
 aTA
+wgF
+wgF
+fxg
+fxg
+wgF
+wgF
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+shC
+shC
+orZ
+gvq
+shC
+shC
+wgF
+wgF
+wgF
+wgF
+wgF
 opi
 scm
 iCX
@@ -22423,10 +22501,10 @@ shC
 shC
 shC
 aTA
-aTA
-aTA
-aTA
-aTA
+shC
+shC
+wgF
+bNM
 bVH
 bVH
 bVH
@@ -22458,18 +22536,18 @@ bVH
 bVH
 shC
 shC
+huB
+sIJ
+xHM
+xHM
+xHM
+xHM
+xHM
+xHM
+sIJ
+huB
 shC
-lix
-xHM
-xHM
-xHM
-xHM
-xHM
-xHM
-lix
 shC
-aTA
-aTA
 bVH
 bVH
 bVH
@@ -22515,26 +22593,26 @@ bVH
 bVH
 bVH
 aTA
+wgF
+wgF
+wgF
+wgF
+wgF
 aTA
 aTA
 aTA
 aTA
+wgF
 aTA
 aTA
+shC
 aTA
 aTA
-bVH
-bVH
-bVH
-bVH
-aTA
-aTA
-aTA
-aTA
+wgF
 fxg
 wgF
 huB
-afj
+ovo
 iCX
 xGR
 iCX
@@ -22679,11 +22757,11 @@ shC
 shC
 shC
 shC
-aTA
-aTA
-aTA
-aTA
-aTA
+shC
+shC
+wgF
+wgF
+yde
 bVH
 bVH
 bVH
@@ -22724,9 +22802,9 @@ xHM
 xHM
 xHM
 lix
+huB
 shC
 aTA
-aTA
 bVH
 rVX
 bVH
@@ -22771,27 +22849,27 @@ bVH
 bVH
 bVH
 bVH
+wgF
+wgF
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-bVH
-bVH
-bVH
-bVH
-bVH
+wgF
 bVH
 bVH
 aTA
 aTA
+wgF
+wgF
+wgF
+shC
+shC
 aTA
 wgF
 fxg
 wgF
 huB
-afj
+ovo
 iCX
 xGR
 iCX
@@ -22936,11 +23014,11 @@ shC
 shC
 shC
 shC
-aTA
-aTA
-aTA
-aTA
-aTA
+shC
+wgF
+wgF
+shC
+shC
 bVH
 bVH
 bVH
@@ -22981,8 +23059,8 @@ hHG
 xHM
 xHM
 lix
+huB
 shC
-aTA
 aTA
 bVH
 bVH
@@ -23037,17 +23115,17 @@ bVH
 bVH
 bVH
 bVH
-bVH
-bVH
-bVH
-bVH
-bVH
+aTA
+aTA
 aTA
 wgF
+aTA
+shC
 wgF
 wgF
 wgF
-opi
+wgF
+huB
 scm
 iCX
 ixz
@@ -23193,10 +23271,10 @@ shC
 shC
 shC
 shC
-aTA
-aTA
-aTA
-aTA
+wgF
+wgF
+wgF
+shC
 bVH
 bVH
 bVH
@@ -23238,73 +23316,73 @@ hHG
 xHM
 xHM
 lix
+huB
 shC
 aTA
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+xpR
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+xpR
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
+bVH
 aTA
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-xpR
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-xpR
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
 wgF
-fxg
-aTA
-aTA
-opi
+wgF
+shC
+gvq
+orZ
+shC
+shC
+huB
 gvq
 gvq
 gvq
@@ -23450,10 +23528,10 @@ shC
 shC
 shC
 shC
-aTA
-aTA
-aTA
-aTA
+wgF
+wgF
+shC
+shC
 bVH
 bVH
 bVH
@@ -23495,9 +23573,9 @@ xHM
 xHM
 xHM
 lix
+huB
 shC
 aTA
-aTA
 bVH
 rVX
 bVH
@@ -23554,16 +23632,16 @@ bVH
 bVH
 bVH
 bVH
-bVH
-bVH
-bVH
-bVH
-bVH
 aTA
+wgF
+wgF
+wgF
+wgF
 aTA
-opi
-aTA
-aTA
+shC
+huB
+wgF
+wgF
 gvq
 llw
 iCX
@@ -23707,7 +23785,7 @@ dhw
 dhw
 dhw
 dhw
-dhw
+prO
 dhw
 dhw
 dhw
@@ -23752,8 +23830,8 @@ lix
 lix
 lix
 lix
+huB
 shC
-aTA
 rVX
 rVX
 bVH
@@ -23812,15 +23890,15 @@ bVH
 bVH
 bVH
 bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-opi
 aTA
 aTA
+aTA
+wgF
+wgF
+shC
+ldZ
+shC
+wgF
 gvq
 gvq
 gvq
@@ -23964,7 +24042,7 @@ dhw
 dhw
 dhw
 dhw
-dhw
+prO
 dhw
 dhw
 dhw
@@ -24009,8 +24087,8 @@ huB
 shC
 shC
 shC
+ehW
 shC
-aTA
 nfN
 bVH
 bVH
@@ -24071,14 +24149,14 @@ bVH
 bVH
 bVH
 bVH
-bVH
-bVH
-bVH
-bVH
-fcd
-opi
-opi
-opi
+aTA
+wgF
+wgF
+aTA
+hLo
+ldZ
+xrN
+ldZ
 opi
 opi
 opi
@@ -24265,8 +24343,8 @@ wgF
 wgF
 aTA
 aTA
-aTA
-aTA
+shC
+wgF
 xpR
 xpR
 xpR
@@ -24330,15 +24408,15 @@ bVH
 bVH
 bVH
 bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
 aTA
 aTA
-aTA
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
+wgF
 aTA
 shC
 "}
@@ -24522,8 +24600,8 @@ wgF
 wgF
 aTA
 aTA
-aTA
-aTA
+shC
+wgF
 bVH
 bVH
 bVH
@@ -24589,13 +24667,13 @@ bVH
 bVH
 bVH
 bVH
-bVH
-bVH
-bVH
-bVH
+aTA
+wgF
 aTA
 aTA
 aTA
+wgF
+wgF
 aTA
 shC
 "}
@@ -24851,7 +24929,7 @@ bVH
 bVH
 bVH
 aTA
-aTA
+wgF
 aTA
 aTA
 shC
@@ -25000,7 +25078,7 @@ emc
 bgU
 mON
 mON
-isz
+xfd
 rEK
 rEK
 rEK
@@ -25108,7 +25186,7 @@ bVH
 bVH
 bVH
 aTA
-aTA
+wgF
 aTA
 aTA
 shC
@@ -25257,7 +25335,7 @@ emc
 bgU
 mON
 mON
-isz
+xfd
 rEK
 rEK
 rEK
@@ -25364,8 +25442,8 @@ bVH
 bVH
 bVH
 bVH
-aTA
-aTA
+wgF
+wgF
 aTA
 aTA
 shC
@@ -26277,7 +26355,7 @@ dhw
 dhw
 dhw
 dhw
-dhw
+prO
 dhw
 dhw
 dhw
@@ -26534,7 +26612,7 @@ dhw
 dhw
 dhw
 dhw
-dhw
+prO
 dhw
 dhw
 dhw
@@ -26790,9 +26868,9 @@ shC
 shC
 shC
 shC
+wgF
+wgF
 shC
-aTA
-aTA
 bVH
 bVH
 bVH
@@ -27047,9 +27125,9 @@ shC
 shC
 shC
 shC
+wgF
+wgF
 shC
-aTA
-aTA
 bVH
 bVH
 bVH
@@ -27305,8 +27383,8 @@ shC
 shC
 shC
 shC
-aTA
-aTA
+wgF
+yde
 bVH
 bVH
 bVH
@@ -27562,8 +27640,8 @@ shC
 shC
 shC
 shC
-aTA
-aTA
+wgF
+bNM
 bVH
 bVH
 bVH
@@ -27819,8 +27897,8 @@ shC
 shC
 shC
 shC
-opi
-opi
+ldZ
+ldZ
 fcd
 fcd
 fcd
@@ -41289,11 +41367,11 @@ nph
 bVH
 bVH
 bVH
-aTA
-aTA
-shC
-shC
-shC
+wgF
+wgF
+vQX
+wgF
+wgF
 shC
 shC
 shC
@@ -41546,13 +41624,13 @@ nph
 cQP
 bVH
 bVH
-aTA
-aTA
-shC
-shC
-shC
-shC
-shC
+wgF
+wgF
+yde
+wgF
+wgF
+wgF
+wgF
 shC
 shC
 shC
@@ -41807,9 +41885,9 @@ aTA
 shC
 shC
 shC
-shC
-shC
-shC
+wgF
+wgF
+wgF
 shC
 shC
 shC
@@ -42053,8 +42131,8 @@ akh
 akh
 imZ
 tCu
-orZ
-orZ
+hLU
+hLU
 tCu
 imZ
 akh
@@ -42066,7 +42144,7 @@ wWG
 wWG
 wWG
 wWG
-wWG
+hLU
 wWG
 wWG
 wWG
@@ -42323,7 +42401,7 @@ wWG
 wWG
 wWG
 wWG
-wWG
+hLU
 wWG
 wWG
 wWG
@@ -43345,7 +43423,7 @@ cZa
 cZa
 cZa
 cZa
-orZ
+hLU
 cZa
 maT
 dMI
@@ -43602,7 +43680,7 @@ cZa
 cZa
 cZa
 cZa
-orZ
+hLU
 cZa
 maT
 dMI
@@ -44335,7 +44413,7 @@ bVH
 bVH
 bVH
 bVH
-opi
+aTA
 aTA
 aTA
 aTA
@@ -44592,7 +44670,7 @@ bVH
 bVH
 bVH
 bVH
-opi
+aTA
 aTA
 aTA
 aTA
@@ -44636,7 +44714,7 @@ wWG
 wWG
 wWG
 wWG
-wWG
+hLU
 wWG
 wWG
 wWG
@@ -44849,7 +44927,7 @@ bVH
 bVH
 bVH
 bVH
-opi
+aTA
 aTA
 aTA
 aTA
@@ -44880,8 +44958,8 @@ akh
 akh
 imZ
 tCu
-orZ
-orZ
+hLU
+hLU
 tCu
 imZ
 akh
@@ -44893,7 +44971,7 @@ wWG
 wWG
 wWG
 wWG
-wWG
+hLU
 wWG
 wWG
 wWG
@@ -45106,15 +45184,15 @@ bVH
 rVX
 bVH
 aTA
-opi
 aTA
-aTA
-aTA
-opi
+ldZ
+ldZ
+ldZ
+ldZ
 huB
 huB
 huB
-opi
+ldZ
 bVH
 bVH
 xpR
@@ -45149,8 +45227,8 @@ shC
 shC
 shC
 shC
-shC
-shC
+wgF
+wgF
 shC
 shC
 shC
@@ -45364,14 +45442,14 @@ bVH
 bVH
 bVH
 bVH
-aTA
-aTA
-aTA
-opi
+nlP
+wgF
+shC
+shC
 kEJ
 wgF
 kEJ
-opi
+ldZ
 bVH
 bVH
 xpR
@@ -45405,9 +45483,9 @@ bVH
 aTA
 shC
 shC
-shC
-shC
-shC
+wgF
+wgF
+wgF
 shC
 shC
 shC
@@ -45621,10 +45699,10 @@ rVX
 bVH
 bVH
 bVH
-aTA
-aTA
-aTA
-ldZ
+dgI
+wgF
+wgF
+shC
 gvq
 ahT
 gvq
@@ -45658,12 +45736,12 @@ bVH
 bVH
 bVH
 bVH
-aTA
-aTA
-shC
-shC
-shC
-shC
+wgF
+wgF
+yde
+wgF
+wgF
+wgF
 shC
 shC
 shC
@@ -45878,10 +45956,10 @@ bVH
 bVH
 bVH
 rVX
-aTA
-aTA
-aTA
-ldZ
+nlP
+fxg
+wgF
+fxg
 iCX
 dXi
 xKA
@@ -45915,11 +45993,11 @@ bVH
 bVH
 bVH
 bVH
-aTA
-aTA
-shC
-shC
-shC
+wgF
+wgF
+vQX
+wgF
+wgF
 shC
 shC
 shC
@@ -46135,10 +46213,10 @@ bVH
 bVH
 bVH
 bVH
-aTA
-aTA
-aTA
 ldZ
+aTA
+dXi
+dXi
 dXi
 gCg
 gCg
@@ -46392,16 +46470,16 @@ bVH
 rVX
 bVH
 bVH
-aTA
-aTA
-aTA
 ldZ
+aTA
+aTA
+dXi
 dXi
 teJ
 dXi
 ldZ
-shC
-shC
+ldZ
+hyk
 bVH
 bVH
 bVH
@@ -46649,17 +46727,17 @@ bVH
 bVH
 bVH
 bVH
-aTA
-aTA
-aTA
 ldZ
+aTA
+aTA
+aTA
 dXi
 teJ
 dXi
-ldZ
 shC
 shC
-shC
+huB
+huB
 bVH
 bVH
 bVH
@@ -46906,19 +46984,19 @@ rVX
 bVH
 bVH
 bVH
-aTA
-aTA
-aTA
 ldZ
+aTA
+aTA
+aTA
 teJ
 dXi
 gCg
+gCg
+ebu
+wgF
+oyK
 huB
-wgF
-wgF
-shC
-shC
-shC
+ldZ
 bVH
 bVH
 bVH
@@ -47163,19 +47241,19 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
 ldZ
+aTA
+aTA
+aTA
 vto
 iCX
 iCX
-huB
-wgF
+gCg
+gvq
 wgF
 wgF
 shC
-shC
+ldZ
 aTA
 aTA
 bVH
@@ -47420,10 +47498,10 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
 ldZ
+aTA
+aTA
+aTA
 dTc
 tai
 tai
@@ -47432,7 +47510,7 @@ shC
 shC
 shC
 shC
-shC
+ldZ
 shC
 shC
 shC
@@ -47677,10 +47755,10 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
 ldZ
+aTA
+aTA
+aTA
 tTZ
 iVr
 iVr
@@ -47689,7 +47767,7 @@ shC
 shC
 shC
 shC
-shC
+ldZ
 shC
 shC
 shC
@@ -57502,14 +57580,14 @@ shC
 shC
 shC
 shC
-oqm
-oqm
-oqm
-oqm
-oqm
-oqm
-oqm
-oqm
+jNS
+jNS
+jNS
+jNS
+jNS
+jNS
+jNS
+jNS
 shC
 shC
 shC
@@ -57759,14 +57837,14 @@ shC
 shC
 shC
 shC
-oqm
+jNS
 ugX
 ugX
 ugX
 ugX
 ugX
 ugX
-oqm
+jNS
 shC
 shC
 shC
@@ -58016,14 +58094,14 @@ shC
 shC
 shC
 shC
-oqm
+jNS
 ugX
 fPw
 fPw
 fPw
 fPw
 ugX
-oqm
+jNS
 shC
 shC
 shC
@@ -58273,14 +58351,14 @@ shC
 shC
 shC
 shC
-oqm
+jNS
 ugX
 fPw
 fPw
 fPw
 fPw
 ugX
-oqm
+jNS
 shC
 shC
 shC
@@ -58530,14 +58608,14 @@ shC
 shC
 shC
 shC
-oqm
+jNS
 ugX
 fPw
 fPw
 pfs
 fPw
 ugX
-oqm
+jNS
 shC
 shC
 shC
@@ -58787,14 +58865,14 @@ shC
 shC
 shC
 shC
-oqm
+jNS
 ugX
 dfi
 avk
 avk
 dfi
 ugX
-oqm
+jNS
 shC
 shC
 shC
@@ -59044,14 +59122,14 @@ shC
 shC
 shC
 shC
-oqm
+jNS
 wQG
 mHk
 tvB
 tvB
 mHk
 kuu
-oqm
+jNS
 shC
 shC
 shC

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -395,7 +395,6 @@
 	icon_state = "boarded";
 	opacity = 1
 	},
-/obj/structure/timeddoor/onetwozerominutes,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/tunnel)
 "du" = (
@@ -738,12 +737,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave/hallways)
 "gd" = (
-/obj/structure/obstacle/barbedwire/end{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
+/obj/structure/nest/coldghouls,
+/turf/open/indestructible/ground/outside/snow,
 /area/f13/mountain_area)
 "gh" = (
 /obj/structure/obstacle/barbedwire{
@@ -925,6 +920,8 @@
 /area/f13/enclave/medbay)
 "hq" = (
 /obj/machinery/light,
+/obj/structure/closet,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "hr" = (
@@ -1343,7 +1340,6 @@
 	icon_state = "boarded";
 	opacity = 1
 	},
-/obj/structure/timeddoor/onetwozerominutes,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/tunnel)
 "jT" = (
@@ -2762,6 +2758,8 @@
 /area/f13/enclave/armory)
 "tY" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "ua" = (
@@ -2883,8 +2881,8 @@
 	},
 /area/f13/enclave)
 "uR" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "uT" = (
@@ -3017,7 +3015,6 @@
 	icon_state = "boarded";
 	opacity = 1
 	},
-/obj/structure/timeddoor/onetwozerominutes,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/tunnel)
 "vS" = (
@@ -4453,13 +4450,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave/hallways)
 "GS" = (
-/obj/structure/obstacle/barbedwire/end{
-	dir = 8
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "ENCLAVENML"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/mountain_area)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/f13,
+/area/f13/enclave)
 "GU" = (
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
@@ -4702,7 +4699,9 @@
 /turf/open/floor/f13,
 /area/f13/enclave)
 "Iv" = (
-/obj/structure/nest/coldghouls,
+/obj/structure/nest/coldghouls{
+	max_mobs = 2
+	},
 /turf/open/indestructible/ground/outside/snow_plating,
 /area/f13/mountain_area)
 "Iw" = (
@@ -5411,7 +5410,6 @@
 	icon_state = "boarded";
 	opacity = 1
 	},
-/obj/structure/timeddoor/onetwozerominutes,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/tunnel)
 "Oq" = (
@@ -6271,6 +6269,7 @@
 	network = list("Enclave");
 	dir = 1
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "Vf" = (
@@ -6281,16 +6280,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave/vertibird)
 "Vg" = (
-/obj/effect/decal/marking{
-	icon_state = "doublevertical"
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
 	},
-/obj/structure/obstacle/barbedwire{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/mountain_area)
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/enclave)
 "Vk" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/snow_plating,
@@ -6799,8 +6793,7 @@
 /area/f13/enclave/virology)
 "Zt" = (
 /obj/structure/nest/coldghouls{
-	max_mobs = 2;
-	spawn_time = 40
+	max_mobs = 2
 	},
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/mountain_area)
@@ -23828,7 +23821,7 @@ AW
 PC
 Jx
 At
-Jx
+sH
 AW
 SP
 SP
@@ -25110,7 +25103,7 @@ hG
 sO
 JF
 AW
-Jx
+zW
 Jx
 Jx
 Ks
@@ -25367,10 +25360,10 @@ AW
 AW
 AW
 AW
-uR
-Jx
-Jx
-Jx
+pv
+Vg
+ml
+Vg
 AW
 SP
 SP
@@ -25624,7 +25617,7 @@ Vy
 hz
 Jb
 AW
-zW
+Jx
 Jx
 Jx
 hq
@@ -25881,8 +25874,8 @@ Vy
 RF
 DI
 AW
-sH
 Jx
+GS
 Jx
 tY
 AW
@@ -26141,7 +26134,7 @@ og
 Jx
 wa
 Jx
-Jx
+uR
 AW
 SP
 kn
@@ -49564,7 +49557,7 @@ ez
 ez
 ez
 ez
-Zt
+gd
 ez
 ez
 ez
@@ -51121,7 +51114,7 @@ Sl
 Er
 ez
 ez
-Zt
+gd
 ez
 hy
 WE
@@ -51135,8 +51128,8 @@ SA
 Er
 ez
 ez
+gd
 ez
-Zt
 ez
 ez
 ez
@@ -57540,7 +57533,7 @@ ez
 ez
 ez
 ez
-Zt
+gd
 ez
 ez
 ez
@@ -57785,7 +57778,7 @@ ez
 ez
 ez
 ez
-Zt
+gd
 ez
 SA
 Sl
@@ -69765,7 +69758,7 @@ Ry
 ic
 jo
 Ry
-gd
+Ry
 Ry
 ex
 ie
@@ -70022,7 +70015,7 @@ mV
 mV
 HO
 mV
-Vg
+mV
 rt
 mK
 pd
@@ -70279,7 +70272,7 @@ Ry
 Ry
 jo
 Ry
-GS
+Ry
 Ry
 iH
 ie


### PR DESCRIPTION
## About The Pull Request
Fixes a host of issues listed in the changelog- some of which I will state here. Restores the enclave no-mans entry. Fixes south bunker timer back to 30mins. Fixes north-casper town timer to 0 from 2 hours. Fixes bugged cold feral spawners that insta-spawned ghouls at lightspeed and were unfun to fight. Adds more exit variety to no mans entries to make camping harder (even tho camping will likely get you smacked anyways. Flanking my beloved.)

## Why It's Good For The Game
Casper is less cancerous to traverse. Enclave can into no-mans land. More exit variety in no mans. South bunker cant be completed before the 30min mark again.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑
add: Enclave NML entrance
add: More entry variety into no mans
del: 2hr door timer in north of casper
add: 30min timer to south bunker
fix: fixed bugged cold feral spawners in casper
del: 3 pieces of barbed wire from casper entrance
balance: increased NML shotgunner melee AP from 0 to 0.2
balance: decreased NML shotgunner melee queue distance from 4 to 2
🆑 