### PR TITLE
Some Drum Magazine Changes

### DIFF
--- a/code/modules/fallout/f13lootdrop.dm
+++ b/code/modules/fallout/f13lootdrop.dm
@@ -1702,6 +1702,8 @@
 				/obj/item/ammo_box/a50MGbox,
 				/obj/item/ammo_box/c4570,
 				/obj/item/ammo_box/needle = 2,
+				/obj/item/ammo_box/magazine/msmg9mm/drum = 2,
+				/obj/item/ammo_box/magazine/mthompson/drum = 2,
 				/obj/item/ammo_box/tube/c4570 = 2,
 				/obj/item/ammo_box/magazine/d12g = 2,
 				/obj/item/ammo_box/magazine/m44 = 2,
@@ -1711,6 +1713,7 @@
 				/obj/item/ammo_box/magazine/amr = 2,
 				/obj/item/ammo_box/magazine/m556mm/extended = 2,
 				/obj/item/ammo_box/magazine/m5mm = 2,
+				/obj/item/ammo_box/magazine/m762mm/extended = 2,
 				/obj/item/stock_parts/cell/ammo/ec,
 	)
 
@@ -1723,15 +1726,12 @@
 	icon_state = "ammot4_loot"
 	lootdoubles = TRUE
 	loot = list(
-				/obj/item/ammo_box/magazine/msmg9mm/drum = 2,
-				/obj/item/ammo_box/magazine/mthompson/drum = 2,
 				/obj/item/ammo_box/magazine/mcalico = 2,
 				/obj/item/ammo_box/magazine/mp90 = 2,
 				/obj/item/ammo_box/magazine/msmg14mm/extended = 2,
 				/obj/item/ammo_box/magazine/m556mm/drum = 2,
 				/obj/item/ammo_box/magazine/m5mm/drum = 2,
 				/obj/item/ammo_box/magazine/mg11 = 2,
-				/obj/item/ammo_box/magazine/m762mm/extended = 2,
 				/obj/item/ammo_box/magazine/lmg = 2,
 				/obj/item/ammo_box/magazine/type88 = 2,
 				/obj/item/stock_parts/cell/ammo/mfc,

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -490,7 +490,7 @@ Paladin
 	name = "Tactical Paladin"
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/assault_rifle/r91 = 1,
-		/obj/item/ammo_box/magazine/m556mm/drum = 2,
+		/obj/item/ammo_box/magazine/m556mm = 2,
 		/obj/item/clothing/accessory/bos/paladin = 1,
 		/obj/item/clothing/accessory/bos/juniorpaladin = 1,
 		)

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -69,7 +69,7 @@
 	start_empty = 1
 
 /obj/item/ammo_box/magazine/m556mm/drum
-	name = "rifle drum magazine (5mm)"
+	name = "rifle drum magazine (5.56mm)"
 	icon_state = "mdrum"
 	max_ammo = 50
 

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -378,9 +378,9 @@
 	build_path = /obj/item/ammo_box/magazine/m556mm/extended/empty
 	category = list("initial", "Intermediate Magazines")
 
-/datum/design/ammolathe/m5mmext
+/datum/design/ammolathe/m5mm
 	name = "empty rifle magazine (5mm)"
-	id = "m5mmext"
+	id = "m5mm"
 	materials = list(/datum/material/iron = 16000)
 	build_path = /obj/item/ammo_box/magazine/m5mm/empty
 	category = list("initial", "Intermediate Magazines")
@@ -435,13 +435,6 @@
 	id = "mcalico"
 	materials = list(/datum/material/iron = 8000)
 	build_path = /obj/item/ammo_box/magazine/mcalico/empty
-	category = list("initial", "Advanced Magazines")
-
-/datum/design/ammolathe/mthompsondrum
-	name = "empty thompson drum magazine (.45 ACP)"
-	id = "mthompsondrum"
-	materials = list(/datum/material/iron = 8000)
-	build_path = /obj/item/ammo_box/magazine/mthompson/drum/empty
 	category = list("initial", "Advanced Magazines")
 
 /datum/design/ammolathe/mp90


### PR DESCRIPTION
- Fixed an issue where 5.56 drum magazines were incorrectly labeled as 5mm.
- Thompson drum magazines removed from ammunition bench recipe list.
- 9mm and Thompson drum magazines moved from ammo loot tier 4 to tier 3, meaning they will be more common.
- 20 round 7.62 magazines moved from ammo loot tier 4 to tier 3, meaning they will be more common.
- Paladins no longer spawn with 2 drum 5.56 magazines roundstart, now they get 2 regular 5.56 magazines intead.