### PR TITLE
Improves Boot Storage

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -98,9 +98,17 @@
 
 /datum/component/storage/concrete/pockets/shoes/Initialize()
 	. = ..()
-	cant_hold = typecacheof(list(/obj/item/screwdriver/power))
+	cant_hold = typecacheof(list(/obj/item/screwdriver/power,
+								/obj/item/screwdriver/hightech,
+								/obj/item/kitchen/knife/butcher,
+								/obj/item/reagent_containers/pill/patch/bitterdrink,
+								/obj/item/reagent_containers/pill/patch/healingpoultice,
+								/obj/item/reagent_containers/pill/patch/healingpowder,
+								/obj/item/reagent_containers/pill/patch/hydra,
+								/obj/item/reagent_containers/pill/patch/turbo,
+								/obj/item/reagent_containers/hypospray/combat,
+								/obj/item/reagent_containers/hypospray/magillitis))
 	can_hold = GLOB.storage_shoes_can_hold
-
 
 /datum/component/storage/concrete/pockets/pocketprotector
 	max_items = 3
@@ -203,17 +211,26 @@ GLOBAL_LIST_INIT(storage_medical_can_hold, typecacheof(list(
 	)))
 
 GLOBAL_LIST_INIT(storage_shoes_can_hold, typecacheof(list(
+	/obj/item/melee/onehanded/knife,
 	/obj/item/melee/smith/dagger,
-	/obj/item/reagent_containers/syringe,
-	/obj/item/reagent_containers/hypospray/medipen,
-	/obj/item/reagent_containers/dropper,
+	/obj/item/melee/smith/throwingknife,
+	/obj/item/smithing/daggerblade,
+	/obj/item/smithing/throwingknife,
+	/obj/item/smithing/knifeblade,
+	/obj/item/nullrod/tribal_knife,
+	/obj/item/kitchen/fork,
+	/obj/item/kitchen/knife,
+	/obj/item/scalpel,
 	/obj/item/screwdriver,
 	/obj/item/weldingtool/mini,
 	/obj/item/pen,
+	/obj/item/reagent_containers/syringe,
+	/obj/item/reagent_containers/hypospray,
+	/obj/item/reagent_containers/dropper,
+	/obj/item/reagent_containers/pill,
+	/obj/item/reagent_containers/medspray,
 	/obj/item/gun/ballistic/revolver/detective,
 	/obj/item/gun/ballistic/revolver/hobo/knifegun,
-	/obj/item/melee/onehanded/knife,
-	/obj/item/scalpel,
 	)))
 
 GLOBAL_LIST_INIT(storage_holster_can_hold, typecacheof(list(


### PR DESCRIPTION
## About The Pull Request
The other variants of knife (i.e. kitchen knives) can now be inserted into boots, along with a few extra parts like knive parts and some more types of reagent container.

## Why It's Good For The Game
Should make holdout attempts a little more interesting, and it didn't make much sense how a survival knife fit but a kitchen knife wouldn't.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
tweak: More objects can now be inserted into boots - try other knife types!
/:cl: