### PR TITLE
Fixes Bus Boundaries

### DIFF
--- a/code/modules/fallout/obj/structures/wrecks.dm
+++ b/code/modules/fallout/obj/structures/wrecks.dm
@@ -30,16 +30,16 @@
 
 /obj/structure/wreck/bus/blue/alt
 	icon = 'icons/obj/vehicles/bus2.dmi'
-	bound_width = 192
-	bound_height = 64
+	bound_width = 64
+	bound_height = 192
 
 /obj/structure/wreck/bus/orange
 	icon_state = "orange"
 
 /obj/structure/wreck/bus/orange/alt
 	icon = 'icons/obj/vehicles/bus2.dmi'
-	bound_width = 192
-	bound_height = 64
+	bound_width = 64
+	bound_height = 192
 
 /obj/structure/wreck/bus/rusted
 	name = "wrecked bus"


### PR DESCRIPTION
## About The Pull Request
![buss](https://github.com/f13babylon/f13babylon/assets/132588088/c53e9b18-b346-48f1-9046-6f91b890a311)


Vertical wrecked buses were set at the same pixel boundaries as their horizontal counterparts, resulting in some odd collision as a result. Fixed.

## Why It's Good For The Game
Another report resolved. It's better to have proper collision with world objects.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed collision issues with vertical versions of wrecked buses.
/:cl: