### PR TITLE
Fixes Enclave Synth Spawn

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -133,7 +133,7 @@
 
 #define F13AI			(1<<0)
 #define F13CYBORG		(1<<1)
-#define F13ENCBORG	(1<<2)
+#define F13ENCBORG		(1<<2)
 #define F13FOLCYBORG	(1<<3)
 
 #define WASTELAND		(1<<8)

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -826,6 +826,10 @@
 /datum/job/enclave/encborg/equip(mob/living/carbon/human/H, visualsOnly = FALSE, announce = TRUE, latejoin = FALSE, datum/outfit/outfit_override = null, client/preference_source)
 	return H.Robotize(FALSE, latejoin)
 
+
+/datum/job/enclave/encborg/override_latejoin_spawn()
+	return TRUE
+
 /datum/job/enclave/encborg/after_spawn(mob/living/silicon/robot/R, mob/M)
 	. = ..()
 	ADD_TRAIT(R, TRAIT_TECHNOPHREAK, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request
Enclave synths will now spawn in their base rather than having to awkwardly trawl all the way across the wasteland.

## Why It's Good For The Game
Less chance of leading some wastelander to the secret batcave.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed Enclave Synth spawn.
/:cl: