### PR TITLE
7.62 Reload Bug Fix and 5.56 Casing Sprite Fix

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -3,7 +3,7 @@
 	name = "5.56mm FMJ bullet casing"
 	desc = "A 5.56mm bullet casing."
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	icon_state = "a762mm"
+	icon_state = "a556mm"
 	caliber = "a556mm"
 	projectile_type = /obj/item/projectile/bullet/a556mm
 

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -620,7 +620,7 @@
 	name = "stripper clip (7.62)"
 	desc = "A stripper clip."
 	icon_state = "762"
-	caliber = "a762"
+	caliber = "a762mm"
 	ammo_type = /obj/item/ammo_casing/a762mm
 	max_ammo = 5
 	multiple_sprites = 1
@@ -631,7 +631,7 @@
 	name = "stripper clip (.308)"
 	desc = "A stripper clip."
 	icon_state = "308"
-	caliber = "a762"
+	caliber = "a762mm"
 	ammo_type = /obj/item/ammo_casing/a762mm/sport
 	max_ammo = 5
 	multiple_sprites = 1
@@ -642,8 +642,8 @@
 	name = "double stack stripper clip (.308)"
 	desc = "A stripper clip."
 	icon_state = "762a"
-	caliber = "a762"
-	ammo_type = /obj/item/ammo_casing/a762mm/sport
+	caliber = "a762mm"
+	ammo_type = /obj/item/ammo_casing/a762mm
 	max_ammo = 10
 	multiple_sprites = 1
 	custom_materials = list(/datum/material/iron = 2000)

--- a/code/modules/projectiles/boxes_magazines/external/lmg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/lmg.dm
@@ -29,7 +29,7 @@
 	name = "sniper rifle magazine (7.62x51)"
 	icon_state = "sniper_mag"
 	ammo_type = /obj/item/ammo_casing/a762mm
-	caliber = "a762"
+	caliber = "a762mm"
 	max_ammo = 10
 	multiple_sprites = 2
 
@@ -78,7 +78,7 @@
 	name = "ammo box (7.62)"
 	icon_state = "r80"
 	ammo_type = /obj/item/ammo_casing/a762mm
-	caliber = "a762"
+	caliber = "a762mm"
 	max_ammo = 60
 	multiple_sprites = 2
 
@@ -91,7 +91,7 @@
 	icon_state = "762belt"
 	ammo_type = /obj/item/ammo_casing/a762mm/sport
 	max_ammo = 80
-	caliber = "a762"
+	caliber = "a762mm"
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/mm762/empty

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -72,7 +72,7 @@
 /obj/item/ammo_box/magazine/internal/cylinder/improvised762
 	name = "improvised internal magazine .308"
 	ammo_type = /obj/item/ammo_casing/a762mm/sport
-	caliber = "a762"
+	caliber = "a762mm"
 	max_ammo = 2
 
 /obj/item/ammo_box/magazine/internal/cylinder/thatgun

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -2,7 +2,7 @@
 	name = "bolt action rifle internal magazine"
 	desc = "Oh god, this shouldn't be here"
 	ammo_type = /obj/item/ammo_casing/a762mm
-	caliber = "a762"
+	caliber = "a762mm"
 	max_ammo = 5
 	multiload = 1
 
@@ -10,7 +10,7 @@
 	name = "bolt action rifle internal magazine"
 	desc = "Oh god, this shouldn't be here"
 	ammo_type = /obj/item/ammo_casing/a762mm
-	caliber = "a762"
+	caliber = "a762mm"
 	max_ammo = 10
 	multiload = 1
 
@@ -24,13 +24,13 @@
 //Fallout 13
 /obj/item/ammo_box/magazine/internal/boltaction/hunting
 	ammo_type = /obj/item/ammo_casing/a762mm/sport
-	caliber = "a762"
+	caliber = "a762mm"
 	max_ammo = 5
 	multiload = 1
 
 /obj/item/ammo_box/magazine/internal/boltaction/hunting/remington
 	ammo_type = /obj/item/ammo_casing/a762mm
-	caliber = "a762"
+	caliber = "a762mm"
 	max_ammo = 5
 	multiload = 1
 


### PR DESCRIPTION
Fixes an issue with certain weapons that use 7.62 being unable to reload. Also changes the 5.56 casings sprite to the actual 5.56 sprite.