### PR TITLE
Tweaks Ghoul Anthro Parts

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/legs_and_taurs.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/legs_and_taurs.dm
@@ -24,7 +24,7 @@
 	center = TRUE
 	dimension_x = 64
 	color_src = MATRIXED
-	recommended_species = list("human", "lizard", "insect", "mammal", "xeno", "jelly", "slimeperson", "podweak", "synthanthro")
+	recommended_species = list("human", "lizard", "insect", "mammal", "xeno", "jelly", "slimeperson", "podweak", "synthanthro", "ghoulanthro")
 	relevant_layers = list(BODY_ADJ_UPPER_LAYER, BODY_FRONT_LAYER)
 	var/taur_mode = NONE //Must be a single specific tauric suit variation bitflag. Don't do FLAG_1|FLAG_2
 	var/alt_taur_mode = NONE //Same as above.

--- a/code/modules/mob/dead/new_player/sprite_accessories/snouts.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/snouts.dm
@@ -30,7 +30,7 @@
 /datum/sprite_accessory/snouts/mam_snouts
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_snouts.dmi'
-	recommended_species = list("mammal", "slimeperson", "insect", "podweak", "lizard", "synthanthro")
+	recommended_species = list("mammal", "slimeperson", "insect", "podweak", "lizard", "synthanthro", "ghoulanthro")
 	relevant_layers = list(BODY_ADJ_LAYER, BODY_FRONT_LAYER)
 
 /datum/sprite_accessory/snouts/mam_snouts/is_not_visible(mob/living/carbon/human/H, tauric)

--- a/code/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -21,7 +21,7 @@
 /datum/sprite_accessory/tails/lizard
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-	recommended_species = list("mammal", "slimeperson", "podweak", "felinid", "insect", "synthanthro")
+	recommended_species = list("mammal", "slimeperson", "podweak", "felinid", "insect", "synthanthro", "ghoulanthro")
 	relevant_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_LAYER)
 
 /datum/sprite_accessory/tails_animated/lizard
@@ -937,7 +937,7 @@
 /datum/sprite_accessory/tails/mam_tails
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-	recommended_species = list("mammal", "slimeperson", "podweak", "felinid", "insect", "synthanthro")
+	recommended_species = list("mammal", "slimeperson", "podweak", "felinid", "insect", "synthanthro", "ghoulanthro")
 	relevant_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_LAYER)
 
 /datum/sprite_accessory/tails/mam_tails/none


### PR DESCRIPTION
## About The Pull Request
Most of the basic anthro parts for anthro ghouls (tails, snouts etc.) weren't 'recommended', which means they only showed if you activated mismatched markings. This was confusing for some players who thought they weren't there at all, and they should be recommended anyway, since it's a furry race.

## Why It's Good For The Game
Better for character creation.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog
:cl:
fix: Fixes creator parts for ghoulified anthromorphs.
/:cl:
