### PR TITLE
Fixes Loadout Hiking Backpack

### DIFF
--- a/modular_citadel/code/modules/client/loadout/hands.dm
+++ b/modular_citadel/code/modules/client/loadout/hands.dm
@@ -4,7 +4,7 @@
 
 /datum/gear/hands/backpack
 	name = "hiking backpack"
-	path = /obj/item/storage/backpack/old
+	path = /obj/item/storage/backpack
 	cost = 2
 
 /datum/gear/hands/backpack/duffel


### PR DESCRIPTION
## About The Pull Request
The 'Hiking Backpack' selectable in the loadout was the legacy version with reduced item capacity, which caused confusion and anger! Now it's the proper version.

## Why It's Good For The Game
Another Discord report solved.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed hiking backpack in loadout.
/:cl: