### PR TITLE
Fixes Gravel Footsteps

### DIFF
--- a/code/modules/fallout/turf/f13_floors.dm
+++ b/code/modules/fallout/turf/f13_floors.dm
@@ -56,20 +56,9 @@
 	desc = "Small pebbles, lots of them."
 	icon = 'icons/fallout/turfs/ground.dmi'
 	icon_state = "gravel"
-
-/turf/open/floor/plating/f13/inside/gravel/edge
-	icon_state = "graveledge"
-
-/turf/open/floor/plating/f13/inside/gravel/corner
-	icon_state = "gravelcorner"
-
-
-//GRAVEL OUTDOORS
-/turf/open/floor/plating/f13/inside/gravel
-	name = "gravel"
-	desc = "Small pebbles, lots of them."
-	icon = 'icons/fallout/turfs/ground.dmi'
-	icon_state = "gravel"
+	footstep = FOOTSTEP_GRAVEL
+	barefootstep = FOOTSTEP_GRAVEL
+	clawfootstep = FOOTSTEP_GRAVEL
 	sunlight_state = SUNLIGHT_SOURCE
 
 /turf/open/floor/plating/f13/inside/gravel/edge
@@ -77,9 +66,6 @@
 
 /turf/open/floor/plating/f13/inside/gravel/corner
 	icon_state = "gravelcorner"
-
-
-//New standard wood floor for most areas, oak for Legion and pure log cabins only, maple for NCR and mayor only, maybe a diner.
 
 #define SHROOM_SPAWN	1
 

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -601,7 +601,9 @@
 	name = "gravel"
 	icon_state = "graveldirt"
 	icon = 'icons/fallout/turfs/ground.dmi'
-//	step_sounds = list("human" = "erikafootsteps")
+	footstep = FOOTSTEP_GRAVEL
+	barefootstep = FOOTSTEP_GRAVEL
+	clawfootstep = FOOTSTEP_GRAVEL
 
 // New gravel, organized. Use directions for control. - Pebbles
 /turf/open/indestructible/ground/outside/gravel
@@ -611,10 +613,6 @@
 	footstep = FOOTSTEP_GRAVEL
 	barefootstep = FOOTSTEP_GRAVEL
 	clawfootstep = FOOTSTEP_GRAVEL
-
-/turf/open/indestructible/ground/outside/gravel/alt
-	name = "gravel"
-	icon_state = "gravel_alt"
 
 /turf/open/indestructible/ground/outside/gravel/path_desert
 	name = "gravel path"


### PR DESCRIPTION
## About The Pull Request
Many of the gravel turfs sounded like walking on metal or at least something that wasn't gravel. Fixed.

Also cleaned some duplicate code and a spriteless unused turf. Turfs probably need a wider cleanup, but at least this is sorted.
## Why It's Good For The Game
More immersive.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed gravel footsteps.
/:cl:
