### PR TITLE
Replaces Static Flagpoles

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -6293,7 +6293,7 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
 "hzc" = (
-/obj/item/renegade_flag,
+/obj/item/flag/renegade,
 /turf/closed/wall/mineral/wood,
 /area/f13/city)
 "hAm" = (
@@ -7679,7 +7679,7 @@
 	},
 /area/f13/bunker)
 "jcW" = (
-/obj/item/renegade_flag,
+/obj/item/flag/renegade,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/city)
 "jda" = (
@@ -16218,7 +16218,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "sTw" = (
-/obj/item/renegade_flag,
+/obj/item/flag/renegade,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "sUw" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -6455,7 +6455,7 @@
 /obj/structure/table/wood/settler{
 	name = "stage"
 	},
-/obj/item/bighorn_flag,
+/obj/item/flag/bighorn,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "dYU" = (
@@ -14314,7 +14314,7 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "tao" = (
-/obj/item/bighorn_flag,
+/obj/item/flag/bighorn,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -16048,7 +16048,7 @@
 	},
 /area/f13/tunnel/bighorn)
 "wlv" = (
-/obj/item/bighorn_flag,
+/obj/item/flag/bighorn,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel/bighorn)
 "wlB" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -14496,7 +14496,7 @@
 	},
 /area/f13/wasteland/bighorn)
 "aZk" = (
-/obj/item/bighorn_flag,
+/obj/item/flag/bighorn,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
@@ -19419,7 +19419,7 @@
 	pixel_x = -8;
 	pixel_y = 15
 	},
-/obj/item/bighorn_flag,
+/obj/item/flag/bighorn,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
 	},
@@ -27522,7 +27522,7 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/offices1st)
 "dSJ" = (
-/obj/item/bighorn_flag,
+/obj/item/flag/bighorn,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/city/bighorn)
 "dSM" = (

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -2259,6 +2259,13 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
+"cfX" = (
+/obj/structure/lattice,
+/obj/item/flag/renegade{
+	pixel_y = 28
+	},
+/turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland/rocksprings)
 "cfZ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -2479,20 +2486,14 @@
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland/rocksprings)
 "cuN" = (
-/obj/structure/barricade/bars{
-	max_integrity = 1200;
-	name = "reinforced metal bars";
-	obj_integrity = 1200
+/obj/structure/lattice,
+/obj/structure/obstacle/barbedwire/end{
+	dir = 8
 	},
-/obj/item/renegade_flag,
-/turf/closed/indestructible/rock{
-	color = "#b09168";
-	desc = "An extremely tough wall.";
-	icon = 'icons/fallout/turfs/walls/house.dmi';
-	icon_state = "house0";
-	icon_type_smooth = "house";
-	name = "salvaged wall"
+/obj/item/flag/renegade{
+	pixel_y = 28
 	},
+/turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland/rocksprings)
 "cuR" = (
 /turf/open/floor/wood/wood_common{
@@ -11191,7 +11192,7 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
 "lpn" = (
-/obj/item/renegade_flag,
+/obj/item/flag/renegade,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 4;
 	icon_state = "dirt"
@@ -21457,7 +21458,7 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
 "vfN" = (
-/obj/item/renegade_flag,
+/obj/item/flag/renegade,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 8;
 	icon_state = "dirt"
@@ -70781,8 +70782,8 @@ mtU
 mtU
 mtU
 mtU
-cuN
-obp
+mtU
+cfX
 hgP
 hgP
 hgP
@@ -77720,8 +77721,8 @@ mtU
 mtU
 mtU
 mtU
+mtU
 cuN
-kmO
 hgP
 hgP
 hgP
@@ -78222,8 +78223,8 @@ mtU
 mtU
 mtU
 mtU
-cuN
-obp
+mtU
+cfX
 hgP
 hgP
 hgP

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -3769,6 +3769,12 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland/warren)
+"dud" = (
+/obj/item/flag/renegade,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland/warren)
 "due" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -58152,7 +58158,7 @@ fsv
 fsv
 fsv
 anJ
-nFf
+dud
 lMO
 pbp
 pbp
@@ -59180,7 +59186,7 @@ wmP
 oBv
 vtb
 anJ
-nFf
+dud
 pbp
 pbp
 lMO

--- a/code/modules/fallout/obj/misc.dm
+++ b/code/modules/fallout/obj/misc.dm
@@ -258,6 +258,13 @@
 	icon_state = "enclaveflag_america"
 	item_state = "enclaveflag_america"
 
+/obj/item/flag/renegade
+	name = "Renegade Corps flag"
+	desc = "A flag marking territory belonging to the Renegade Corps mercenaries."
+	icon_state = "renegade_flag"
+	item_state = "renegade_flag"
+	faction = "Renegade"
+
 /obj/item/flag/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/stack/sheet/leather) && item_state == "emptyflag")
 		visible_message("<span class='notice'>[user] begins to make a flag.</span>")

--- a/modular_sunset/code/game/objects/sunsetmisc.dm
+++ b/modular_sunset/code/game/objects/sunsetmisc.dm
@@ -1,27 +1,3 @@
-// Sunset Flags
-
-/obj/item/bighorn_flag
-	name = "La Verkin flag"
-	desc = "A flag depicting the head of a bighorner. It's a symbol of the town of La Verkin."
-	icon = 'modular_sunset/icons/structures/bighorn_flag.dmi'
-	icon_state = "bighorn_flag"
-	item_state = "bighorn_flag"
-	density = 1
-	anchored = 1
-	w_class = 4
-	layer = 4.1
-
-/obj/item/renegade_flag
-	name = "Renegade Corps flag"
-	desc = "A flag marking territory belonging to the Renegade Corps mercenaries."
-	icon = 'modular_sunset/icons/structures/bighorn_flag.dmi'
-	icon_state = "renegade_flag"
-	item_state = "renegade_flag"
-	density = 1
-	anchored = 1
-	w_class = 4
-	layer = 4.1
-
 // Sunset Signs - SMALL
 
 /obj/item/sign/bee_warning


### PR DESCRIPTION
## About The Pull Request
There were two types of flagpole, for Bighorn and Renegades, that weren't interactable like normal flagpoles, instead being their own static object. These have been removed from the game and all instances replaced with interactable versions.

Two Renegade flags were also added to their Warren hideout, where they mysteriously had none.
## Why It's Good For The Game
More bloat objects removed, and being able to interact with things is always good.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog
:cl:
fix: Fixes some uninteractable flagpoles.
/:cl: