### PR TITLE
the khan rebuffening

### DIFF
--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -82,8 +82,8 @@
 	title = "Khan Enforcer"
 	flag = F13KHAN
 	faction = FACTION_KHAN
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 5
+	spawn_positions = 5
 	description = "You are a Khan, a member of the local band that the Chief has sent to scout these lands. Listen to the Chemist, and assure you've a steady supply of caps for the Chief."
 	supervisors = "the Senior Enforcer"
 	selection_color = "#ff915e"
@@ -151,12 +151,13 @@
 /datum/outfit/loadout/soldier
 	name = "Heavy Enforcer"
 	belt = /obj/item/storage/backpack/spearquiver
-	r_hand = /obj/item/gun/ballistic/shotgun/automatic/combat/auto5
+	r_hand = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/armored
 	head = /obj/item/clothing/head/helmet/f13/khan
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
 		/obj/item/twohanded/baseball/spiked = 1,
+		/obj/item/ammo_box/shotgun/buck = 4,
 		/obj/item/book/granter/trait/bigleagues = 1,
 		/obj/item/book/granter/trait/selection = 1)
 
@@ -174,11 +175,11 @@
 
 /datum/outfit/loadout/soldierc
 	name = "Scout Enforcer"
-	r_hand = /obj/item/gun/ballistic/rifle/repeater/trail
+	r_hand = /obj/item/gun/ballistic/rifle/hunting
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
 	head = /obj/item/clothing/head/helmet/f13/khan/bandana
 	backpack_contents = list(
-		/obj/item/ammo_box/m44box = 2,
+		/obj/item/ammo_box/a308 = 2,
 		/obj/item/attachments/scope = 1,
 		/obj/item/book/granter/trait/trekking = 1,
 		/obj/item/book/granter/trait/selection = 1)
@@ -205,26 +206,25 @@
 	glasses = /obj/item/clothing/glasses/sunglasses
 	belt = /obj/item/storage/belt/bandolier
 	backpack_contents = list(
-		/obj/item/book/granter/trait/chemistry = 1,
 		/obj/item/book/granter/trait/explosives_advanced = 1,
+		/obj/item/book/granter/trait/chemistry = 1,
+		/obj/item/book/granter/trait/lowsurgery = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
 
 //SENIOR =================================================================
 
 /datum/outfit/loadout/seniora
 	name = "Teachings of Regis"
-	suit_store = /obj/item/twohanded/sledgehammer/rockethammer
+	suit_store = /obj/item/gun/ballistic/automatic/shotgun/riot/boss
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/pistol/deagle = 1,
-		/obj/item/ammo_box/magazine/m44 = 2,
-		/obj/item/grenade/smokebomb = 1,
+		/obj/item/ammo_box/magazine/d12g = 2,
 		)
 
 /datum/outfit/loadout/seniorb
 	name = "Teachings of Jessup"
-	suit_store = /obj/item/gun/ballistic/automatic/assault_rifle/infiltrator
+	suit_store = /obj/item/gun/ballistic/automatic/assault_carbine/worn
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m556/rifle = 2,
+		/obj/item/ammo_box/magazine/m5mm = 2,
 		)
 
 /datum/outfit/loadout/seniorc
@@ -232,6 +232,8 @@
 	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/w308 = 3,
+		/obj/item/gun/ballistic/automatic/pistol/deagle = 1,
+		/obj/item/ammo_box/magazine/m44 = 2,
 		)
 
 
@@ -259,8 +261,8 @@
 	gloves = /obj/item/clothing/gloves/f13/blacksmith
 	r_pocket = /obj/item/flashlight/lantern
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
-		/obj/item/ammo_box/magazine/m9mmds = 2,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever = 1,
+		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/stack/sheet/metal/twenty = 2,
 		/obj/item/stack/sheet/mineral/wood/twenty = 1,
 		/obj/item/stack/sheet/leather/twenty = 1,
@@ -283,7 +285,7 @@
 
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/greasegun)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/auto5)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/lever_action)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/trail_carbine)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/remingtonhuntingrifle)
 

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -165,21 +165,21 @@
 	name = "Grunt Enforcer"
 	belt = /obj/item/storage/belt/bandolier
 	l_hand = /obj/item/melee/onehanded/machete/scrapsabre/khan
-	r_hand = /obj/item/gun/ballistic/automatic/smg/smg10mm
+	r_hand = /obj/item/gun/ballistic/automatic/smg/uzi
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
 	head = /obj/item/clothing/head/helmet/f13/khan/bandana
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/msmg10mm = 2,
+		/obj/item/ammo_box/magazine/msmg9mm = 3,
 		/obj/item/book/granter/trait/trekking = 1,
 		/obj/item/book/granter/trait/selection = 1)
 
 /datum/outfit/loadout/soldierc
 	name = "Scout Enforcer"
-	r_hand = /obj/item/gun/ballistic/rifle/hunting
+	r_hand = /obj/item/gun/ballistic/revolver/hunting
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
 	head = /obj/item/clothing/head/helmet/f13/khan/bandana
 	backpack_contents = list(
-		/obj/item/ammo_box/a308 = 2,
+		/obj/item/ammo_box/c4570 = 2,
 		/obj/item/attachments/scope = 1,
 		/obj/item/book/granter/trait/trekking = 1,
 		/obj/item/book/granter/trait/selection = 1)

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -222,9 +222,9 @@
 
 /datum/outfit/loadout/seniorb
 	name = "Teachings of Jessup"
-	suit_store = /obj/item/gun/ballistic/automatic/assault_carbine/worn
+	suit_store = /obj/item/gun/ballistic/automatic/assault_rifle/infiltrator
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m5mm = 2,
+		/obj/item/ammo_box/magazine/m556/rifle = 2,
 		)
 
 /datum/outfit/loadout/seniorc

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -431,13 +431,14 @@
 	semi_auto = TRUE
 	fire_sound = 'sound/f13weapons/riot_shotgun.ogg'
 
-//Boss' unique riot shotgun.
+//Khan S.E unique riot shotgun.
 /obj/item/gun/ballistic/automatic/shotgun/riot/boss
 	name = "Left Hand"
-	desc = "A compact riot shotgun with a large ammo drum and semi-automatic fire, designed to fight in close quarters. \
-	This one has engravings, dedicated to a 'Captain' of some sort. Odd."
+	desc = "A modified, fully metal and notably heavy riot shotgun with a large ammo drum and notably rapid semi-automatic fire, designed to fight in close quarters. \
+	This one has engravings, dedicated to a Khan Senior Enforcer."
 	fire_delay = 3
 	recoil = 1
+	slowdown = 0.65 //added so it's not just a straight upgrade sort of unique. total of 0.8 slowdown when used with S.E armor
 
 /obj/item/gun/ballistic/automatic/shotgun/pancor
 	name = "Pancor Jackhammer"


### PR DESCRIPTION
## About The Pull Request
Buffs the Khan SE and Khan loadouts as a whole by re-adding their favoured lever-action. None of this auto-5 shit given the lever action got hit by a nerf a while back. Also slides one to the armourer and makes sure all chemists get surgery as a QOL thing. Armourer can even craft them again!

## Why It's Good For The Game
Khan SE's loadouts mostly suck. Now they're very fucking good (Infiltrator is staying as it's being buffed in the rifle remake pr on request of Mazz, Uzi is being shuffled in place of the 10mm SMG for the same reason), given the SE is essentially the only power-role in the Khans. Giving khans back their old shotgun and fixing the surgery issue should help alleviate the issues that have been brought up with regards to the Khans in past- atleast partially.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑 
del: a single khan enforcer slot
tweak: provided melissa teachings a deagle
tweak: ensured both chemist loadouts learn some degree of surgery
balance: swapped auto-5's for lever action shotguns for khans
balance: swapped auto-5 recipe for lever action recipe for khans
balance: gave Khan Armorer a lever action shotgun
balance: swapped rocketsledge loadout with 'boss' riot shotgun
tweak: gave the boss riot shotgun extra slowdown
balance: swapped trail carbine for hunting revolver
balance: swapped 10mm smg for Uzi
🆑 