### PR TITLE
Improves Join Menu

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -83,9 +83,7 @@
 #define EXP_TYPE_RANGER         "Ranger"
 #define EXP_TYPE_SCRIBE         "Scribe"
 #define EXP_TYPE_DECANUS        "Decanus"
-#define EXP_TYPE_TRIBAL			"Tribal"
 #define EXP_TYPE_FOLLOWERS		"FoA"
-#define EXP_TYPE_OUTLAW			"Outlaw"
 #define EXP_TYPE_KHAN			"Great Khans"
 //Flags in the players table in the db
 #define DB_FLAG_EXEMPT 							(1<<0)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -156,12 +156,6 @@
 		if(rank in GLOB.wasteland_positions)
 			was[name] = rank
 			department = 1
-		if(rank in GLOB.tribal_positions)
-			tri[name] = rank
-			department = 1
-		if(rank in GLOB.outlaw_positions)
-			out[name] = rank
-			department = 1
 		if(!department && !(name in command))
 			misc[name] = rank
 	if(length(command))

--- a/code/modules/jobs/job_types/raider.dm
+++ b/code/modules/jobs/job_types/raider.dm
@@ -10,7 +10,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	access = list(ACCESS_RAIDER)
 	minimal_access = list(ACCESS_RAIDER)
 	exp_requirements = 0
-	exp_type = EXP_TYPE_OUTLAW
+	exp_type = EXP_TYPE_WASTELAND
 
 /datum/job/raider/f13raider
 	title = "Raider"

--- a/code/modules/jobs/job_types/tribal.dm
+++ b/code/modules/jobs/job_types/tribal.dm
@@ -7,7 +7,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	selection_color = "#825b73"
 	department_flag = TRIBAL
 	faction = FACTION_TRIBAL
-	exp_type = EXP_TYPE_TRIBAL
+	exp_type = EXP_TYPE_WASTELAND
 	access = list(ACCESS_TRIBE)
 	blacklisted_quirks = list(/datum/quirk/herbal_affinity)
 	social_faction = "Tribal"

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -232,18 +232,10 @@ GLOBAL_LIST_INIT(vault_positions, list(
 GLOBAL_LIST_INIT(wasteland_positions, list(
 	"Vigilante",
 	"Wastelander",
-))
-
-GLOBAL_LIST_INIT(tribal_positions, list(
-	"Tribal",
-	"Tribal Hunter",
-	"Tribal Gatherer",
-	"Tribal Shaman",
-))
-
-GLOBAL_LIST_INIT(outlaw_positions, list(
 	"Raider",
+	"Tribal",
 ))
+
 
 GLOBAL_LIST_INIT(khan_positions, list(
 	"Khan Senior Enforcer",
@@ -285,16 +277,14 @@ GLOBAL_LIST_INIT(followers_positions, list(
 
 // job categories for rendering the late join menu
 GLOBAL_LIST_INIT(position_categories, list(
+	EXP_TYPE_WASTELAND = list("jobs" = wasteland_positions, "color" = "#5a5a5a"),
+	EXP_TYPE_BIGHORN = list("jobs" = bighorn_positions, "color" = "#d7b088"),
 	EXP_TYPE_NCR = list("jobs" = ncr_positions, "color" = "#ffeeaa"),
 	EXP_TYPE_FOLLOWERS = list("jobs" = followers_positions, "color" = "#ffeeaa"),
-	EXP_TYPE_BROTHERHOOD = list("jobs" = brotherhood_positions, "color" = "#95a5a6"),
 	EXP_TYPE_LEGION = list("jobs" = legion_positions, "color" = "#f81717"),
-	EXP_TYPE_WASTELAND = list("jobs" = wasteland_positions, "color" = "#5a5a5a"),
-	EXP_TYPE_TRIBAL = list("jobs" = tribal_positions, "color" = "#825b73"),
-	EXP_TYPE_OUTLAW = list("jobs" = outlaw_positions, "color" = "#db3529"),
-	EXP_TYPE_ENCLAVE = list("jobs" = enclave_positions, "color" = "#434944"),
 	EXP_TYPE_KHAN = list("jobs" = khan_positions, "color" = "#006666"),
-	EXP_TYPE_BIGHORN = list("jobs" = bighorn_positions, "color" = "#d7b088"),
+	EXP_TYPE_BROTHERHOOD = list("jobs" = brotherhood_positions, "color" = "#95a5a6"),
+	EXP_TYPE_ENCLAVE = list("jobs" = enclave_positions, "color" = "#434944"),
 ))
 
 GLOBAL_LIST_INIT(exp_jobsmap, list(
@@ -308,10 +298,8 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 	EXP_TYPE_SILICON = list("titles" = list("AI","Cyborg")),
 	EXP_TYPE_SERVICE = list("titles" = civilian_positions),
 
-	EXP_TYPE_FALLOUT = list("titles" = brotherhood_positions | bighorn_positions | legion_positions | khan_positions | ncr_positions | vault_positions | wasteland_positions | tribal_positions | outlaw_positions | followers_positions | enclave_positions),
+	EXP_TYPE_FALLOUT = list("titles" = brotherhood_positions | bighorn_positions | legion_positions | khan_positions | ncr_positions | vault_positions | wasteland_positions | followers_positions | enclave_positions),
 
-	EXP_TYPE_OUTLAW = list("titles" = outlaw_positions),
-	EXP_TYPE_TRIBAL = list("titles" = tribal_positions),
 	EXP_TYPE_BROTHERHOOD = list("titles" = brotherhood_positions),
 	EXP_TYPE_BIGHORN = list("titles" = bighorn_positions),
 	EXP_TYPE_LEGION = list("titles" = legion_positions),

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -595,11 +595,11 @@
 		dat += jointext(dept_dat, "")
 		dat += "</fieldset><br>"
 		column_counter++
-		if(column_counter > 0 && (column_counter % 3 == 0))
+		if(column_counter > 0 && (column_counter % 2 == 0))
 			dat += "</td><td valign='top'>"
 	dat += "</td></tr></table></center>"
 	dat += "</div></div>"
-	var/datum/browser/popup = new(src, "latechoices", "Choose Profession", 680, 580)
+	var/datum/browser/popup = new(src, "latechoices", "Choose Profession", 900, 650)
 	popup.add_stylesheet("playeroptions", 'html/browser/playeroptions.css')
 	popup.set_content(jointext(dat, ""))
 	popup.open(FALSE) // 0 is passed to open so that it doesn't use the onclose() proc

--- a/html/browser/playeroptions.css
+++ b/html/browser/playeroptions.css
@@ -1,6 +1,6 @@
 .job {
   display: block;
-  width: 173px;
+  width: 187px;
 }
 
 .command {


### PR DESCRIPTION
## About The Pull Request
![newmenu](https://github.com/f13babylon/f13babylon/assets/132588088/2a0ffc5b-9fd7-411d-b9e7-3eb592f6f01b)

A new version of the join menu with some significant QoL changes.

- The window is bigger - no more scrolling! In fact, since it all fits, the scrollbars are just automatically gone. There was a concern that a lot of people weren't choosing town jobs as they were hidden unless you scrolled right.
- Raider and Tribal are now under 'Wasteland' with Wastelanders rather than having their own pointless one-role department. They are all otherwise unaffiliated wastelanders.
- More intuitive column grouping - Wasteland and Bighorn are neutral and beginner friendly factions, NCR and Follower are 'good' factions, Legion and Khan are 'bad' factions, and BoS and Enclave are snowflake factions. Generally I'd say the further right you go, the more specialist/complex it is.

## Why It's Good For The Game
Better and prettier.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
tweak: QoL tweaks to the join menu.
/:cl:

