### PR TITLE
Removes force weapon drop from CQC and Berserker

### DIFF
--- a/code/datums/martial/berserker.dm
+++ b/code/datums/martial/berserker.dm
@@ -81,7 +81,6 @@
 	else
 		D.apply_damage(damage*0.5, BRUTE, BODY_ZONE_HEAD, armor_block, wound_bonus = CANT_WOUND)
 		D.apply_damage(damage + 20, STAMINA, BODY_ZONE_HEAD, armor_block, wound_bonus = CANT_WOUND)
-		D.drop_all_held_items()
 		D.visible_message("<span class='warning'>[A] pummels [D]!</span>", \
 					"<span class='userdanger'>You are kicked in the head by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
 		to_chat(A, "<span class='danger'>You pummel [D]!</span>")

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -176,7 +176,6 @@
 			D.visible_message("<span class='warning'>[A] strikes [D]'s jaw with their hand!</span>", \
 							"<span class='userdanger'>[A] strikes your jaw, disorienting you!</span>")
 			playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
-			D.drop_all_held_items()
 			D.Jitter(2)
 			D.Dizzy(damage)
 			D.apply_damage(damage*2 + 20, STAMINA)


### PR DESCRIPTION
## About The Pull Request
Less stun-based combat of the local vex or centurion spam clicking harm then grab to instant force-disarm and down, ending the other guys round immediately. This should have been removed ages ago, I just kept being side-tracked- after seeing it used again while in ghost, figured I might as well get it out of the way.

## Why It's Good For The Game
Stun combat bad. No stun combat good. We removed most of the map baton spawns for a reason. Berserker still gets knockdown, but you aren't going to stun people into losing their weapon permanently now.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑
del: CQC & Berserker knockdown
🆑 