### PR TITLE
Rubber Bullet Removal (Except Non-Lethal Shotgun Shells)

### DIFF
--- a/code/modules/fallout/resources/factory.dm
+++ b/code/modules/fallout/resources/factory.dm
@@ -144,7 +144,6 @@
 			"5mm" = image(icon = 'icons/fallout/objects/guns/ammo.dmi', icon_state = "5mmbox"),
 			"mfc" = image(icon = 'icons/fallout/objects/powercells.dmi', icon_state = "mfc-full"),
 			"4.73mm" = image(icon = 'icons/fallout/objects/guns/ammo.dmi', icon_state = "ammobox"),
-			"Rubber 4.73mm" = image(icon = 'icons/fallout/objects/guns/ammo.dmi', icon_state = "ammobox")
 			)
 		var/list/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE)
 		switch(choice)
@@ -178,9 +177,6 @@
 			if("4.73mm")
 				to_chat(user, "You chose 4.73mm.")
 				new /obj/item/ammo_box/a473(drop_location)
-			if("Rubber 4.73mm")
-				to_chat(user, "You chose rubber 4.73mm.")
-				new /obj/item/ammo_box/a473/rubber(drop_location)
 			else
 				return
 		flick("research_key_off", src)
@@ -193,4 +189,3 @@
 		return
 	else
 		to_chat(user, "[goal - progress] until an item is ready to be dispensed.")
-

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -5,10 +5,6 @@
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/c10mm
 
-/obj/item/ammo_casing/c10mm/rubber
-	name = "A 10mm rubber bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c10mm/rubber
-
 /obj/item/ammo_casing/c10mm/incendiary
 	name = "A 10mm incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c10mm/incendiary
@@ -24,11 +20,6 @@
 	name = "homemade 9mm bullet casing"
 	desc = "A homemade 9mm bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c9mm/improv
-
-/obj/item/ammo_casing/c9mm/rubber
-	name = "9mm rubber bullet casing"
-	desc = "A 9mm rubber bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c9mm/rubber
 
 /obj/item/ammo_casing/c9mm/incendiary
 	name = "9mm incendiary bullet casing"
@@ -60,11 +51,6 @@
 	desc = "A .22lr bullet casing."
 	caliber = ".22lr"
 	projectile_type = /obj/item/projectile/bullet/c22
-
-/obj/item/ammo_casing/a22/rubber
-	name = ".22lr rubber bullet casing"
-	desc = "A .22lr rubber bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c22/rubber
 
 /obj/item/ammo_casing/a22/shock
 	name = ".22lr shock bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -34,11 +34,6 @@
 	caliber = "38"
 	projectile_type = /obj/item/projectile/bullet/c38/improv
 
-/obj/item/ammo_casing/c38/rubber
-	name = ".38 special rubber bullet casing"
-	desc = "A .38 specia rubber bullet casing. For when you want to be extra useless."
-	projectile_type = /obj/item/projectile/bullet/c38/rubber
-
 /obj/item/ammo_casing/c38/incendiary
 	name = ".38 special incendiary bullet casing"
 	desc = "A .38 special incendiary bullet casing. For when you want to be slightly less useless."

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -21,23 +21,12 @@
 	desc = "Not depleted uranium. Regular uranium."
 	projectile_type = /obj/item/projectile/bullet/a762/uraniumtipped
 
-
-/obj/item/ammo_casing/a762/rubber
-	name = "7.62 rubber bullet casing"
-	desc = "A 7.62 rubber bullet casing, for training purposes."
-	projectile_type = /obj/item/projectile/bullet/a762/rubber
-
 // 5.56mm
 /obj/item/ammo_casing/a556
 	name = "5.56mm FMJ bullet casing"
 	desc = "A 5.56mm bullet casing."
 	caliber = "a556"
 	projectile_type = /obj/item/projectile/bullet/a556
-
-/obj/item/ammo_casing/a556/rubber
-	name = "5.56mm rubber bullet casing"
-	desc = "A 5.56mm rubber bullet casing, for training purposes."
-	projectile_type = /obj/item/projectile/bullet/a556/rubber
 
 /obj/item/ammo_casing/a556/microshrapnel
 	name = "5.56mm microshrapnel bullet casing"
@@ -61,7 +50,6 @@
 	desc = "A 5mm bullet casing."
 	caliber = "a5mm"
 	projectile_type = /obj/item/projectile/bullet/a5mm
-
 
 /obj/item/ammo_casing/a5mm/shock
 	name = "5mm shock bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -1,4 +1,4 @@
-// .45 
+// .45
 
 /obj/item/ammo_casing/c45
 	name = ".45 FMJ bullet casing"
@@ -10,9 +10,3 @@
 	name = ".45 incendiary bullet casing"
 	desc = "A .45 incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c45/incendiary
-
-/obj/item/ammo_casing/c45/rubber
-	name = "a .45 rubber bullet casing"
-	desc = "A .45 rubber bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c45/rubber
-

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -22,11 +22,6 @@
 	icon_state = "50ex2"
 	projectile_type = /obj/item/projectile/bullet/a50MG/explosive
 
-/obj/item/ammo_casing/a50MG/rubber
-	name = ".50 MG rubber bullet casing"
-	desc = "Who makes .50 in rubber? This is going to kill someone."
-	projectile_type = /obj/item/projectile/bullet/a50MG/rubber
-
 /obj/item/ammo_casing/a50MG/penetrator
 	name = ".50 MG penetrator bullet casing"
 	desc = "This titanium-reinforced highpower bullet will penetrate anything. Yes. Anything."

--- a/code/modules/projectiles/ammunition/caseless/ballistic.dm
+++ b/code/modules/projectiles/ammunition/caseless/ballistic.dm
@@ -5,10 +5,6 @@
 	icon_state = "762-casing"
 	projectile_type = /obj/item/projectile/bullet/a473
 
-/obj/item/ammo_casing/caseless/a473/rubber
-	name = "4.73mm polyurethane cartridge"
-	projectile_type  = /obj/item/projectile/bullet/a473/rubber
-
 /obj/item/ammo_casing/caseless/a473/incendiary
 	name = "4.73mm tracer cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/incendiary

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -62,11 +62,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron = 6000, /datum/material/blackpowder = 1000)
 
-/obj/item/ammo_box/m22/rubber
-	name = "ammo box (.22lr rubber)"
-	desc = "A box of .22 rubber rounds. For when you want to be useless."
-	ammo_type = /obj/item/ammo_casing/a22/rubber
-
 /obj/item/ammo_box/m22/shock
 	name = "ammo box (.22lr electroshock)"
 	icon_state = "22shockbox"
@@ -83,14 +78,6 @@
 	ammo_type = /obj/item/ammo_casing/c9mm
 	max_ammo = 30
 	custom_materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1000)
-
-/obj/item/ammo_box/c9mm/rubber
-	name = "ammo box (9mm rubber)"
-	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	icon_state = "9mmbox"
-	multiple_sprites = 2
-	caliber = "9mm"
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
 
 /obj/item/ammo_box/c9mm/incendiary
 	name = "ammo box (9mm incendiary-tipped)"
@@ -114,13 +101,6 @@
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 30
 	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
-
-/obj/item/ammo_box/c38box/rubber
-	name = "ammo box (.38 rubber)"
-	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	icon_state = "38box"
-	multiple_sprites = 2
-	ammo_type = /obj/item/ammo_casing/c38/rubber
 
 /obj/item/ammo_box/c38box/incendiary
 	name = "ammo box (.38 incendiary-tipped)"
@@ -151,10 +131,6 @@
 	desc = "A box of 10mm incendiary-tipped rounds. This'll burn."
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	ammo_type = /obj/item/ammo_casing/c10mm/incendiary
-
-/obj/item/ammo_box/c10mm/rubber
-	name = "ammo box (10mm rubber)"
-	ammo_type = /obj/item/ammo_casing/c10mm/rubber
 
 /obj/item/ammo_box/c10mm/improvised
 	name = "bag with reloaded 10mm bullets"
@@ -237,14 +213,6 @@
 	max_ammo = 30
 	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 
-/obj/item/ammo_box/c45/rubber
-	name = "ammo box (.45 rubber)"
-	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	caliber = ".45"
-	multiple_sprites = 2
-	icon_state = "45box"
-	ammo_type = /obj/item/ammo_casing/c45/rubber
-
 /obj/item/ammo_box/c45/incendiary
 	name = "ammo box (.45 incendiary-tipped)"
 	ammo_type = /obj/item/ammo_casing/c45/incendiary
@@ -313,14 +281,6 @@
 	name = "ammo box (.223 sport)"
 	ammo_type = /obj/item/ammo_casing/a556/sport
 	custom_materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1000)
-
-/obj/item/ammo_box/a556/rubber
-	name = "ammo box (5.56 rubber)"
-	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	icon_state = "556box"
-	multiple_sprites = 2
-	caliber = "a556"
-	ammo_type = /obj/item/ammo_casing/a556/rubber
 
 /obj/item/ammo_box/a556/microshrapnel
 	name = "ammo box (5.56 microshrapnel)"
@@ -393,14 +353,6 @@
 	desc = "Now with EVEN MORE fragments!"
 	ammo_type = /obj/item/ammo_casing/a762/microshrapnel
 
-/obj/item/ammo_box/a762box/rubber
-	name = "ammo box (7.62x51 rubber)"
-	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	icon_state = "762box"
-	multiple_sprites = 2
-	caliber = "a762"
-	ammo_type = /obj/item/ammo_casing/a762/rubber
-
 
 //.50 MG and 14mm
 /obj/item/ammo_box/a50MGbox
@@ -413,14 +365,6 @@
 	max_ammo = 25
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 1500)
-
-/obj/item/ammo_box/a50MGbox/rubber
-	name = "ammo box (.50 rubber)"
-	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	icon_state = "50box"
-	multiple_sprites = 2
-	caliber = "a50MG"
-	ammo_type = /obj/item/ammo_casing/a50MG/rubber
 
 /obj/item/ammo_box/a50MGbox/contam
 	name = "ammo box (12.7mm contaminated)"
@@ -458,10 +402,6 @@
 	multiple_sprites = 2
 	ammo_type = /obj/item/ammo_casing/caseless/a473
 	max_ammo = 50
-
-/obj/item/ammo_box/a473/rubber
-	name = "ammo box (4.73mm less-than-lethal)"
-	ammo_type = /obj/item/ammo_casing/caseless/a473/rubber
 
 /obj/item/ammo_box/a473/incendiary
 	name = "ammo box (4.73mm incendiary)"

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -54,11 +54,11 @@ Uranium, Contaminated
 /obj/item/projectile/bullet/c22/rubber
 	name = ".22lr rubber bullet"
 	damage = 2
-	stamina = 22
+	stamina = 6
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	dmg_dropoff_per_tile = 2 * 0.5 / 10
-	stam_dropoff_per_tile = 22 * 0.5 / 10
+	stam_dropoff_per_tile = 6 * 0.5 / 10
 
 /obj/item/projectile/bullet/c22/shock
 	name = ".22lr shock bullet"

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -51,15 +51,6 @@ Uranium, Contaminated
 	if(damage < 0 && stamina < 0)
 		qdel(src)
 
-/obj/item/projectile/bullet/c22/rubber
-	name = ".22lr rubber bullet"
-	damage = 2
-	stamina = 6
-	wound_bonus = 0
-	sharpness = SHARP_NONE
-	dmg_dropoff_per_tile = 2 * 0.5 / 10
-	stam_dropoff_per_tile = 6 * 0.5 / 10
-
 /obj/item/projectile/bullet/c22/shock
 	name = ".22lr shock bullet"
 	damage = 8
@@ -90,15 +81,6 @@ Uranium, Contaminated
 		stamina -= stam_dropoff_per_tile
 	if(damage < 0 && stamina < 0)
 		qdel(src)
-
-/obj/item/projectile/bullet/c38/rubber
-	name = ".38 rubber bullet"
-	damage = 4
-	stamina = 32
-	wound_bonus = 0
-	sharpness = SHARP_NONE
-	dmg_dropoff_per_tile = 4 * 0.5 / 10
-	stam_dropoff_per_tile = 32 * 0.5 / 10
 
 /obj/item/projectile/bullet/c38/improv
 	damage = 12
@@ -165,15 +147,6 @@ Uranium, Contaminated
 	damage = 18
 	dmg_dropoff_per_tile = 0
 	var/extra_speed = 500
-
-/obj/item/projectile/bullet/c9mm/rubber
-	name = "9mm rubber bullet"
-	damage = 6
-	stamina = 25
-	wound_bonus = 0
-	sharpness = SHARP_NONE
-	dmg_dropoff_per_tile = 6 * 0.5 / 10
-	stam_dropoff_per_tile = 25 * 0.5 / 10
 
 /obj/item/projectile/bullet/c9mm/acid
 	name = "9mm acid-tipped bullet"
@@ -246,15 +219,6 @@ Uranium, Contaminated
 	wound_bonus = 24
 	dmg_dropoff_per_tile = 0
 
-/obj/item/projectile/bullet/c10mm/rubber
-	name = "10mm rubber bullet"
-	damage = 8
-	stamina = 26
-	wound_bonus = 0
-	sharpness = SHARP_NONE
-	dmg_dropoff_per_tile = 8 * 0.25 / 10
-	stam_dropoff_per_tile = 26 * 0.25 / 10
-
 /obj/item/projectile/bullet/c10mm/incendiary
 	name = "10mm incendiary bullet"
 	damage = 5
@@ -301,15 +265,6 @@ Uranium, Contaminated
 	damage = 28
 	var/extra_speed = 500
 	dmg_dropoff_per_tile = 0
-
-/obj/item/projectile/bullet/c45/rubber
-	name = ".45 rubber bullet"
-	damage = 6
-	stamina = 24
-	sharpness = SHARP_NONE
-	wound_bonus = 0
-	dmg_dropoff_per_tile = 6 * 0.25 / 10
-	stam_dropoff_per_tile = 24 * 0.25 / 10
 
 /obj/item/projectile/bullet/c45/incendiary
 	name = ".45 incendiary bullet"

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -60,15 +60,6 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	supereffective_damage = 15
 	supereffective_faction = list("hostile", "ant", "deathclaw", "cazador", "china", "gecko", "radscorpion") //5.56 being effective against the Chinese is a funny code joke that someone will look at like 4 years from now on and cry about.
 
-/obj/item/projectile/bullet/a556/rubber
-	name = "5.56 rubber bullet"
-	damage = 8
-	stamina = 32
-	sharpness = SHARP_NONE
-	armour_penetration = 0
-	wound_bonus = 0
-	bare_wound_bonus = 0
-
 /obj/item/projectile/bullet/a556/microshrapnel
 	name = "5.56 microshrapnel bullet"
 	damage = 12
@@ -111,15 +102,6 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	bare_wound_bonus = 32
 	supereffective_damage = 14
 	supereffective_faction = list("hostile", "ant", "deathclaw", "cazador", "gecko", "radscorpion")
-
-/obj/item/projectile/bullet/a762/rubber
-	name = "7.62 rubber bullet"
-	damage = 12
-	stamina = 30
-	sharpness = SHARP_NONE
-	armour_penetration = 0
-	wound_bonus = 0
-	bare_wound_bonus = 0
 
 /obj/item/projectile/bullet/a762/sport/simple //for simple mobs, separate to allow balancing
 	name = ".308 bullet"
@@ -176,13 +158,6 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	..()
 	explosion(target, 0, 1, 1, 1)
 
-/obj/item/projectile/bullet/a50MG/rubber
-	name = ".50 rubber bullet"
-	damage = 25
-	stamina = 100
-	armour_penetration = 0
-	sharpness = SHARP_NONE
-
 /obj/item/projectile/bullet/a50MG/penetrator
 	name = ".50 penetrator round"
 	damage = 50
@@ -234,14 +209,6 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	armour_penetration = 0.1
 	wound_bonus = 8
 	bare_wound_bonus = 12
-
-/obj/item/projectile/bullet/a473/rubber
-	name = "4.73 polyurethane bullet"
-	damage = 6
-	stamina = 24
-	sharpness = SHARP_NONE
-	wound_bonus = 0
-	bare_wound_bonus = 0
 
 /obj/item/projectile/bullet/a473/incendiary
 	name = "4.73 tracer bullet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -65,8 +65,8 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 2
-	stamina = 10
+	damage = 3.5
+	stamina = 20.5
 	sharpness = SHARP_NONE
 	embedding = null
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -52,7 +52,7 @@
 //PELLET SHELLS
 /obj/item/projectile/bullet/pellet
 	var/tile_dropoff = 0.45
-	var/tile_dropoff_s = 1.25
+	var/tile_dropoff_s = 2.5
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -135,25 +135,11 @@
 	materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1500)
 	category = list("initial", "Basic Ammo")
 
-/datum/design/ammolathe/c9mm/rubber
-	name = "9mm rubber ammo box"
-	id = "c9mmrubber_lathe"
-	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
-	build_path = /obj/item/ammo_box/c9mm/rubber
-	category = list("initial", "Simple Ammo")
-
 /datum/design/ammolathe/c10mm
 	name = "10mm FMJ ammo box"
 	id = "c10mm_lathe"
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 	build_path = /obj/item/ammo_box/c10mm
-	category = list("initial", "Simple Ammo")
-
-/datum/design/ammolathe/c10mm/rubber
-	name = "10mm rubber ammo box"
-	id = "c10mmrubber_lathe"
-	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
-	build_path = /obj/item/ammo_box/c10mm/rubber
 	category = list("initial", "Simple Ammo")
 
 /datum/design/ammolathe/a308
@@ -170,26 +156,12 @@
 	build_path = /obj/item/ammo_box/c38box
 	category = list("initial", "Simple Ammo")
 
-/datum/design/ammolathe/c38rubber
-	name = ".38 rubber ammo box"
-	id = "useless"
-	materials = list(/datum/material/iron = 8000, /datum/material/blackpowder = 1000)
-	build_path = /obj/item/ammo_box/c38box/rubber
-	category = list("initial", "Simple Ammo")
-
 /datum/design/ammolathe/a223
 	name = ".223 ammo box"
 	id = "a223"
 	build_path = /obj/item/ammo_box/a556/sport
 	materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 1000)
 	category = list("initial", "Simple Ammo")
-
-/datum/design/ammolathe/a50rubber
-	name = ".50 rubber ammo box"
-	id = "a50MGrubber"
-	materials = list(/datum/material/iron = 15000, /datum/material/blackpowder = 1500)
-	build_path = /obj/item/ammo_box/a50MGbox/rubber
-	category = list("initial", "Basic Ammo")
 
 /* --Tier 2 Ammo And Magazines-- */
 //Tier 2 Magazines
@@ -274,13 +246,6 @@
 	build_path = /obj/item/ammo_box/a556
 	category = list("initial", "Basic Ammo")
 
-/datum/design/ammolathe/a556rubber
-	name = "5.56mm rubber ammo box"
-	id = "a556rubber"
-	materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 1500)
-	build_path = /obj/item/ammo_box/a556/rubber
-	category = list("initial", "Basic Ammo")
-
 /datum/design/ammolathe/a5mm
 	name = "5mm FMJ ammo box"
 	id = "a5mm"
@@ -314,27 +279,6 @@
 	id = "a45fmj"
 	build_path = /obj/item/ammo_box/c45
 	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
-	category = list("initial", "Basic Ammo")
-
-/datum/design/ammolathe/a45rubber
-	name = ".45 ACP rubber ammo box"
-	id = "a45rubber"
-	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
-	build_path = /obj/item/ammo_box/c45/rubber
-	category = list("initial", "Basic Ammo")
-
-/datum/design/ammolathe/a22rubber
-	name = ".22 rubber ammo box"
-	id = "m22rubber"
-	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
-	build_path = /obj/item/ammo_box/m22/rubber
-	category = list("initial", "Basic Ammo")
-
-/datum/design/ammolathe/a762rubber
-	name = "7.62 rubber ammo box"
-	id = "a762_lathe_rubber"
-	materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1500)
-	build_path = /obj/item/ammo_box/a762box/rubber
 	category = list("initial", "Basic Ammo")
 
 /* --Tier 3 Ammo and Magazines -- */
@@ -581,13 +525,6 @@
 	id = "a473fmj"
 	materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 2000)
 	build_path = /obj/item/ammo_box/a473
-	category = list("initial", "Advanced Ammo")
-
-/datum/design/ammolathe/a473rubber
-	name = "4.73mm caseless rubber ammo box"
-	id = "a473rubber"
-	materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 1000)
-	build_path = /obj/item/ammo_box/a473/rubber
 	category = list("initial", "Advanced Ammo")
 
 /datum/design/ammolathe/a473incin


### PR DESCRIPTION
Removes rubber bullets due to them being more effective against other people than lethal bullets. They stamcrit faster than lethal bullets crit, and result in an easy kill for the person using them.

Non-lethal shotgun shells are kept and rubbershot has been buffed to more closely resemble beanbags in terms of effectiveness.

Rubbershot pellet changes:
Damage: 2 -> 3.5
Stamina damage: 10 -> 20.5