### PR TITLE
Fixes Year + Descriptions

### DIFF
--- a/code/modules/fallout/obj/decals.dm
+++ b/code/modules/fallout/obj/decals.dm
@@ -62,7 +62,6 @@
 
 /obj/effect/decal/riverbank
 	name = "riverbank"
-	desc = "try"
 	icon = 'icons/fallout/objects/decals.dmi'
 	icon_state = "riverbank"
 	anchored = 1
@@ -71,7 +70,6 @@
 
 /obj/effect/decal/riverbankcorner
 	name = "riverbankcorner"
-	desc = "try2"
 	icon = 'icons/fallout/objects/decals.dmi'
 	icon_state = "riverbank2"
 	anchored = 1

--- a/code/modules/mapping/map_config.dm
+++ b/code/modules/mapping/map_config.dm
@@ -48,7 +48,7 @@
 		"ferry" = "ferry_fancy",
 		"emergency" = "emergency_pahrump")
 
-	var/year_offset = 260 //2284 - 2024
+	var/year_offset = 259 //2283 - 2024
 
 	// "fun things"
 	/// Orientation to load in by default.

--- a/code/modules/mapping/map_config.dm
+++ b/code/modules/mapping/map_config.dm
@@ -48,7 +48,7 @@
 		"ferry" = "ferry_fancy",
 		"emergency" = "emergency_pahrump")
 
-	var/year_offset = 540 //The offset of ingame year from the actual IRL year. You know you want to make a map that takes place in the 90's. Don't lie.
+	var/year_offset = 260 //2284 - 2024
 
 	// "fun things"
 	/// Orientation to load in by default.


### PR DESCRIPTION
## About The Pull Request
![2283](https://github.com/f13babylon/f13babylon/assets/132588088/5b53b72c-a0ad-4281-b0e6-2787a3c1d8c7)
The year is now properly presented as 2283, as it is in canon.

Also fixed a weird description with riverbanks while I was here.

## Why It's Good For The Game
Another Discord report solved.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed inconsistencies with the server year.
/:cl:

