### PR TITLE
Fixes Proto Kinetic Cells (+ INTEGRATION FIX)

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -582,7 +582,7 @@ Senior Scribe
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/aer9/recharger = 1,
 		/obj/item/stock_parts/cell/ammo/breeder = 2,
-		/obj/item/book/granter/crafting_recipe/blueprint/marksman = 1,,
+		/obj/item/book/granter/crafting_recipe/blueprint/marksman = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_three=1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_four=1,
 		/obj/item/book/granter/trait/explosives_advanced = 1

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -19,6 +19,8 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
+	can_charge = 0
+	can_remove = 0
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()


### PR DESCRIPTION
## About The Pull Request
These guns are self-recharging and weren't intended for cell removal, but since their energy gun parent does, it causes oddities (able to remove the cell but not replace) without these added vars.

Also fixes a typo from #426 that I think is causing recent integration failures.

## Why It's Good For The Game
These guns could be permanently broken if the cell was removed, so this fix is good. Another Discord report solved.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed issues with proto-kinetic cells.
/:cl:
