### PR TITLE
Fixes Currency Valuation

### DIFF
--- a/code/modules/fallout/obj/stack/f13Cash.dm
+++ b/code/modules/fallout/obj/stack/f13Cash.dm
@@ -102,7 +102,7 @@
 
 /obj/item/stack/f13Cash/proc/update_desc()
 	var/total_worth = get_item_credit_value()
-	desc = "It's worth [total_worth] [singular_name][ (latin) ? (( amount > 1 ) ? "i" : "us") : (( amount > 1 ) ? "s each" : "")].\n[flavor_desc]"
+	desc = "It's worth [total_worth] caps.\n[flavor_desc]"
 
 /obj/item/stack/f13Cash/get_item_credit_value()
 	return (amount*value)
@@ -113,6 +113,11 @@
 	update_icon()
 
 /obj/item/stack/f13Cash/use(used, transfer = FALSE, check = TRUE)
+	. = ..()
+	update_desc()
+	update_icon()
+
+/obj/item/stack/f13Cash/attackby(obj/item/stack/S, mob/user, params)
 	. = ..()
 	update_desc()
 	update_icon()
@@ -132,9 +137,11 @@
 	stack.loc = loc
 	stack.amount = round(rand(min_qty, max_qty))
 	stack.update_icon()
+	stack.update_desc()
 
 /* we have 6 icons, so we will use our own, instead of stack's   */
 /obj/item/stack/f13Cash/update_icon()
+	update_desc()
 	switch(amount)
 		if(1)
 			icon_state = "[initial(icon_state)]"

--- a/code/modules/fallout/obj/stack/f13Cash.dm
+++ b/code/modules/fallout/obj/stack/f13Cash.dm
@@ -97,7 +97,6 @@
 
 /obj/item/stack/f13Cash/Initialize(mapload)
 	. = ..()
-	update_desc()
 	update_icon()
 
 /obj/item/stack/f13Cash/proc/update_desc()
@@ -109,17 +108,10 @@
 
 /obj/item/stack/f13Cash/merge(obj/item/stack/S)
 	. = ..()
-	update_desc()
 	update_icon()
 
 /obj/item/stack/f13Cash/use(used, transfer = FALSE, check = TRUE)
 	. = ..()
-	update_desc()
-	update_icon()
-
-/obj/item/stack/f13Cash/attackby(obj/item/stack/S, mob/user, params)
-	. = ..()
-	update_desc()
 	update_icon()
 
 /obj/item/stack/f13Cash/random
@@ -137,7 +129,6 @@
 	stack.loc = loc
 	stack.amount = round(rand(min_qty, max_qty))
 	stack.update_icon()
-	stack.update_desc()
 
 /* we have 6 icons, so we will use our own, instead of stack's   */
 /obj/item/stack/f13Cash/update_icon()
@@ -249,6 +240,7 @@
 	merge_type = /obj/item/stack/f13Cash/ncr
 
 /obj/item/stack/f13Cash/ncr/update_icon()
+	update_desc()
 	switch(amount)
 		if(1  to 9)
 			icon_state = "[initial(icon_state)]"


### PR DESCRIPTION
## About The Pull Request

![34135](https://github.com/f13babylon/f13babylon/assets/132588088/57670fbf-ba08-4ec2-8e22-31daa36062e5)

Currency examine text is supposed to tell you how much something is worth in caps, but was broken in two ways:
1. It always told you something was worth x of _itself_, rather than caps.
(A denarius isn't worth four denarius, it's worth four caps.)
2. It would often revert to the base amount, telling you a stack was only worth the equivalent of what one in it would be. 
(10058 caps isn't worth 1 cap.)

Fixed.
## Why It's Good For The Game
Less confusing now.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed currency examine text.
/:cl: