### PR TITLE
Fixes Towel Sprite Issues

### DIFF
--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -97,11 +97,6 @@
 			body_parts_covered = HEAD
 			flags_inv = HIDEHAIR
 
-/obj/item/reagent_containers/glass/rag/towel/dropped(mob/user)
-	. = ..()
-	body_parts_covered = NONE
-	flags_inv = NONE
-
 /obj/item/reagent_containers/glass/rag/towel/attack_self(mob/user)
 	if(!user.can_reach(src) || !user.dropItemToGround(src))
 		return

--- a/code/modules/reagents/reagent_containers/rags.dm
+++ b/code/modules/reagents/reagent_containers/rags.dm
@@ -158,11 +158,6 @@
 			body_parts_covered = HEAD
 			flags_inv = HIDEHAIR
 
-/obj/item/reagent_containers/rag/towel/dropped(mob/user)
-	. = ..()
-	body_parts_covered = NONE
-	flags_inv = NONE
-
 /obj/item/reagent_containers/rag/towel/attack_self(mob/user)
 	if(!user.can_reach(src) || !user.dropItemToGround(src))
 		return


### PR DESCRIPTION
## About The Pull Request
Wearing a towel on the head then taking it off could make your hair invisible until you toggled some clothing items around. Fixed.

## Why It's Good For The Game
Another Discord report solved. Classic example of overcoding.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed a sprite issue with towels.
/:cl:
