### PR TITLE
Fixes Warren Areas + Roofs

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
@@ -42,7 +42,7 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "aW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -62,10 +62,10 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "bg" = (
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bq" = (
 /obj/structure/sign/plaques/ncr_cpt{
 	pixel_y = -32
@@ -84,7 +84,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -101,7 +101,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "bN" = (
 /obj/structure/closet/crate/bin{
 	pixel_x = 6;
@@ -126,13 +126,13 @@
 "cm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "cq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "cv" = (
 /turf/open/transparent/openspace,
 /area/f13/ncr)
@@ -153,7 +153,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "cE" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -166,7 +166,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "cG" = (
 /obj/structure/simple_door/room{
 	name = "Representative"
@@ -198,7 +198,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "dg" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -219,11 +219,11 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "dm" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dx" = (
 /obj/machinery/light/small,
 /obj/structure/nest/radroach,
@@ -231,7 +231,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken6"
 	},
-/area/f13/city)
+/area/f13/building)
 "dy" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/ammo_box/magazine/m556mm,
@@ -256,7 +256,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "dB" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -264,7 +264,7 @@
 	pixel_x = 32
 	},
 /turf/open/transparent/openspace,
-/area/f13/city)
+/area/f13/building)
 "dQ" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/laceup,
@@ -285,7 +285,7 @@
 	icon_state = "book-5"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "em" = (
 /obj/structure/sign/poster/ncr/irradiated_food{
 	pixel_y = 32
@@ -310,7 +310,7 @@
 /obj/structure/junk/drawer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "eC" = (
 /obj/machinery/light{
 	dir = 4;
@@ -327,11 +327,11 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eJ" = (
 /obj/structure/table,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eL" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -341,7 +341,7 @@
 /area/f13/ncr)
 "eM" = (
 /turf/closed/wall/f13/sunset/brick_small_light,
-/area/f13/city)
+/area/f13/building)
 "eO" = (
 /obj/structure/closet/locker/fridge,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -357,7 +357,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "eV" = (
 /obj/machinery/button/door{
 	id = "ncrlogisticshutter";
@@ -380,12 +380,12 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken4"
 	},
-/area/f13/city)
+/area/f13/building)
 "ff" = (
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken2"
 	},
-/area/f13/city)
+/area/f13/building)
 "fm" = (
 /obj/machinery/light{
 	dir = 4
@@ -410,7 +410,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "fB" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland/ncr)
@@ -423,7 +423,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "fE" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowbottom"
@@ -436,7 +436,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "fF" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -444,7 +444,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fO" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/ncr)
@@ -456,13 +456,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "fV" = (
 /turf/open/floor/carpet/cyan,
 /area/f13/ncr)
 "ga" = (
 /turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/city)
+/area/f13/building)
 "gc" = (
 /obj/item/storage/secure/safe{
 	pixel_x = 5;
@@ -476,14 +476,14 @@
 /obj/item/clothing/suit/armored/medium/painspike,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "gJ" = (
 /obj/structure/railing/corner,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
 "gQ" = (
 /turf/open/floor/carpet/cyan,
-/area/f13/city)
+/area/f13/building)
 "ha" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -497,12 +497,12 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "hd" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "hu" = (
 /obj/structure/curtain,
 /obj/machinery/shower{
@@ -556,7 +556,7 @@
 "ib" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "ij" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -571,7 +571,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "iy" = (
 /obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -579,7 +579,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "iz" = (
 /obj/structure/table/glass,
 /obj/item/toy/cards/deck,
@@ -591,7 +591,7 @@
 "iA" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "iB" = (
 /obj/structure/closet/crate,
 /obj/item/card/id/dogtag/town/ncr,
@@ -660,7 +660,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "jt" = (
 /obj/structure/railing{
 	dir = 1
@@ -681,12 +681,12 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "jG" = (
 /obj/item/newspaper,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -696,7 +696,7 @@
 "jM" = (
 /mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "jN" = (
 /obj/structure/railing{
 	dir = 1
@@ -762,14 +762,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "ky" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland/warren)
 "kz" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kD" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -778,7 +778,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kI" = (
 /obj/item/storage/secure/safe/ncr_rep{
 	pixel_x = 5;
@@ -791,7 +791,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "la" = (
 /obj/machinery/light{
 	dir = 1
@@ -803,7 +803,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "lc" = (
 /obj/machinery/light/broken{
 	dir = 1;
@@ -812,7 +812,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "lh" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -835,12 +835,12 @@
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "lx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "lz" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -849,16 +849,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "lC" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "lR" = (
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken6"
 	},
-/area/f13/city)
+/area/f13/building)
 "lS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v2{
@@ -867,7 +867,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "lT" = (
 /obj/structure/toilet{
 	pixel_y = 17
@@ -875,7 +875,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "lV" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -899,13 +899,13 @@
 	pixel_x = -4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "mf" = (
 /obj/item/wirecutters/basic,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "mk" = (
 /obj/structure/closet/crate/secure/engineering,
 /obj/item/circuitboard/computer/card/ncr,
@@ -923,7 +923,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "my" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -937,7 +937,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "mU" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -974,12 +974,12 @@
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "nD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nJ" = (
 /obj/structure/nest/protectron{
 	max_mobs = 2
@@ -988,7 +988,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "nO" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -1008,7 +1008,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "nS" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1018,23 +1018,23 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "nT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "nU" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nW" = (
 /obj/item/reagent_containers/spray/pestspray,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nX" = (
 /obj/structure/chair/bench,
 /obj/structure/curtain{
@@ -1046,14 +1046,14 @@
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "nZ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
 	icon_state = "housewindowvertical"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "oa" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -1069,24 +1069,24 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "of" = (
 /obj/structure/chair/sofa/left,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "og" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "oi" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ol" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "drip5"
@@ -1098,11 +1098,11 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "op" = (
 /obj/item/paper,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "or" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -1122,7 +1122,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "oD" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -1133,7 +1133,7 @@
 	name = "rejected drafts"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "oV" = (
 /turf/closed/wall/rust,
 /area/f13/wasteland/warren)
@@ -1157,7 +1157,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "pj" = (
 /turf/closed/wall/f13/vault{
 	name = "regulation wall"
@@ -1173,7 +1173,7 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pC" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -1232,7 +1232,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "qo" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "drip1"
@@ -1241,7 +1241,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "qu" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -1268,36 +1268,36 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "qy" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "qA" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/transparent/openspace,
-/area/f13/city)
+/area/f13/building)
 "qE" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/random,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "qM" = (
 /obj/structure/table,
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "qZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "rb" = (
 /obj/structure/simple_door/room{
 	name = "Restroom"
@@ -1310,7 +1310,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "re" = (
 /obj/structure/curtain{
 	color = "#1e549c";
@@ -1321,7 +1321,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rh" = (
 /obj/structure/railing{
 	dir = 4
@@ -1358,14 +1358,14 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ru" = (
 /turf/open/space,
 /area/f13/wasteland)
 "rK" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "rW" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -1380,7 +1380,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "sd" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -1393,7 +1393,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sl" = (
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/vault,
@@ -1401,7 +1401,7 @@
 "sm" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "sq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -1415,13 +1415,13 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken6"
 	},
-/area/f13/city)
+/area/f13/building)
 "sw" = (
 /obj/item/light/tube,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "sC" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland/ncr)
@@ -1451,12 +1451,12 @@
 	name = "rejected drafts"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/tile/carpet/purple/ten,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "sX" = (
 /obj/structure/sign/poster/prewar/poster81{
 	pixel_x = 32
@@ -1471,7 +1471,7 @@
 	},
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tj" = (
 /obj/structure/sign/plaques/ncr_lo{
 	pixel_y = -32
@@ -1493,7 +1493,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken3"
 	},
-/area/f13/city)
+/area/f13/building)
 "tW" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/stripes/white/box{
@@ -1509,7 +1509,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "um" = (
 /obj/structure/closet/crate/mortar_shells,
 /obj/item/mortar_kit,
@@ -1555,7 +1555,7 @@
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken4"
 	},
-/area/f13/city)
+/area/f13/building)
 "uI" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -1573,14 +1573,14 @@
 	icon_state = "housewindowbrokenvertical"
 	},
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "vb" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -1597,7 +1597,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "vA" = (
 /obj/structure/railing{
 	dir = 1
@@ -1636,7 +1636,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vM" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -1648,7 +1648,7 @@
 	icon_state = "housewindowbrokenvertical"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "vR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/ncr/loaded{
@@ -1673,7 +1673,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "vY" = (
 /obj/structure/toilet/secret/prison{
 	dir = 4
@@ -1682,7 +1682,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "wb" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -1692,7 +1692,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "wd" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -1705,7 +1705,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "wj" = (
 /obj/structure/simple_door/room{
 	name = "restroom"
@@ -1713,7 +1713,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "wm" = (
 /obj/structure/toilet{
 	dir = 8;
@@ -1731,7 +1731,7 @@
 	icon_state = "book-2"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wp" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -1748,19 +1748,19 @@
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken3"
 	},
-/area/f13/city)
+/area/f13/building)
 "ww" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "wx" = (
 /obj/structure/table,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wE" = (
 /obj/structure/railing,
 /turf/open/transparent/openspace,
@@ -1778,7 +1778,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "wM" = (
 /obj/structure/table/wood,
 /obj/item/storage/lockbox,
@@ -1792,7 +1792,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "xa" = (
 /obj/structure/sign/plaques/ncr_lt{
 	pixel_y = 32
@@ -1805,7 +1805,7 @@
 "xc" = (
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xh" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -1817,7 +1817,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "xi" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -1829,7 +1829,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/structure/closet/crate/wooden,
 /turf/open/floor/carpet/cyan,
-/area/f13/city)
+/area/f13/building)
 "xk" = (
 /obj/structure/nest/protectron{
 	max_mobs = 2
@@ -1837,34 +1837,34 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xo" = (
 /obj/structure/chair/sofa/corner{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "xr" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "drip5"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "xC" = (
 /obj/structure/simple_door/glass,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "xG" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -1874,7 +1874,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "xJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -1883,7 +1883,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "xR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1891,7 +1891,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "yf" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/suit/armored/light/vest/bulletproof,
@@ -1901,7 +1901,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "yl" = (
 /obj/machinery/microwave/stove,
 /obj/structure/curtain{
@@ -1909,13 +1909,13 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "ym" = (
 /mob/living/simple_animal/hostile/renegade/drifter,
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken2"
 	},
-/area/f13/city)
+/area/f13/building)
 "yq" = (
 /obj/machinery/light{
 	dir = 8
@@ -1932,7 +1932,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "yy" = (
 /obj/structure/railing,
 /turf/open/indestructible/ground/outside/roof,
@@ -1948,24 +1948,24 @@
 "yB" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "yE" = (
 /obj/structure/simple_door/room{
 	name = "North River Apartments"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "yK" = (
 /obj/structure/chair/sofa/corp/corner,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "yT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken2"
 	},
-/area/f13/city)
+/area/f13/building)
 "yV" = (
 /obj/machinery/computer/card/ncr{
 	dir = 8
@@ -1979,7 +1979,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "zj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1993,7 +1993,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken3"
 	},
-/area/f13/city)
+/area/f13/building)
 "zt" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -2003,13 +2003,13 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "zu" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/ghoul,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "zz" = (
 /obj/structure/simple_door/room{
 	name = "Senior Enlisted Advisor"
@@ -2040,7 +2040,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Af" = (
 /obj/structure/railing{
 	dir = 1
@@ -2070,7 +2070,7 @@
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken3"
 	},
-/area/f13/city)
+/area/f13/building)
 "Az" = (
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/warren)
@@ -2081,7 +2081,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "AR" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/laceup,
@@ -2109,7 +2109,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Bt" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -2117,7 +2117,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "Bw" = (
 /obj/effect/spawner/bundle/f13/trenchshotgun,
 /obj/effect/spawner/bundle/f13/trenchshotgun,
@@ -2131,7 +2131,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "Bx" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -2145,14 +2145,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "Bz" = (
 /obj/structure/window/fulltile/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "BQ" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal";
@@ -2182,7 +2182,7 @@
 /obj/item/toner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Cf" = (
 /obj/structure/railing{
 	dir = 4
@@ -2206,7 +2206,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Cn" = (
 /obj/structure/table,
 /obj/item/pda,
@@ -2221,7 +2221,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Cw" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -2230,7 +2230,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Cz" = (
 /obj/structure/railing,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -2252,7 +2252,7 @@
 "CZ" = (
 /obj/effect/decal/cleanable/blood/gibs/human/torso,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Dk" = (
 /obj/structure/railing{
 	dir = 4
@@ -2276,11 +2276,11 @@
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "DG" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "DI" = (
 /obj/structure/shelf_wood,
 /obj/effect/decal/cleanable/dirt,
@@ -2316,7 +2316,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ei" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -2331,7 +2331,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "Em" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -2350,13 +2350,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ew" = (
 /obj/structure/chair/wood/dining{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "EA" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
@@ -2397,7 +2397,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "Fc" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2418,7 +2418,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "Fx" = (
 /obj/effect/turf_decal/stripes/white/box{
 	color = "#a67c33"
@@ -2462,7 +2462,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "FW" = (
 /obj/structure/railing{
 	dir = 4
@@ -2483,12 +2483,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Gg" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Gl" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/machinery/light/small{
@@ -2496,13 +2496,13 @@
 	light_color = "red"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Gm" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "Gq" = (
 /obj/structure/sink{
 	dir = 4;
@@ -2522,7 +2522,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "GE" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/f13/ncrdrillsergeant,
@@ -2537,7 +2537,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "GK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2545,7 +2545,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "GS" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -2562,14 +2562,14 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "GU" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Hd" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland/warren)
@@ -2580,7 +2580,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Hg" = (
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
@@ -2601,7 +2601,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "Hq" = (
 /turf/open/floor/wood/wood_fancy,
 /area/f13/ncr)
@@ -2676,13 +2676,13 @@
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "Jr" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "drip1"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Jt" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -2694,12 +2694,12 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Jv" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "Jw" = (
 /obj/structure/toilet{
 	dir = 4
@@ -2708,13 +2708,13 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "Jz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "JA" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -2729,7 +2729,7 @@
 	},
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/floor/carpet/cyan,
-/area/f13/city)
+/area/f13/building)
 "JI" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -2773,7 +2773,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "JW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -2783,7 +2783,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ke" = (
 /obj/structure/railing/corner,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -2801,7 +2801,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "Kr" = (
 /obj/structure/closet/locker/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -2815,7 +2815,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "Ks" = (
 /turf/closed/wall/r_wall,
 /area/f13/ncr)
@@ -2823,18 +2823,18 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "KK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "KN" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "KP" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/random,
@@ -2848,7 +2848,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/carpet/cyan,
-/area/f13/city)
+/area/f13/building)
 "KU" = (
 /obj/machinery/button/door{
 	id = "ncradvisorshutter";
@@ -2862,7 +2862,7 @@
 	icon_state = "housewindowbroken"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Lk" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -2880,7 +2880,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "LB" = (
 /obj/structure/railing{
 	dir = 8
@@ -2897,7 +2897,7 @@
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "LT" = (
 /obj/structure/simple_door/room{
 	name = "restroom"
@@ -2906,7 +2906,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "LX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -2915,7 +2915,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "Mm" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -2930,14 +2930,14 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Mr" = (
 /obj/effect/decal/remains/human,
 /obj/item/key,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "Mv" = (
 /obj/effect/overlay/junk/shower{
 	pixel_y = 12
@@ -2949,7 +2949,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Mx" = (
 /obj/item/clothing/shoes/combat,
 /obj/structure/closet,
@@ -2959,7 +2959,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "MA" = (
 /obj/structure/shelf_wood,
 /turf/open/floor/wood/wood_fancy,
@@ -2972,7 +2972,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "MD" = (
 /obj/structure/nest/protectron{
 	max_mobs = 2
@@ -2981,12 +2981,12 @@
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "MF" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "MQ" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -3003,7 +3003,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken2"
 	},
-/area/f13/city)
+/area/f13/building)
 "MX" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkdirty"
@@ -3024,7 +3024,7 @@
 "Np" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/city)
+/area/f13/building)
 "Nr" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -3032,7 +3032,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "Nx" = (
 /obj/item/kirbyplants{
 	pixel_x = -7
@@ -3062,39 +3062,39 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "NK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
 "NX" = (
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "NY" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Ob" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Og" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "Oi" = (
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken4"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ol" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -3106,7 +3106,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "On" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -3115,7 +3115,7 @@
 /obj/item/clothing/mask/muzzle,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Oo" = (
 /obj/structure/simple_door/room{
 	name = "North River Apartments"
@@ -3123,7 +3123,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ou" = (
 /obj/structure/railing{
 	dir = 1
@@ -3141,7 +3141,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Oz" = (
 /obj/structure/sign/poster/contraband/pinup_shower{
 	pixel_x = -32
@@ -3154,13 +3154,13 @@
 "OD" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "OF" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "OI" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -3177,7 +3177,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "OW" = (
 /obj/structure/debris/v2{
 	pixel_x = -10
@@ -3185,7 +3185,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Pa" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -3195,14 +3195,14 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Pg" = (
 /obj/structure/simple_door/room{
 	name = "North River Apartments"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Pr" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
@@ -3225,7 +3225,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "PP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3257,25 +3257,25 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "Qg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken3"
 	},
-/area/f13/city)
+/area/f13/building)
 "Qi" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/cyan,
-/area/f13/city)
+/area/f13/building)
 "Qs" = (
 /obj/structure/closet/locker/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Qt" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy,
@@ -3305,7 +3305,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "QU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3313,13 +3313,13 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "QZ" = (
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ra" = (
 /obj/machinery/button/door{
 	id = "ncrlieushutter";
@@ -3341,7 +3341,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "Rc" = (
 /obj/structure/junk/small/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -3350,7 +3350,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Rf" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/wood_fancy,
@@ -3376,7 +3376,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "Sv" = (
 /obj/structure/chair/wood/dining{
 	dir = 4
@@ -3384,7 +3384,7 @@
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken6"
 	},
-/area/f13/city)
+/area/f13/building)
 "SF" = (
 /obj/item/paper{
 	pixel_x = 9;
@@ -3392,13 +3392,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "SG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "SJ" = (
 /obj/item/paper,
 /obj/item/paper{
@@ -3406,13 +3406,13 @@
 	pixel_y = 12
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "SK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken4"
 	},
-/area/f13/city)
+/area/f13/building)
 "SZ" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -3429,7 +3429,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Ti" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -3453,7 +3453,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Tx" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -3466,20 +3466,20 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "TJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken2"
 	},
-/area/f13/city)
+/area/f13/building)
 "TM" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "TT" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -3513,7 +3513,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Un" = (
 /obj/structure/showcase/machinery/tv{
 	name = "Pre-war television"
@@ -3521,17 +3521,17 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Up" = (
 /obj/structure/junk/drawer,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Uq" = (
 /obj/item/newspaper,
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken5"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ur" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -3541,7 +3541,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Uv" = (
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_x = 12;
@@ -3550,7 +3550,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "UB" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal";
@@ -3567,16 +3567,16 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "UH" = (
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "UL" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "UU" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -3587,7 +3587,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "UV" = (
 /obj/structure/curtain{
 	color = "#e09634";
@@ -3600,7 +3600,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "Vd" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -3610,7 +3610,7 @@
 	termtag = "Business"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Ve" = (
 /obj/structure/sink{
 	dir = 4;
@@ -3623,23 +3623,23 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Vg" = (
 /obj/structure/curtain{
 	color = "#1e549c";
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Vi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "Vl" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "Vu" = (
 /obj/structure/sign/poster/official/twelve_gauge{
 	pixel_x = -32
@@ -3663,7 +3663,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "VG" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/machinery/light{
@@ -3685,7 +3685,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "VI" = (
 /obj/machinery/blackbox_recorder{
 	name = "data unit"
@@ -3726,14 +3726,14 @@
 /obj/item/rack_parts,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "VY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken2"
 	},
-/area/f13/city)
+/area/f13/building)
 "Wf" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -3742,7 +3742,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "Wg" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -3784,7 +3784,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
 	},
-/area/f13/city)
+/area/f13/building)
 "WG" = (
 /obj/structure/curtain{
 	color = "#1e549c";
@@ -3793,7 +3793,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "WJ" = (
 /obj/item/bedsheet/random,
 /obj/effect/decal/cleanable/dirt,
@@ -3801,7 +3801,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken5"
 	},
-/area/f13/city)
+/area/f13/building)
 "WK" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -3818,10 +3818,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "WZ" = (
 /turf/open/transparent/openspace,
-/area/f13/city)
+/area/f13/building)
 "Xb" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6"
@@ -3832,10 +3832,10 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Xi" = (
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/city)
+/area/f13/building)
 "Xm" = (
 /obj/machinery/light,
 /obj/structure/sign/poster/ncr/keep_to_myself{
@@ -3848,7 +3848,7 @@
 "Xn" = (
 /obj/structure/table,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "Xo" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/stripes/white/box{
@@ -3865,14 +3865,14 @@
 	icon_state = "housewindowbroken"
 	},
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "Xz" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "drip3"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "XA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -3880,7 +3880,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "XC" = (
 /obj/structure/railing{
 	dir = 1
@@ -3888,10 +3888,10 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "XH" = (
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "XL" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -3901,7 +3901,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "XO" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
@@ -3909,7 +3909,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "XQ" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -3919,7 +3919,7 @@
 	termtag = "Business"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "XU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/electrical,
@@ -3927,7 +3927,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "XZ" = (
 /obj/structure/curtain{
 	color = "#1e549c";
@@ -3937,7 +3937,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "Yh" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowleft"
@@ -3950,7 +3950,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "Yp" = (
 /obj/structure/sink{
 	dir = 4;
@@ -3962,7 +3962,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ys" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -3979,7 +3979,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "YF" = (
 /obj/machinery/door/unpowered/secure_steeldoor{
 	max_integrity = 1400;
@@ -3997,7 +3997,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/city)
+/area/f13/building)
 "YO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4005,19 +4005,19 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Ze" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "Zt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "Zy" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/small{
@@ -4026,7 +4026,7 @@
 	},
 /obj/item/toner,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ZA" = (
 /obj/structure/railing{
 	dir = 4
@@ -4042,7 +4042,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "ZI" = (
 /obj/structure/sign/plaques/ncr_sea{
 	name = "senior enlisted advisor";
@@ -34619,17 +34619,17 @@ sC
 JO
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -34876,17 +34876,17 @@ sC
 JO
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -35133,17 +35133,17 @@ sC
 JO
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -35390,17 +35390,17 @@ sC
 JO
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -35647,17 +35647,17 @@ JO
 JO
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -35904,17 +35904,17 @@ JO
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -36161,20 +36161,20 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -36418,20 +36418,20 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -36675,20 +36675,20 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -36936,16 +36936,16 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -37193,16 +37193,16 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -37450,16 +37450,16 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -37707,16 +37707,16 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -37964,16 +37964,16 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -38221,16 +38221,16 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -38478,16 +38478,16 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -38735,16 +38735,16 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -40535,15 +40535,15 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -40792,15 +40792,15 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -41049,15 +41049,15 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -41306,15 +41306,15 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -41563,15 +41563,15 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -41820,15 +41820,15 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC
@@ -42077,15 +42077,15 @@ sC
 sC
 sC
 sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
-sC
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
+RJ
 sC
 sC
 sC

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -30,7 +30,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aac" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39,7 +39,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "aad" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -52,13 +52,13 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "aae" = (
 /obj/machinery/door/airlock/vault,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "aaf" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -80,7 +80,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aah" = (
 /obj/structure/toilet{
 	dir = 4
@@ -90,7 +90,7 @@
 	},
 /mob/living/simple_animal/hostile/retaliate/poison/snake,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aai" = (
 /obj/effect/landmark/vertibird{
 	name = "Warren AFB Exterior"
@@ -104,7 +104,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aaH" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -113,7 +113,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "abj" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "ncrrec"
@@ -149,20 +149,20 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "abT" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 8;
 	pixel_x = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "acj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "acM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -174,12 +174,12 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "adg" = (
 /obj/structure/closet/crate/wooden,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "adC" = (
 /obj/structure/window/spawner/north,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -190,14 +190,14 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aew" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "afy" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -209,7 +209,7 @@
 /obj/structure/table/wood/bar,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "afK" = (
 /obj/structure/closet/crate/wicker,
 /obj/item/ingot/silver{
@@ -231,7 +231,7 @@
 /area/f13/ncr)
 "afX" = (
 /turf/closed/wall/f13/supermart,
-/area/f13/city)
+/area/f13/building)
 "agA" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -241,7 +241,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "aht" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/ruins,
@@ -249,7 +249,7 @@
 "ahM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
-/area/f13/city)
+/area/f13/building)
 "ahP" = (
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -271,7 +271,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "aiJ" = (
 /obj/structure/closet/fridge,
 /turf/open/indestructible/ground/outside/dirt/dark{
@@ -283,7 +283,7 @@
 	dir = 5;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "ajz" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/outside/savannah,
@@ -323,7 +323,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "akK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -333,7 +333,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "alq" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 6
@@ -355,7 +355,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/city)
+/area/f13/building)
 "amS" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -376,13 +376,13 @@
 /turf/closed/wall/f13/vault{
 	name = "regulation wall"
 	},
-/area/f13/city)
+/area/f13/building)
 "anO" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
 	},
-/area/f13/city)
+/area/f13/building)
 "anQ" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblecorner"
@@ -407,7 +407,7 @@
 "aqj" = (
 /obj/item/ingot/titanium,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "aqB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool/retro/black,
@@ -424,7 +424,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aqS" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -442,7 +442,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "arD" = (
 /obj/machinery/light/small/broken{
 	dir = 1;
@@ -451,13 +451,13 @@
 	},
 /obj/structure/junk/small/bed,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "arR" = (
 /obj/structure/simple_door/room{
 	name = "North River Apartments"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "arU" = (
 /obj/structure/chair/comfy/purple{
 	dir = 4;
@@ -465,7 +465,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "arX" = (
 /obj/structure/fence{
 	dir = 4
@@ -488,7 +488,7 @@
 /area/f13/wasteland/ncr)
 "atw" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "atO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -503,7 +503,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "auw" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
@@ -518,7 +518,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "avr" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -533,15 +533,15 @@
 	pixel_x = -14
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "axa" = (
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/city)
+/area/f13/building)
 "axO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/raiderloot,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "ayi" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -559,7 +559,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "ayt" = (
 /obj/structure/fence,
 /obj/structure/fence/corner{
@@ -586,7 +586,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "ayw" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -594,7 +594,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ayC" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -16
@@ -688,7 +688,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aCv" = (
 /obj/effect/overlay/turfs/sidewalk,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -710,23 +710,23 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aEC" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aEE" = (
 /obj/structure/junk/locker,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "aET" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aFS" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/structure/rack/shelf_metal,
@@ -736,7 +736,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aFZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
@@ -750,7 +750,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aGJ" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt,
@@ -759,7 +759,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "aHo" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -781,7 +781,7 @@
 /area/f13/ncr)
 "aID" = (
 /turf/open/floor/plasteel/elevatorshaft,
-/area/f13/city)
+/area/f13/building)
 "aJz" = (
 /mob/living/simple_animal/opossum,
 /turf/open/indestructible/ground/outside/dirt,
@@ -799,7 +799,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "aLe" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -818,14 +818,14 @@
 /obj/item/melee/baton/cattleprod,
 /obj/item/storage/crayons,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aLj" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aLn" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -874,7 +874,7 @@
 	pixel_y = 1
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/area/f13/building)
 "aNo" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -917,7 +917,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "aQM" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -951,12 +951,12 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "aRQ" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tunnel,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "aRX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -965,20 +965,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "aSh" = (
 /obj/structure/safe,
 /obj/item/storage/bag/money/small/den,
 /obj/effect/spawner/lootdrop/weapons/selfdefence,
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "aSo" = (
 /obj/machinery/light{
 	dir = 1;
 	pixel_x = -16
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aSz" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -986,10 +986,10 @@
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aTg" = (
 /turf/closed/wall/f13/sunset/brick_small_light,
-/area/f13/city)
+/area/f13/building)
 "aTq" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/item/seeds/wheat,
@@ -1021,7 +1021,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "aUt" = (
 /obj/machinery/light{
 	dir = 4
@@ -1029,7 +1029,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "aUJ" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -1037,13 +1037,13 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
-/area/f13/city)
+/area/f13/building)
 "aUP" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aVg" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -1051,17 +1051,17 @@
 	termtag = "Business"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aVA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "aVK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aVX" = (
 /obj/machinery/light{
 	dir = 1
@@ -1070,7 +1070,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "aWr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -1079,17 +1079,17 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/window/fulltile/house/broken,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "aWV" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "aXy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "aXz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
@@ -1113,7 +1113,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "aYs" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1132,7 +1132,7 @@
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "aZx" = (
 /obj/item/storage/bag/trash,
 /obj/structure/rack/shelf_metal{
@@ -1178,7 +1178,7 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "baC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1217,7 +1217,7 @@
 /obj/item/trash/f13/rotten,
 /obj/item/reagent_containers/food/snacks/f13/sugarbombs,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bce" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1231,7 +1231,7 @@
 "bcH" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/area/f13/building)
 "bcS" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1241,7 +1241,7 @@
 "bde" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "bdE" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
@@ -1344,7 +1344,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bhp" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
@@ -1386,23 +1386,23 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "bjq" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "bjU" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bks" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "bkB" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -1428,7 +1428,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "blK" = (
 /obj/structure/chair/stool/retro,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1456,7 +1456,7 @@
 /obj/item/paper,
 /obj/item/pen,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bnB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "cross2"
@@ -1466,7 +1466,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken5"
 	},
-/area/f13/city)
+/area/f13/building)
 "bnV" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 5;
@@ -1486,7 +1486,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bom" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/greenglow/radioactive{
@@ -1513,7 +1513,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bpP" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
@@ -1551,11 +1551,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bqr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/city)
+/area/f13/building)
 "bqJ" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 27
@@ -1563,7 +1563,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
 	},
-/area/f13/city)
+/area/f13/building)
 "bqR" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medical Officer";
@@ -1591,12 +1591,12 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "bry" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "brC" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
@@ -1612,12 +1612,12 @@
 /obj/structure/nest/radroach,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bsW" = (
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/pill/salicyclic,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "btw" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Command Centre";
@@ -1651,7 +1651,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bwc" = (
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
@@ -1677,7 +1677,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "bxy" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -1732,7 +1732,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "bAU" = (
 /obj/structure/weightlifter,
 /turf/open/floor/f13{
@@ -1746,7 +1746,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bBv" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -1772,13 +1772,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "bDA" = (
 /mob/living/simple_animal/hostile/renegade/doc,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/city)
+/area/f13/wasteland/warren)
 "bEE" = (
 /obj/structure/closet/bus,
 /turf/open/indestructible/ground/outside/road{
@@ -1803,7 +1803,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bFl" = (
 /obj/structure/fence{
 	max_integrity = 500;
@@ -1832,7 +1832,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "bFV" = (
 /obj/structure/fence,
 /obj/structure/fence/corner{
@@ -1876,19 +1876,14 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "bIC" = (
 /obj/structure/railing{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
-"bIN" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
-	},
-/area/f13/city)
+/area/f13/building)
 "bIZ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -1920,7 +1915,7 @@
 /obj/structure/junk/drawer,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bKS" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
@@ -1936,13 +1931,13 @@
 /obj/structure/obstacle/old_locked_door,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bLk" = (
 /obj/item/chair/wood{
 	pixel_y = -3
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bLR" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/cmo,
@@ -1958,7 +1953,7 @@
 "bMJ" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "bNb" = (
 /obj/item/minefield_sign{
 	pixel_y = 8
@@ -1973,11 +1968,11 @@
 	icon_state = "housewindowbroken"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "bNu" = (
 /obj/item/storage/fancy/ringbox/diamond,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "bNG" = (
 /obj/structure/chair{
 	dir = 4
@@ -1985,7 +1980,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bOX" = (
 /obj/structure/fence{
 	pixel_x = -14
@@ -2002,13 +1997,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bPm" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bPp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -2016,19 +2011,19 @@
 	},
 /obj/structure/barricade/bars,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "bPw" = (
 /obj/structure/simple_door/tentflap_cloth{
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/area/f13/building)
 "bPz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "bQe" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -2039,7 +2034,7 @@
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bQh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/house{
@@ -2048,7 +2043,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "bQk" = (
 /obj/structure/car/rubbish3{
 	pixel_x = -5
@@ -2062,7 +2057,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "bQJ" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
@@ -2074,28 +2069,28 @@
 /obj/structure/junk/locker,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "bRH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/house{
 	name = "RobCo Outlet"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/city)
+/area/f13/building)
 "bRZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair2{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bSo" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "bSR" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -2106,14 +2101,14 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "bTf" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "bTs" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
@@ -2127,7 +2122,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "bTQ" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -2188,7 +2183,7 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bWE" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
@@ -2213,7 +2208,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "bYc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom1"
@@ -2237,13 +2232,13 @@
 /obj/item/reagent_containers/food/snacks/lollipop,
 /obj/item/clothing/glasses/regular/hipster,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "bYR" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "bYW" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -2259,7 +2254,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "bZl" = (
 /obj/structure/table,
 /obj/structure/barricade/bars,
@@ -2268,7 +2263,7 @@
 	name = "counter shutters"
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "bZZ" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2282,7 +2277,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "cal" = (
 /obj/effect/turf_decal/huge{
 	dir = 4
@@ -2309,14 +2304,14 @@
 	},
 /obj/structure/barricade/bars,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "cbp" = (
 /obj/machinery/door/poddoor/gate{
 	id = "Supermutant";
 	name = "Fortress Gate"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "cbO" = (
 /obj/structure/reagent_dispensers/compostbin{
 	pixel_x = 3;
@@ -2336,7 +2331,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "cdj" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag{
@@ -2349,14 +2344,14 @@
 "cdm" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "cdL" = (
 /obj/machinery/light/small/broken,
 /obj/structure/decoration/shock{
 	pixel_y = -32
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "ceg" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
@@ -2369,7 +2364,7 @@
 	icon_state = "skin"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "cey" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/ruins,
@@ -2382,7 +2377,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "ceX" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -2400,7 +2395,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "cfv" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2410,7 +2405,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "cgr" = (
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2420,7 +2415,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken3"
 	},
-/area/f13/city)
+/area/f13/building)
 "cgA" = (
 /obj/structure/closet/fridge,
 /obj/machinery/light/small/broken{
@@ -2429,7 +2424,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cgG" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -2437,7 +2432,7 @@
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cij" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -2446,7 +2441,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "cil" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2454,7 +2449,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "civ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06"
@@ -2526,7 +2521,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "clC" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -2553,13 +2548,13 @@
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "cmB" = (
 /obj/effect/overlay/junk/toilet,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "cmZ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
@@ -2567,7 +2562,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "cnu" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -2585,7 +2580,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "coi" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -2611,7 +2606,7 @@
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cpI" = (
 /obj/item/toy/beach_ball/holoball,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -2632,7 +2627,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cqK" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -2653,20 +2648,20 @@
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 8
 	},
-/area/f13/city)
+/area/f13/building)
 "crn" = (
 /turf/open/floor/plasteel/stairs,
-/area/f13/city)
+/area/f13/building)
 "csn" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "csN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "ctG" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -2676,7 +2671,7 @@
 	dir = 1;
 	icon_state = "bluecorner"
 	},
-/area/f13/city)
+/area/f13/building)
 "cuq" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2687,13 +2682,13 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/brown,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "cvg" = (
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "cvW" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -2717,7 +2712,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "cxl" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 5
@@ -2756,17 +2751,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
-"cze" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner"
-	},
-/area/f13/city)
+/area/f13/building)
 "czw" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "czM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/engine,
@@ -2776,13 +2766,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
-"czO" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder"
-	},
-/area/f13/city)
+/area/f13/building)
 "cAd" = (
 /obj/machinery/light{
 	dir = 1
@@ -2810,29 +2794,26 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "cAL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/cheesie,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
-"cBd" = (
-/turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cBi" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
 	icon_state = "ruinswindow"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cBv" = (
 /turf/closed/wall/rust,
 /area/f13/wasteland/warren)
 "cBy" = (
 /obj/structure/curtain,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "cDq" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -31
@@ -2889,7 +2870,7 @@
 /obj/item/pen,
 /obj/item/ammo_box/c10mm/improvised,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cFc" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/gloves/botanic_leather,
@@ -2899,7 +2880,7 @@
 /obj/item/stack/medical/bruise_pack,
 /obj/item/clothing/suit/armor/f13/brahmin_leather_duster,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cFP" = (
 /obj/machinery/light{
 	dir = 4;
@@ -2922,7 +2903,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "cHj" = (
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
@@ -2931,14 +2912,14 @@
 "cHl" = (
 /obj/structure/campfire/stove,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cHG" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
 	},
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "cHJ" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
@@ -2963,13 +2944,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "cIm" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "cIw" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken4"
@@ -2982,13 +2963,13 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cJg" = (
 /obj/machinery/light/broken{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "cJi" = (
 /obj/structure/rack,
 /obj/item/radio/headset/headset_ncr,
@@ -3040,7 +3021,7 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "cLw" = (
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland/ncr)
@@ -3065,7 +3046,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "cNe" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 4;
@@ -3087,7 +3068,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "cOa" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4;
@@ -3119,7 +3100,7 @@
 "cOJ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "cOK" = (
 /obj/structure/railing/wood{
 	dir = 8;
@@ -3150,19 +3131,19 @@
 /turf/open/floor/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "cQo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken2"
 	},
-/area/f13/city)
+/area/f13/building)
 "cQt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "cQA" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3187,10 +3168,10 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "cRn" = (
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "cRt" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 4;
@@ -3229,7 +3210,7 @@
 	pixel_x = -16
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cTQ" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -3247,14 +3228,14 @@
 	dir = 1;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "cUO" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "cUZ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerouter"
@@ -3279,7 +3260,7 @@
 	icon_state = "booth_west_north"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "cWQ" = (
 /obj/machinery/workbench/forge,
 /turf/open/indestructible/ground/inside/subway,
@@ -3307,11 +3288,11 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "cZm" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/rust,
-/area/f13/city)
+/area/f13/building)
 "cZw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -3355,13 +3336,13 @@
 "dbu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dbO" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dbY" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark,
 /area/f13/wasteland/warren)
@@ -3381,18 +3362,13 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
-"ddv" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2"
-	},
-/area/f13/city)
+/area/f13/building)
 "ddH" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ddT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
@@ -3410,7 +3386,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "deK" = (
 /obj/structure/simple_door/house{
 	name = "North River Apartments"
@@ -3419,7 +3395,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "dfk" = (
 /obj/structure/toilet{
 	pixel_y = 17
@@ -3431,11 +3407,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "dfl" = (
 /obj/structure/junk/small/tv,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "dfq" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -3446,7 +3422,7 @@
 	pixel_x = 16
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "dgh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3472,12 +3448,12 @@
 	dir = 1;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/city)
+/area/f13/wasteland/warren)
 "dhq" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "dhu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool{
@@ -3487,14 +3463,14 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "dhw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/room{
 	name = "North River Apartments"
 	},
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "dig" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermainleft"
@@ -3526,7 +3502,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "djC" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -3536,7 +3512,7 @@
 "dkz" = (
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "dkL" = (
 /obj/structure/rack,
 /turf/open/indestructible/ground/outside/graveldirt{
@@ -3564,7 +3540,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "dmf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera/autoname{
@@ -3573,7 +3549,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "dmA" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/ruins,
@@ -3588,17 +3564,17 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/raiderloot,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dnk" = (
 /obj/structure/decoration/rag{
 	pixel_x = -14
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/area/f13/building)
 "dnq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/city)
+/area/f13/building)
 "dnz" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -3622,7 +3598,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "dpj" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -3634,13 +3610,13 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "dpt" = (
 /obj/structure/chair/booth{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dpu" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -16
@@ -3660,7 +3636,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/bomb/tier3,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/city)
+/area/f13/building)
 "dpW" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -3678,7 +3654,7 @@
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "dqR" = (
 /obj/item/stack/sheet/lead/twenty,
 /obj/structure/closet/crate,
@@ -3688,7 +3664,7 @@
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "drK" = (
 /obj/structure/barricade/tentclothedge{
 	pixel_y = -4
@@ -3715,7 +3691,7 @@
 "dsH" = (
 /obj/structure/simple_door/room/dirty,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dsL" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -3739,7 +3715,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "dti" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "cross3"
@@ -3750,14 +3726,14 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "dtK" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
 	icon_state = "ruinswindowbroken"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dtL" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3796,7 +3772,7 @@
 "dux" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "duQ" = (
 /obj/structure/simple_door/room{
 	name = "Archives"
@@ -3812,7 +3788,7 @@
 "dvt" = (
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "dvy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -3840,7 +3816,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "dwl" = (
 /obj/structure/decoration/vent/rusty,
 /obj/machinery/light/small{
@@ -3852,12 +3828,12 @@
 "dwp" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "dwr" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dwu" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
@@ -3916,7 +3892,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dza" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -16
@@ -3940,7 +3916,7 @@
 	dir = 1;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "dAz" = (
 /obj/machinery/light{
 	dir = 4;
@@ -3950,7 +3926,7 @@
 	pixel_x = -10
 	},
 /turf/open/floor/plasteel/stairs,
-/area/f13/city)
+/area/f13/building)
 "dAT" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -3969,7 +3945,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "dCy" = (
 /obj/structure/table,
 /obj/item/binoculars,
@@ -3984,7 +3960,7 @@
 "dDl" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "dDA" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -3994,7 +3970,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "dFi" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/structure/curtain,
@@ -4004,11 +3980,11 @@
 /obj/item/clothing/mask/breath/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "dFs" = (
 /obj/structure/table,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dFB" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/vault,
@@ -4023,7 +3999,7 @@
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "dHl" = (
 /obj/machinery/light{
 	dir = 1
@@ -4050,7 +4026,7 @@
 /obj/structure/table/wood,
 /obj/machinery/light/small/broken,
 /turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "dIS" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -4061,7 +4037,7 @@
 	icon_state = "storewindowtop"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "dKf" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -4074,7 +4050,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "dKP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -4096,7 +4072,7 @@
 	icon_state = "housewindowbrokenvertical"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dLK" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_x = -4;
@@ -4104,11 +4080,7 @@
 	},
 /obj/item/clothing/under/f13/female/flapper,
 /turf/open/floor/carpet,
-/area/f13/city)
-"dMc" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
+/area/f13/building)
 "dMQ" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -4116,7 +4088,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "dNj" = (
 /obj/structure/railing/wood{
 	pixel_x = -1
@@ -4152,7 +4124,7 @@
 	pixel_y = -32
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "dOf" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -4160,11 +4132,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "dOV" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dPl" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -12
@@ -4191,12 +4163,12 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "dQd" = (
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "dQg" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -4210,7 +4182,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "dRe" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
@@ -4251,7 +4223,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "dTw" = (
 /obj/item/newspaper,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4262,7 +4234,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "dUq" = (
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland/warren)
@@ -4272,28 +4244,28 @@
 	color = "#363636"
 	},
 /turf/closed/wall/f13/ruins,
-/area/f13/city)
+/area/f13/building)
 "dVk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dVO" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "dVR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "dXb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "dXc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -4302,7 +4274,7 @@
 "dXj" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "dXE" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light{
@@ -4324,14 +4296,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "dZj" = (
 /obj/structure/closet/crate/footchest,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "dZk" = (
 /obj/structure/junk/cabinet,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4357,13 +4329,13 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "ebQ" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ece" = (
 /obj/effect/decal/cleanable/greenglow/radioactive{
 	pixel_x = -4;
@@ -4387,17 +4359,17 @@
 	pixel_x = -13
 	},
 /turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "edE" = (
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "edY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fence/corner,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "eej" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4420,7 +4392,7 @@
 "egf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/area/f13/building)
 "egn" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -4443,7 +4415,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ehn" = (
 /obj/structure/barricade/concrete,
 /turf/open/indestructible/ground/outside/road{
@@ -4455,7 +4427,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "ehI" = (
 /obj/effect/landmark/start/f13/ncrdrillsergeant,
 /turf/open/floor/plasteel/vault,
@@ -4464,7 +4436,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "ein" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark1"
@@ -4493,13 +4465,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ekM" = (
 /obj/item/ingot/silver,
 /obj/item/ingot/gold,
 /obj/item/ingot/titanium,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "ekO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fence{
@@ -4521,7 +4493,7 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "emM" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4563,7 +4535,7 @@
 /turf/closed/wall/f13/vault{
 	name = "regulation wall"
 	},
-/area/f13/city)
+/area/f13/building)
 "ens" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/indestructible/ground/outside/ruins{
@@ -4581,13 +4553,13 @@
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "eoB" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eoC" = (
 /obj/item/flag/ncr{
 	pixel_y = 31
@@ -4604,7 +4576,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "epG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken{
@@ -4616,7 +4588,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "epL" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottomleft"
@@ -4625,13 +4597,13 @@
 "epT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/city)
+/area/f13/building)
 "eqS" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "erf" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
@@ -4648,13 +4620,13 @@
 	dir = 4;
 	icon_state = "bluecorner"
 	},
-/area/f13/city)
+/area/f13/building)
 "erV" = (
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "esi" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -4692,7 +4664,7 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "eul" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
@@ -4700,7 +4672,7 @@
 "evr" = (
 /obj/item/stack/ore/iron,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "ewp" = (
 /obj/effect/decal/fakelattice,
 /turf/closed/indestructible/rock,
@@ -4712,7 +4684,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "ewI" = (
 /obj/structure/debris/v1,
 /turf/open/indestructible/ground/outside/ruins{
@@ -4725,7 +4697,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "exi" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -4746,14 +4718,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/junk/small/bed2,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eyn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/spacevine{
 	name = "Mutant Vines"
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "eyU" = (
 /obj/structure/closet/crate/radiation,
 /obj/structure/spider/stickyweb,
@@ -4767,7 +4739,7 @@
 	req_one_access_txt = "62"
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "ezn" = (
 /obj/structure/fence{
 	dir = 8;
@@ -4783,7 +4755,7 @@
 "ezr" = (
 /obj/structure/junk/small/table,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "ezR" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -4794,21 +4766,21 @@
 	pixel_x = 14
 	},
 /turf/open/indestructible/ground/outside/savannah/topleft,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "eAG" = (
 /obj/structure/railing/wood{
 	dir = 8;
 	pixel_x = -3
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "eAJ" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowbottom"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "eBB" = (
 /obj/machinery/light/small/broken{
 	dir = 1;
@@ -4819,7 +4791,7 @@
 /turf/open/floor/f13{
 	icon_state = "damaged2"
 	},
-/area/f13/city)
+/area/f13/building)
 "eCe" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -4834,13 +4806,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "eCV" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "eDK" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -4863,7 +4835,7 @@
 "eEJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "eEQ" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -4890,12 +4862,12 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "eFB" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/gambling,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "eFH" = (
 /obj/machinery/light{
 	dir = 1
@@ -4906,7 +4878,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "eFR" = (
 /obj/machinery/light{
 	dir = 4;
@@ -4917,14 +4889,14 @@
 "eGa" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall/rust,
-/area/f13/city)
+/area/f13/building)
 "eGe" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/ruins,
-/area/f13/city)
+/area/f13/building)
 "eGt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
@@ -4963,7 +4935,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eIs" = (
 /obj/structure/sign/poster/ncr/irradiated_food{
 	pixel_x = -32
@@ -5005,7 +4977,7 @@
 	light_color = "#706891"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eJN" = (
 /obj/effect/overlay/turfs/cliff/corner{
 	dir = 6;
@@ -5021,12 +4993,12 @@
 /obj/effect/decal/cleanable/robot_debris,
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "eJV" = (
 /obj/structure/table/wood,
 /obj/structure/punching_bag,
 /turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "eJX" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -5039,7 +5011,7 @@
 "eKj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/wasteland/warren)
 "eKn" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -5071,7 +5043,7 @@
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "eMA" = (
 /obj/structure/sink{
 	dir = 4;
@@ -5102,14 +5074,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "eMY" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/burger,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "eNd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/retro/backed,
@@ -5132,7 +5104,7 @@
 	pixel_y = 2
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/area/f13/building)
 "eOG" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -5150,7 +5122,7 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "eQe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -5158,7 +5130,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "eQt" = (
 /obj/structure/table/wood/fancy,
 /obj/effect/decal/cleanable/dirt,
@@ -5167,7 +5139,7 @@
 "eQz" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "eQA" = (
 /obj/machinery/vending/tool,
 /obj/effect/decal/cleanable/dirt,
@@ -5175,7 +5147,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "eRl" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/wasteland/ncr)
@@ -5189,20 +5161,20 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "eTh" = (
 /obj/structure/sign/departments/restroom{
 	pixel_x = -30
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eTx" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/ncr)
 "eTy" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eTK" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5215,7 +5187,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "eVc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3"
@@ -5226,25 +5198,25 @@
 	icon_state = "storewindowright"
 	},
 /turf/closed/wall/f13/store,
-/area/f13/city)
+/area/f13/building)
 "eVr" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eWo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "eWp" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "eWC" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/ncr)
@@ -5323,13 +5295,13 @@
 /obj/structure/chair/office/light,
 /obj/structure/safe/floor,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "faf" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
 /obj/item/stack/ore/blackpowder/fifty,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fam" = (
 /obj/machinery/light{
 	dir = 1;
@@ -5363,7 +5335,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "fbi" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -5380,7 +5352,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fda" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5392,7 +5364,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fdR" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -5402,17 +5374,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "feQ" = (
 /obj/structure/chair/office/dark,
 /mob/living/simple_animal/hostile/renegade/engie,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "feW" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fgc" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5427,7 +5399,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "fgO" = (
 /obj/structure/table,
 /obj/item/grenade/f13/stinger,
@@ -5446,14 +5418,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/raiders)
-"fhf" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/city)
 "fhl" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
@@ -5467,7 +5431,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "fhA" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_north"
@@ -5476,7 +5440,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fhN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -5512,13 +5476,13 @@
 	name = "North River Apartments"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "fiK" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "fjv" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -5554,7 +5518,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "flz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
@@ -5565,7 +5529,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "flZ" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/indestructible/ground/outside/road{
@@ -5577,7 +5541,7 @@
 	max_mobs = 2
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "fmL" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -5590,7 +5554,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken3"
 	},
-/area/f13/city)
+/area/f13/building)
 "fnx" = (
 /obj/structure/wreck/trash/one_barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5607,12 +5571,12 @@
 /area/f13/wasteland/warren)
 "foo" = (
 /turf/closed/wall/f13/wood,
-/area/f13/city)
+/area/f13/building)
 "foT" = (
 /obj/machinery/light/small,
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "fpe" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/raiders)
@@ -5624,19 +5588,19 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "fps" = (
 /obj/machinery/light/small,
 /mob/living/simple_animal/pet/dog/protectron,
 /turf/open/floor/plating,
-/area/f13/city)
+/area/f13/building)
 "fpz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "fpC" = (
 /obj/effect/overlay/turfs/cliff/corner{
 	dir = 9;
@@ -5676,7 +5640,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "fqq" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5687,11 +5651,11 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "fqJ" = (
 /obj/machinery/mineral/wasteland_vendor/pipboy,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "frd" = (
 /obj/structure/table/wood,
 /obj/item/documents{
@@ -5708,7 +5672,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "frG" = (
 /obj/structure/simple_door/tentflap_cloth{
 	pixel_y = 3
@@ -5716,7 +5680,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "frL" = (
 /obj/machinery/vending/nukacolavend,
 /obj/effect/decal/cleanable/dirt,
@@ -5726,26 +5690,20 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "fsv" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
-"fsH" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontaltopborderbottom2left"
-	},
-/area/f13/city)
+/area/f13/building)
 "ftu" = (
 /obj/item/healthanalyzer/advanced,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "ftG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/defibrillator/primitive,
@@ -5754,11 +5712,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ftT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "ftX" = (
 /obj/item/geiger_counter,
 /turf/open/floor/plating/rust,
@@ -5790,13 +5748,13 @@
 /obj/structure/table,
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "fuI" = (
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "fuN" = (
 /obj/item/storage/trash_stack,
 /obj/machinery/light/lampost{
@@ -5815,7 +5773,7 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/item/reagent_containers/food/snacks/grown/tea,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
-/area/f13/city)
+/area/f13/building)
 "fvh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/vehicle/ridden/fuel/motorcycle/green{
@@ -5867,7 +5825,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "fxL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet,
@@ -5890,12 +5848,12 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/f13/city)
+/area/f13/building)
 "fxN" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "fxS" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -5910,7 +5868,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "fyd" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
@@ -5934,7 +5892,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "fyZ" = (
 /obj/structure/railing/wood/underlayer{
 	dir = 1;
@@ -5982,7 +5940,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "fDx" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -5990,7 +5948,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "fDN" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/water,
@@ -6045,23 +6003,23 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "fFq" = (
 /obj/structure/table/wood/bar,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fFC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken6"
 	},
-/area/f13/city)
+/area/f13/building)
 "fFF" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fFX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/glass/bucket,
@@ -6090,7 +6048,7 @@
 	color = "#845f58"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fHq" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -6124,7 +6082,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "fIs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6132,7 +6090,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "fIv" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6148,13 +6106,13 @@
 "fJq" = (
 /obj/structure/window/fulltile/store,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "fJP" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "fJQ" = (
 /obj/item/crafting/fuse,
 /obj/item/crafting/fuse,
@@ -6177,7 +6135,7 @@
 	dir = 4;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "fKE" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -6210,24 +6168,23 @@
 	},
 /area/f13/wasteland/ncr)
 "fNh" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left"
+/turf/open/indestructible/ground/outside/graveldirt{
+	icon_state = "graveldirtedge"
 	},
-/area/f13/city)
+/area/f13/wasteland/warren)
 "fNq" = (
 /obj/structure/closet/crate/footlocker,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "fOd" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "fOn" = (
 /obj/structure/fence/door/opened,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -6237,12 +6194,12 @@
 	icon_state = "storewindowbottom"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "fQl" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
-/area/f13/city)
+/area/f13/building)
 "fQm" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/savannah,
@@ -6261,7 +6218,7 @@
 	dir = 1;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "fRW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -6270,7 +6227,7 @@
 /obj/structure/closet,
 /obj/item/melee/onehanded/knife/switchblade,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fTN" = (
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland/warren)
@@ -6292,13 +6249,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "fUN" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "fUV" = (
 /obj/item/chair/stool/bar,
 /obj/machinery/light/small/broken{
@@ -6307,7 +6264,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "fVU" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/road{
@@ -6349,7 +6306,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "fYo" = (
 /obj/effect/landmark/start/f13/outsider,
 /turf/open/indestructible/ground/outside/road{
@@ -6393,7 +6350,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "fZl" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland/ncr)
@@ -6411,14 +6368,14 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "gan" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "gaL" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -6433,7 +6390,7 @@
 /area/f13/ncr)
 "gcd" = (
 /turf/closed/indestructible/opshuttle,
-/area/f13/city)
+/area/f13/building)
 "gco" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -12
@@ -6456,7 +6413,7 @@
 	reagent_id = /datum/reagent/water
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "gdq" = (
 /obj/structure/railing/wood{
 	dir = 8;
@@ -6487,10 +6444,6 @@
 /obj/item/cultivator,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
-"gem" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
 "ges" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -6505,7 +6458,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gfs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -6526,7 +6479,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "ggh" = (
 /obj/structure/closet/crate,
 /obj/item/advanced_crafting_components/alloys,
@@ -6556,14 +6509,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "ghB" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/city)
+/area/f13/building)
 "ghE" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain0"
@@ -6578,14 +6531,14 @@
 	icon_state = "skin"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "gio" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "giC" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -6611,7 +6564,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "gke" = (
 /obj/structure/railing/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -6623,7 +6576,7 @@
 	},
 /obj/item/crafting/coffee_pot,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "gkv" = (
 /obj/structure/fence{
 	dir = 4
@@ -6644,7 +6597,7 @@
 /area/f13/ncr)
 "gkF" = (
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "glh" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowtop"
@@ -6652,7 +6605,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gmk" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -6675,14 +6628,14 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "gns" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "gnH" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -6709,7 +6662,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "goE" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/ncr)
@@ -6744,7 +6697,7 @@
 	pixel_x = 10
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "gqH" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -6753,7 +6706,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "grh" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8"
@@ -6768,7 +6721,7 @@
 	dir = 4;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "gsp" = (
 /obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/outside/dirt,
@@ -6778,14 +6731,14 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "gsB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/f13/city)
+/area/f13/building)
 "gsM" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = 12
@@ -6868,7 +6821,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gum" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -6876,7 +6829,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "guq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6888,13 +6841,13 @@
 "guS" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "guT" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "gvg" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -6916,7 +6869,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "gwj" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Logistics Center";
@@ -6932,7 +6885,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "gwD" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4;
@@ -6961,11 +6914,11 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "gxn" = (
 /obj/structure/bedsheetbin,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "gxv" = (
 /obj/structure/closet/crate{
 	icon_state = "medicalcrate"
@@ -6976,7 +6929,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "gxw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6996,7 +6949,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "gyz" = (
 /obj/item/newspaper,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7008,7 +6961,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/city)
+/area/f13/building)
 "gyX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed{
@@ -7053,7 +7006,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gAJ" = (
 /obj/item/tank/internals/anesthetic,
 /obj/item/tank/internals/anesthetic,
@@ -7079,7 +7032,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "gBM" = (
 /obj/structure/fence{
 	pixel_x = -14
@@ -7094,7 +7047,7 @@
 /obj/effect/gibspawner/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "gDu" = (
 /obj/effect/overlay/junk/shower{
 	dir = 4
@@ -7109,7 +7062,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gDK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
@@ -7121,7 +7074,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gFf" = (
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
@@ -7156,7 +7109,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken3"
 	},
-/area/f13/city)
+/area/f13/building)
 "gFW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -7174,7 +7127,7 @@
 "gHV" = (
 /obj/structure/decoration/smokeold,
 /turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/city)
+/area/f13/building)
 "gIb" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/beret/ncr_codresscap,
@@ -7208,23 +7161,18 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gIx" = (
 /obj/structure/chair/pew/right{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
-"gIF" = (
-/turf/open/indestructible/ground/outside/savannah/edgesnew{
-	dir = 8
-	},
-/area/f13/caves)
+/area/f13/building)
 "gJd" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "gJX" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -10
@@ -7257,7 +7205,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "gLP" = (
 /obj/effect/landmark/start/f13/ncrmp,
 /turf/open/floor/f13{
@@ -7282,7 +7230,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "gMI" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/ncr/ncr_shorts,
@@ -7312,7 +7260,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "gOG" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -7325,13 +7273,13 @@
 "gOS" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "gOZ" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowdestroyed"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "gPd" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/car/rubbish3,
@@ -7346,7 +7294,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "gPG" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowbottom"
@@ -7356,7 +7304,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gQo" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -7411,9 +7359,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/warren)
-"gTa" = (
-/turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
 "gUg" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -7427,7 +7372,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "gUQ" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
@@ -7453,14 +7398,14 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "gVV" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "gWW" = (
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
@@ -7492,11 +7437,11 @@
 	},
 /obj/structure/decoration/rag,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "gXW" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "gYg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -7545,7 +7490,7 @@
 	dir = 6;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "haI" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -12
@@ -7561,7 +7506,7 @@
 	icon_state = "small"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "haP" = (
 /obj/structure/sink{
 	dir = 4;
@@ -7576,19 +7521,19 @@
 /area/f13/raiders)
 "hbf" = (
 /turf/open/floor/plasteel/neutral/side,
-/area/f13/city)
+/area/f13/building)
 "hbK" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/food/snacks/f13/sugarbombs,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hdd" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "hdi" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -7596,11 +7541,11 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "hdn" = (
 /obj/machinery/light,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "hdJ" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -7634,7 +7579,7 @@
 	pixel_y = 2
 	},
 /turf/closed/wall/mineral/brick,
-/area/f13/city)
+/area/f13/building)
 "hek" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 9;
@@ -7654,12 +7599,12 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "heL" = (
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "heZ" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -7669,7 +7614,7 @@
 /area/f13/ncr)
 "hfM" = (
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "hgd" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
@@ -7706,7 +7651,7 @@
 /turf/open/floor/f13{
 	icon_state = "redchess"
 	},
-/area/f13/city)
+/area/f13/building)
 "hhW" = (
 /obj/structure/fence{
 	dir = 4
@@ -7717,13 +7662,13 @@
 /area/f13/wasteland/ncr)
 "his" = (
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/wasteland/warren)
 "hjf" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "hjW" = (
 /obj/structure/closet,
 /obj/item/key/bcollar,
@@ -7742,7 +7687,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hkJ" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/savannah,
@@ -7755,7 +7700,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "hlE" = (
 /obj/effect/decal/remains/deadeyebot,
 /obj/effect/decal/cleanable/oil,
@@ -7764,12 +7709,12 @@
 "hmd" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hnK" = (
 /obj/structure/flora/grass/jungle/b,
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "hop" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers,
@@ -7786,7 +7731,7 @@
 /obj/structure/mirelurkegg,
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "hoG" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -7796,13 +7741,13 @@
 	name = "North River Apartments"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "hoL" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "hpn" = (
 /obj/structure/simple_door/room{
 	name = "Unknown"
@@ -7815,7 +7760,7 @@
 /obj/structure/table/wood/bar,
 /obj/item/paper,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hqi" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
@@ -7827,7 +7772,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "hrv" = (
 /obj/structure/closet{
 	desc = "Stores suits and gear.";
@@ -7841,7 +7786,7 @@
 	light_color = "#706891"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "hrH" = (
 /obj/item/storage/secure/safe{
 	name = "apartment mailbox";
@@ -7856,7 +7801,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "hrR" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
@@ -7871,7 +7816,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "hsQ" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7879,7 +7824,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "hsU" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontaldegraded"
@@ -7919,14 +7864,14 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "huf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "hui" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7952,7 +7897,7 @@
 "hvm" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "hvo" = (
 /obj/effect/landmark/start/f13/ncrcombatengineer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -7966,7 +7911,7 @@
 "hwv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/city)
+/area/f13/building)
 "hwx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -7986,7 +7931,7 @@
 /obj/effect/decal/cleanable/generic,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hwE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -8008,7 +7953,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "hwT" = (
 /obj/structure/railing{
 	dir = 4
@@ -8068,7 +8013,7 @@
 	pixel_x = 27
 	},
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "hyZ" = (
 /obj/structure/lamp_post/quadra,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8080,19 +8025,19 @@
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "hAK" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hBa" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowleft"
 	},
 /turf/closed/wall/f13/store,
-/area/f13/city)
+/area/f13/building)
 "hBj" = (
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
 /turf/open/indestructible/ground/outside/dirt,
@@ -8116,7 +8061,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "hCn" = (
 /obj/structure/fence{
 	max_integrity = 500;
@@ -8129,7 +8074,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "hCZ" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4;
@@ -8157,7 +8102,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hDV" = (
 /obj/structure/flora/grass/jungle,
 /turf/closed/mineral/random/low_chance,
@@ -8171,7 +8116,7 @@
 	pixel_x = -10
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "hEF" = (
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/ncr)
@@ -8216,7 +8161,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "hGo" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -8250,7 +8195,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "hHW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -8258,12 +8203,12 @@
 	name = "counter shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "hIw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chalkboard,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hIx" = (
 /obj/machinery/door/unpowered/secure_NCR,
 /turf/open/floor/f13{
@@ -8296,7 +8241,7 @@
 "hJD" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "hJP" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -8314,7 +8259,7 @@
 	name = "counter shutters"
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "hKb" = (
 /obj/item/geiger_counter,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8328,17 +8273,17 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "hKu" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "hKR" = (
 /obj/structure/bookshelf,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hKT" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -8362,7 +8307,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "hLp" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -16
@@ -8432,7 +8377,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "hQO" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -8440,7 +8385,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "hRe" = (
 /obj/item/kirbyplants/dead{
 	desc = "A mummified potted plant.";
@@ -8449,7 +8394,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "hRN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/dresser,
@@ -8458,7 +8403,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "hRW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -8476,7 +8421,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "hSU" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8487,7 +8432,7 @@
 /obj/structure/table/rolling,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "hTA" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8518,7 +8463,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "hVk" = (
 /obj/structure/mirror{
 	pixel_x = -26
@@ -8529,7 +8474,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "hWz" = (
 /obj/structure/fence{
 	dir = 4
@@ -8550,7 +8495,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "hZx" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -8572,12 +8517,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"hZD" = (
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2right"
-	},
-/area/f13/city)
 "hZX" = (
 /obj/structure/decoration/vent{
 	icon_state = "ventrusty"
@@ -8598,7 +8537,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ibu" = (
 /obj/structure/fence{
 	dir = 4
@@ -8613,7 +8552,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "ibY" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -8651,7 +8590,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "igi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left"
@@ -8669,7 +8608,7 @@
 	name = "Novely News"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iha" = (
 /obj/structure/fence{
 	dir = 4
@@ -8702,12 +8641,12 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "ihz" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/plasteel/five,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iij" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/old,
@@ -8719,7 +8658,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "iim" = (
 /obj/machinery/light/small,
 /obj/item/flashlight/lamp/green{
@@ -8727,7 +8666,7 @@
 	},
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iiF" = (
 /obj/item/kirbyplants/dead{
 	desc = "A mummified potted plant.";
@@ -8738,7 +8677,7 @@
 /turf/open/floor/f13{
 	icon_state = "redchess"
 	},
-/area/f13/city)
+/area/f13/building)
 "ijx" = (
 /obj/machinery/light/small,
 /obj/structure/barricade/sandbags,
@@ -8781,7 +8720,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "ilu" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/fakelattice,
@@ -8797,7 +8736,7 @@
 	dir = 4;
 	icon_state = "blue"
 	},
-/area/f13/city)
+/area/f13/building)
 "ily" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
@@ -8816,7 +8755,7 @@
 /turf/open/floor/f13{
 	icon_state = "redsolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ilV" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/caves)
@@ -8826,33 +8765,33 @@
 	pixel_y = -2
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "imp" = (
 /obj/item/chair,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "imu" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "imV" = (
 /obj/item/chair/stool/bar,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "inf" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "inl" = (
 /turf/closed/wall/rust,
-/area/f13/city)
+/area/f13/building)
 "inp" = (
 /obj/effect/landmark/start/f13/ncrheavytrooper,
 /turf/open/indestructible/ground/outside/road{
@@ -8873,7 +8812,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "inQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8899,7 +8838,7 @@
 /turf/open/floor/f13{
 	icon_state = "redsolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ioF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8908,7 +8847,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "ioI" = (
 /obj/effect/overlay/junk/sink{
 	pixel_y = 20
@@ -8916,7 +8855,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "ioY" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -8932,7 +8871,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "iqb" = (
 /turf/open/indestructible/ground/outside/dirthole,
 /area/f13/wasteland/warren)
@@ -8941,7 +8880,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "iqi" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -8955,7 +8894,7 @@
 "iql" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/area/f13/building)
 "iqS" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -8972,7 +8911,7 @@
 	icon_state = "book-5"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "irD" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 8
@@ -8999,14 +8938,14 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "itj" = (
 /obj/structure/window/fulltile/store,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "itq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -9018,7 +8957,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/overlay/junk/toilet,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/city)
+/area/f13/building)
 "itF" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/indestructible/ground/outside/road{
@@ -9039,7 +8978,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken4"
 	},
-/area/f13/city)
+/area/f13/building)
 "iuG" = (
 /obj/structure/railing,
 /obj/machinery/conveyor{
@@ -9087,7 +9026,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "iwJ" = (
 /obj/structure/fence/wooden{
 	climbable = 0;
@@ -9117,11 +9056,11 @@
 	pixel_y = -5
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ixV" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iye" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -9129,12 +9068,12 @@
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "izd" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "izs" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -9153,12 +9092,12 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /obj/item/melee/onehanded/knife/bowie,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iAy" = (
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "iAH" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	dir = 4
@@ -9169,7 +9108,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "iAY" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -9198,7 +9137,7 @@
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iBY" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -9209,7 +9148,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "iCp" = (
 /obj/machinery/smartfridge/drying_rack{
 	pixel_y = 4
@@ -9228,12 +9167,12 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "iDm" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+/turf/closed/wall/f13/vault{
+	name = "regulation wall"
 	},
-/area/f13/city)
+/area/f13/wasteland/warren)
 "iDy" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -9258,11 +9197,11 @@
 	pixel_y = 7
 	},
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "iEf" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iEq" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -9287,7 +9226,7 @@
 	icon_state = "housewindowvertical"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "iGq" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -9324,14 +9263,14 @@
 /obj/structure/flora/grass/wasteland,
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/city)
+/area/f13/building)
 "iIM" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
 	icon_state = "ruinswindowdestroyed"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iJK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -9345,7 +9284,7 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/city)
+/area/f13/building)
 "iJX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
@@ -9363,7 +9302,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "iKp" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile/house{
@@ -9415,19 +9354,19 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "iMk" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/railing/wood,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/city)
+/area/f13/building)
 "iMq" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 8;
 	pixel_x = 1
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "iMH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/drawer,
@@ -9436,7 +9375,7 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "iNc" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/barricade/sandbags,
@@ -9454,7 +9393,7 @@
 	dir = 5;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "iOn" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /obj/machinery/light/broken{
@@ -9463,7 +9402,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "iOE" = (
 /obj/structure/simple_door/room{
 	name = "Recovery Ward"
@@ -9495,7 +9434,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "iPd" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -9504,7 +9443,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "iPR" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
@@ -9527,13 +9466,13 @@
 /obj/structure/table/wood,
 /obj/item/paper/crumpled/bloody,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iRE" = (
 /obj/machinery/door/airlock/vault,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/city)
+/area/f13/building)
 "iTt" = (
 /obj/item/flag/locust{
 	desc = "A flag, marking the area as raider territory.";
@@ -9580,7 +9519,7 @@
 "iVn" = (
 /obj/machinery/light,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iVE" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Command Centre";
@@ -9598,7 +9537,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "iWJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "crossborder";
@@ -9627,7 +9566,7 @@
 /obj/structure/closet,
 /obj/item/flashlight,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "iYr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9644,7 +9583,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "iYP" = (
 /obj/machinery/light/fo13colored/Aqua{
 	desc = "A lighting fixture with cold blue lighting.";
@@ -9654,14 +9593,14 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "iZc" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "iZf" = (
 /obj/machinery/shower{
 	dir = 8
@@ -9683,14 +9622,14 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "jbA" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/caves)
 "jbM" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "jcc" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -9698,7 +9637,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jcl" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
@@ -9709,7 +9648,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
 	},
-/area/f13/city)
+/area/f13/building)
 "jdp" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -9731,14 +9670,14 @@
 	},
 /obj/machinery/smartfridge/bottlerack/gardentool/primitive,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "jeF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "jeT" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9758,7 +9697,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "jfK" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -9787,15 +9726,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "jgA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "jhF" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/area/f13/building)
 "jhT" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -9830,7 +9769,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "jjr" = (
 /turf/closed/wall/rust,
 /area/f13/ncr)
@@ -9883,7 +9822,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "jmm" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/barricade/bars{
@@ -9909,7 +9848,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "jmU" = (
 /obj/effect/decal/riverbankcorner{
 	dir = 4
@@ -9949,7 +9888,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "jqi" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -9961,7 +9900,7 @@
 "jrc" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "jrt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
@@ -9970,7 +9909,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "jrJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -9980,7 +9919,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "jsX" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9995,7 +9934,7 @@
 "juc" = (
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "juD" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10004,7 +9943,7 @@
 /area/f13/wasteland/warren)
 "juF" = (
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "juH" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/wood,
@@ -10018,7 +9957,7 @@
 	icon_state = "book-2"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jvj" = (
 /obj/structure/railing{
 	dir = 9
@@ -10027,7 +9966,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "jvk" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -10070,7 +10009,7 @@
 	pixel_y = 19
 	},
 /turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "jzk" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -10122,12 +10061,12 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "jAz" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "jAD" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -10142,7 +10081,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "jAI" = (
 /obj/machinery/autolathe,
 /turf/open/indestructible/ground/inside/subway,
@@ -10190,19 +10129,13 @@
 /obj/structure/table,
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
-"jDH" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerborder"
-	},
-/area/f13/city)
+/area/f13/building)
 "jDZ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "jEC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/shard{
@@ -10211,11 +10144,11 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "jED" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood/house/broken,
-/area/f13/city)
+/area/f13/building)
 "jFs" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -10262,7 +10195,7 @@
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "jIa" = (
 /obj/structure/rack{
 	pixel_x = 3;
@@ -10272,7 +10205,7 @@
 /obj/item/brahmincollar,
 /obj/item/brahminbridle,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/city)
+/area/f13/building)
 "jIo" = (
 /obj/structure/table/reinforced,
 /obj/item/roller,
@@ -10301,12 +10234,12 @@
 /obj/item/chair,
 /obj/item/pen,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jJN" = (
 /obj/structure/simple_door/wood,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jJZ" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -10324,14 +10257,14 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "jKy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/optable,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "jKz" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/savannah,
@@ -10349,7 +10282,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jNf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -10359,7 +10292,7 @@
 /obj/structure/bed,
 /obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "jNo" = (
 /obj/structure/fence{
 	dir = 4
@@ -10390,19 +10323,19 @@
 /area/f13/wasteland/warren)
 "jOK" = (
 /turf/closed/wall/f13/store,
-/area/f13/city)
+/area/f13/building)
 "jOL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "jOP" = (
 /mob/living/simple_animal/hostile/renegade/defender,
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "jPb" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -10420,7 +10353,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "jPm" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -10431,7 +10364,7 @@
 	pixel_y = -30
 	},
 /turf/closed/wall/r_wall/rust,
-/area/f13/city)
+/area/f13/building)
 "jPu" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
@@ -10452,7 +10385,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "jQU" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -10472,13 +10405,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "jRG" = (
 /obj/structure/sign/poster/prewar/poster66{
 	pixel_x = -29
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jSm" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -10517,14 +10450,14 @@
 	pixel_y = 29
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jTt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "jTE" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -10532,7 +10465,7 @@
 	},
 /obj/item/shard,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jTM" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -10567,7 +10500,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "jUD" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile/house{
@@ -10583,7 +10516,7 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "jVT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10591,12 +10524,12 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "jWa" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "jWr" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -10619,11 +10552,11 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "jWX" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "jXh" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -10642,7 +10575,7 @@
 /turf/open/floor/plasteel/darkbrown/corner{
 	dir = 8
 	},
-/area/f13/city)
+/area/f13/building)
 "jYn" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -10671,7 +10604,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "kaz" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -10689,19 +10622,19 @@
 	color = "#845f58"
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "kbq" = (
 /obj/structure/filingcabinet,
 /obj/structure/filingcabinet{
 	pixel_x = 11
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "kbz" = (
 /turf/open/floor/f13{
 	icon_state = "redsolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "kcm" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
@@ -10720,7 +10653,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "kdW" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -10728,7 +10661,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "keO" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -10746,7 +10679,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "keZ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/suit/bio_suit/f13/hazmat,
@@ -10768,13 +10701,13 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "kfR" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "kgo" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 4
@@ -10796,7 +10729,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "kht" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
 /area/f13/ncr)
@@ -10809,11 +10742,11 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kiS" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "kjL" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -10846,13 +10779,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kkF" = (
 /obj/structure/curtain{
 	color = "#ffc0cb"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kkI" = (
 /obj/effect/overlay/turfs/sidewalk,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10862,7 +10795,7 @@
 	icon_state = "brokenstore"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "kly" = (
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/road{
@@ -10889,13 +10822,13 @@
 "knT" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "knU" = (
 /obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "koU" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/flora/grass/jungle/b,
@@ -10905,13 +10838,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
-"kpo" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerbordercorner"
-	},
-/area/f13/city)
+/area/f13/building)
 "kpG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10921,20 +10848,20 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "kqo" = (
 /obj/structure/fence/wooden{
 	dir = 1;
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "kqQ" = (
 /obj/structure/closet,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "krz" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10967,7 +10894,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/city)
+/area/f13/building)
 "ktI" = (
 /obj/machinery/light{
 	dir = 1
@@ -10975,13 +10902,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kue" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/city)
+/area/f13/building)
 "kul" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowleft"
@@ -10990,7 +10917,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kuM" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11000,7 +10927,7 @@
 "kvn" = (
 /obj/structure/window/fulltile/house,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "kvR" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
@@ -11008,7 +10935,7 @@
 /area/f13/wasteland/warren)
 "kwt" = (
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "kxm" = (
 /obj/structure/anvil/obtainable/table,
 /obj/item/stack/sheet/metal/ten,
@@ -11025,7 +10952,7 @@
 	dir = 10;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "kyu" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11041,7 +10968,7 @@
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "kzz" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
@@ -11063,7 +10990,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kAk" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -11073,7 +11000,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "kAE" = (
 /obj/structure/debris/v3,
 /obj/structure/wreck/trash/engine,
@@ -11082,7 +11009,7 @@
 "kAI" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kAK" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -11094,7 +11021,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kCk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -11105,7 +11032,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "kCT" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -11115,7 +11042,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "kDb" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
@@ -11124,13 +11051,13 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kDn" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kDF" = (
 /obj/structure/railing/wood{
 	dir = 8;
@@ -11147,7 +11074,7 @@
 /area/f13/wasteland/warren)
 "kEq" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "kEs" = (
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
 /area/f13/wasteland/warren)
@@ -11206,7 +11133,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "kHm" = (
 /obj/structure/closet/crate/bin{
 	pixel_x = -7;
@@ -11227,7 +11154,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "kIn" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
@@ -11238,7 +11165,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "kIH" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -11247,7 +11174,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "kJa" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -11259,11 +11186,11 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "kJf" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "kJl" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -11324,20 +11251,20 @@
 	pixel_y = 19
 	},
 /turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "kMg" = (
 /obj/structure/sign/warning/explosives{
 	icon_state = "explosives2"
 	},
 /turf/closed/wall/f13/store,
-/area/f13/city)
+/area/f13/building)
 "kMw" = (
 /obj/structure/junk/locker,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kMS" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	dir = 9;
@@ -11348,11 +11275,11 @@
 "kNj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/interior,
-/area/f13/city)
+/area/f13/building)
 "kNk" = (
 /obj/structure/safe,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "kNv" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/floor/f13/wood,
@@ -11392,11 +11319,11 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kPL" = (
 /obj/machinery/light/broken,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kQg" = (
 /obj/structure/table/wood,
 /obj/item/paper/fluff{
@@ -11434,7 +11361,7 @@
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "kRp" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -11452,12 +11379,12 @@
 "kRx" = (
 /obj/structure/junk/cabinet,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kRW" = (
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "kRY" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -11465,7 +11392,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "kSG" = (
 /obj/structure/fence{
 	dir = 4
@@ -11474,7 +11401,7 @@
 	dir = 1;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "kTe" = (
 /obj/structure/grille,
 /obj/structure/barricade/bars,
@@ -11488,11 +11415,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kUv" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/city)
+/area/f13/building)
 "kUX" = (
 /obj/structure/railing/wood/underlayer{
 	dir = 1;
@@ -11508,11 +11435,11 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "kVN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "kVS" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/indestructible/ground/outside/savannah,
@@ -11538,12 +11465,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kWF" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft1"
 	},
-/area/f13/city)
+/area/f13/building)
 "kWP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/prewar/poster72{
@@ -11552,7 +11479,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kXD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
@@ -11574,7 +11501,7 @@
 "kYD" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "kYF" = (
 /obj/structure/closet/crate/footchest,
 /obj/item/stack/ore/blackpowder/fifty,
@@ -11582,7 +11509,7 @@
 /obj/item/stack/sheet/metal/ten,
 /obj/item/stack/sheet/mineral/wood/twenty,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "kYT" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 1
@@ -11590,13 +11517,13 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "kZb" = (
 /obj/structure/simple_door/brokenglass,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "kZh" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11607,7 +11534,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/wastelootgood,
 /turf/open/floor/plasteel/darkbrown/side,
-/area/f13/city)
+/area/f13/building)
 "kZw" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -11620,7 +11547,7 @@
 	},
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "lae" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11633,7 +11560,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "lav" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken3"
@@ -11662,7 +11589,7 @@
 	pixel_x = -14
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "laS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11683,7 +11610,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "lbm" = (
 /obj/effect/overlay/junk/shower{
 	dir = 4
@@ -11712,7 +11639,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "lbL" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -11724,7 +11651,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "lbQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -11742,14 +11669,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "lcV" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
 /area/f13/ncr)
 "lcZ" = (
 /turf/closed/wall/r_wall/rust,
-/area/f13/city)
+/area/f13/building)
 "ldg" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -11758,12 +11685,12 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ldh" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "lec" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/graveldirt{
@@ -11780,24 +11707,24 @@
 	pixel_y = -7
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "lfh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken4"
 	},
-/area/f13/city)
+/area/f13/building)
 "lfJ" = (
 /obj/structure/mirelurkegg,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "lgg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/prewar/poster71{
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "lgq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11808,7 +11735,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "lgP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -11825,7 +11752,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "lha" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
@@ -11848,7 +11775,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/city)
+/area/f13/building)
 "lig" = (
 /obj/structure/simple_door/metal/store{
 	name = "General Atomics"
@@ -11857,7 +11784,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lik" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11866,25 +11793,25 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "ljq" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "ljV" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "lkg" = (
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/area/f13/building)
 "lkv" = (
 /obj/item/stack/ore/slag,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "lky" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -11897,7 +11824,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "lkP" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
@@ -11924,7 +11851,7 @@
 "loR" = (
 /obj/structure/closet,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "loT" = (
 /obj/structure/table,
 /obj/item/stack/f13Cash/random/med,
@@ -11932,7 +11859,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lpr" = (
 /obj/effect/turf_decal/huge{
 	dir = 4
@@ -11968,7 +11895,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/city)
+/area/f13/building)
 "lqx" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/condiment/saltshaker,
@@ -11980,13 +11907,13 @@
 "lqV" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "lrc" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "lrJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -12002,7 +11929,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lsq" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/warren)
@@ -12014,7 +11941,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lsO" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -12040,7 +11967,7 @@
 "ltC" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/indestructible/rock,
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "ltL" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -12055,7 +11982,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "luH" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/plasteel/vault,
@@ -12092,7 +12019,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/city)
+/area/f13/building)
 "lvB" = (
 /obj/structure/table,
 /obj/item/radio,
@@ -12137,11 +12064,11 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lyO" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/carpet/royalblue,
-/area/f13/city)
+/area/f13/building)
 "lzC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -12151,7 +12078,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lAl" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12160,7 +12087,7 @@
 	termtag = "Business"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "lAE" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -12178,7 +12105,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "lAL" = (
 /obj/structure/bed/mattress,
 /obj/item/bedsheet/pirate,
@@ -12197,7 +12124,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lBx" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
@@ -12221,11 +12148,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/warren)
-"lDG" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/city)
 "lDI" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -12233,7 +12155,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lDW" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken6"
@@ -12253,7 +12175,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "lGF" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -12264,13 +12186,13 @@
 	pixel_y = 11
 	},
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "lGL" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lHk" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -12290,7 +12212,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lHY" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2right"
@@ -12323,7 +12245,7 @@
 /obj/structure/table/booth,
 /obj/item/reagent_containers/pill/fixer,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "lKo" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -12333,7 +12255,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lKY" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/dark,
@@ -12343,7 +12265,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "lLr" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -12351,7 +12273,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "lLs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12386,11 +12308,11 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "lMB" = (
 /obj/structure/chair/sofa/corner,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "lMI" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12406,7 +12328,7 @@
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 8
 	},
-/area/f13/city)
+/area/f13/building)
 "lNk" = (
 /obj/effect/overlay/junk/shower{
 	dir = 4
@@ -12415,7 +12337,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lNn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -12437,7 +12359,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lNV" = (
 /obj/structure/nest/protectron{
 	max_mobs = 2
@@ -12445,13 +12367,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lOk" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "lOM" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 4;
@@ -12474,7 +12396,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lQm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12486,7 +12408,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "lQy" = (
 /obj/structure/fence{
 	dir = 8;
@@ -12507,18 +12429,18 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "lRa" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 9;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "lRg" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
-/area/f13/city)
+/area/f13/building)
 "lRI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -12535,7 +12457,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
-/area/f13/city)
+/area/f13/building)
 "lRT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/railing{
@@ -12544,7 +12466,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lRU" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -12566,13 +12488,13 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "lSj" = (
 /obj/item/geiger_counter,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "lSm" = (
 /obj/structure/bookshelf{
 	icon_state = "book-3"
@@ -12582,7 +12504,7 @@
 	pixel_x = -7
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "lSq" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
@@ -12621,7 +12543,7 @@
 	pixel_x = 3
 	},
 /turf/open/floor/carpet/royalblue,
-/area/f13/city)
+/area/f13/building)
 "lVy" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -12676,32 +12598,32 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "lXy" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "lYm" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "lYF" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/fancy/candle_box,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "lZL" = (
 /obj/structure/junk/locker,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "lZQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -12710,7 +12632,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "lZU" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12721,20 +12643,20 @@
 /obj/machinery/computer,
 /obj/structure/curtain,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "mbg" = (
 /obj/structure/simple_door/room{
 	name = "North River Apartments"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "mcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mcm" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -12754,12 +12676,12 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "mco" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mcZ" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -12784,7 +12706,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "mdW" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -12822,7 +12744,7 @@
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/trash/f13/rotten,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mhw" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
@@ -12834,13 +12756,13 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "mhS" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "mhZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -12854,7 +12776,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "mip" = (
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite,
@@ -12863,7 +12785,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "miy" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -12880,13 +12802,13 @@
 "miR" = (
 /obj/structure/junk/micro,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mjj" = (
 /obj/structure/bookshelf{
 	icon_state = "book-4"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mjD" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -12900,7 +12822,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "mjQ" = (
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/wasteland/warren)
@@ -12913,38 +12835,38 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mku" = (
 /obj/structure/curtain{
 	color = "#ffc0cb";
 	pixel_y = 5
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mkI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "mkL" = (
 /obj/item/clothing/accessory/medal/gold,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "mkV" = (
 /obj/structure/barricade/tentclothcorner{
 	pixel_y = 3
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "mlR" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mlV" = (
 /obj/structure/table/wood/junk,
 /obj/item/reagent_containers/food/snacks/cubancarp{
@@ -12952,7 +12874,7 @@
 	pixel_y = 13
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "mna" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -12981,11 +12903,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mpo" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mps" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12997,11 +12919,11 @@
 /obj/structure/rack,
 /obj/item/stack/ore/blackpowder/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "mrm" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "mrs" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13011,7 +12933,7 @@
 "mrA" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "msi" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -13045,7 +12967,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "muq" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13070,7 +12992,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "mva" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -13079,7 +13001,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "mvf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass{
@@ -13088,10 +13010,10 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mvj" = (
 /turf/closed/wall/f13/wood/house/broken,
-/area/f13/city)
+/area/f13/building)
 "mvy" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
@@ -13122,7 +13044,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mxr" = (
 /obj/structure/fence/corner{
 	pixel_y = -12
@@ -13132,7 +13054,7 @@
 "mys" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "myL" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -13164,7 +13086,7 @@
 "mAV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "mCd" = (
 /obj/structure/fence{
 	max_integrity = 500;
@@ -13175,7 +13097,7 @@
 "mCe" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mCm" = (
 /obj/structure/sign/plaques/ncr_rep{
 	pixel_y = 32
@@ -13198,7 +13120,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "mCK" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -13206,13 +13128,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mCU" = (
 /obj/structure/closet,
 /obj/item/lipstick/random,
 /obj/item/storage/backpack/satchel/leather,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mDn" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken1"
@@ -13220,7 +13142,7 @@
 /area/f13/wasteland/warren)
 "mDz" = (
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/city)
+/area/f13/building)
 "mDB" = (
 /obj/effect/landmark/start/f13/ncrcorporal,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -13233,7 +13155,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "mDQ" = (
 /obj/structure/table,
 /obj/structure/barricade/wooden,
@@ -13241,7 +13163,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mEf" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Command Centre";
@@ -13255,7 +13177,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mEB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13277,7 +13199,7 @@
 	dir = 10;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "mFt" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
@@ -13318,7 +13240,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mFT" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -13327,14 +13249,14 @@
 "mGc" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mGq" = (
 /obj/structure/table,
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mGz" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13391,7 +13313,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "mIf" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13399,7 +13321,7 @@
 "mIm" = (
 /obj/item/chair,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mJo" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/reagent_containers/pill/patch/healingpoultice,
@@ -13411,7 +13333,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "mJR" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -13432,11 +13354,11 @@
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/plasteel/elevatorshaft,
-/area/f13/city)
+/area/f13/building)
 "mKO" = (
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/wasteland/warren)
 "mKR" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13458,7 +13380,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mLW" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_5"
@@ -13479,7 +13401,7 @@
 	icon_state = "tall_grass_8"
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "mOz" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13511,7 +13433,7 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/mob_spawn/human/corpse,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "mQf" = (
 /turf/open/indestructible/ground/outside/savannah/center,
 /area/f13/ncr)
@@ -13535,10 +13457,10 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "mRw" = (
 /turf/closed/indestructible/fakeglass,
-/area/f13/city)
+/area/f13/building)
 "mRP" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -13558,7 +13480,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "mRV" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Command Centre";
@@ -13571,13 +13493,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/ruins,
-/area/f13/city)
+/area/f13/building)
 "mSp" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "mSs" = (
 /obj/structure/table/wood/bar,
 /obj/item/storage/box/cups,
@@ -13609,7 +13531,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "mUk" = (
 /obj/structure/decoration/vent/rusty,
 /obj/machinery/light/small/broken{
@@ -13620,7 +13542,7 @@
 "mUw" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mUJ" = (
 /obj/structure/simple_door/metal/store{
 	name = "Warren Police Department"
@@ -13628,7 +13550,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "mUM" = (
 /obj/machinery/light{
 	dir = 4;
@@ -13677,7 +13599,7 @@
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "mWH" = (
 /obj/structure/closet/crate/hydroponics{
 	anchored = 1;
@@ -13727,13 +13649,13 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "mXy" = (
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mZl" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -13756,7 +13678,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "mZJ" = (
 /obj/structure/noticeboard{
 	name = "bounty board"
@@ -13768,7 +13690,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "mZS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13777,7 +13699,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "nar" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -13785,7 +13707,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/city)
+/area/f13/building)
 "nav" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13796,7 +13718,7 @@
 /obj/structure/junk/small/table,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "naY" = (
 /obj/structure/chair/stool/f13stool,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -13813,7 +13735,7 @@
 /obj/structure/junk/small/bed,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "nbt" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -13821,7 +13743,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "nbw" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -13832,19 +13754,19 @@
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "nbD" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 10;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "nbM" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nbT" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -13863,7 +13785,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ndk" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
@@ -13883,7 +13805,7 @@
 /area/f13/ncr)
 "nei" = (
 /turf/open/floor/carpet/royalblue,
-/area/f13/city)
+/area/f13/building)
 "nek" = (
 /obj/structure/decoration/vent/rusty,
 /obj/effect/decal/cleanable/dirt,
@@ -13896,14 +13818,14 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "neB" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "neY" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -13916,17 +13838,17 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "nfw" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/city)
+/area/f13/building)
 "nfM" = (
 /mob/living/simple_animal/hostile/renegade/guardian,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "nfR" = (
 /obj/effect/landmark/start/f13/ncrrearechelon,
 /turf/open/indestructible/ground/outside/road{
@@ -13940,7 +13862,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ngt" = (
 /obj/machinery/light{
 	dir = 1
@@ -13971,7 +13893,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "njw" = (
 /obj/structure/decoration/vent{
 	icon_state = "ventrustyalt"
@@ -13983,7 +13905,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "njX" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -16
@@ -14001,7 +13923,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "nkd" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -14027,7 +13949,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "nkA" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -14039,13 +13961,13 @@
 "nls" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plasteel/darkbrown/side,
-/area/f13/city)
+/area/f13/building)
 "nlE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "nlV" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/savannah,
@@ -14084,7 +14006,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "nng" = (
 /obj/structure/filingcabinet{
 	pixel_x = 11
@@ -14093,7 +14015,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "nnk" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -14109,7 +14031,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "nns" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -14133,7 +14055,7 @@
 /obj/structure/table/wood/bar,
 /obj/item/crafting/reloader,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "noO" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14171,7 +14093,7 @@
 /turf/open/floor/f13{
 	icon_state = "redchess"
 	},
-/area/f13/city)
+/area/f13/building)
 "nsn" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
@@ -14184,7 +14106,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ntf" = (
 /obj/machinery/light{
 	dir = 1;
@@ -14210,7 +14132,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ntM" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -14242,10 +14164,8 @@
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/ncr)
 "nux" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/city)
+/turf/open/floor/wood/wood_common,
+/area/f13/building)
 "nvm" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
@@ -14259,7 +14179,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nvW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14295,12 +14215,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "nxu" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "nxO" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8
@@ -14332,7 +14252,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "nyC" = (
 /obj/structure/simple_door/bunker{
 	name = "Water Treatment Plant"
@@ -14340,7 +14260,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "nyO" = (
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/f13vaultrusted,
@@ -14349,12 +14269,12 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "nzA" = (
 /obj/structure/junk/cabinet,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "nAa" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-08"
@@ -14394,12 +14314,12 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "nEZ" = (
 /obj/structure/table/wood/bar,
 /obj/item/ammo_box/c45/improvised,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nFf" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -14412,12 +14332,12 @@
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nFQ" = (
 /obj/structure/table/wood/bar,
 /obj/item/paper_bin,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nGG" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -14429,7 +14349,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken4"
 	},
-/area/f13/city)
+/area/f13/building)
 "nGS" = (
 /obj/machinery/autolathe/constructionlathe,
 /obj/effect/decal/cleanable/dirt{
@@ -14439,7 +14359,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "nGU" = (
 /obj/structure/sink{
 	dir = 4;
@@ -14449,7 +14369,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "nGY" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14468,10 +14388,10 @@
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland/warren)
 "nHQ" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder"
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 8
 	},
-/area/f13/city)
+/area/f13/wasteland/warren)
 "nIf" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14492,7 +14412,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "nJz" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -14517,7 +14437,7 @@
 	pixel_x = 3
 	},
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "nKA" = (
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -14547,7 +14467,7 @@
 	},
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nMN" = (
 /turf/open/floor/plasteel/darkpurple,
 /area/f13/ncr)
@@ -14567,7 +14487,7 @@
 "nNB" = (
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "nNH" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
@@ -14584,7 +14504,7 @@
 "nPB" = (
 /mob/living/simple_animal/hostile/renegade/drifter,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/wasteland/warren)
 "nPV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -14611,24 +14531,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "nQR" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "nRt" = (
 /obj/structure/closet,
 /obj/item/storage/medical/ancientfirstaid,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "nRF" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
-/area/f13/city)
+/area/f13/building)
 "nRO" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkdirty"
@@ -14649,7 +14569,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "nSn" = (
 /obj/structure/table,
 /obj/item/folder/blue,
@@ -14668,7 +14588,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "nSV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/ncr/keep_to_myself{
@@ -14692,7 +14612,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
-/area/f13/city)
+/area/f13/building)
 "nUd" = (
 /obj/structure/fence/cut/medium{
 	dir = 4
@@ -14712,7 +14632,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "nVD" = (
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/ncr)
@@ -14720,7 +14640,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/raiderloot,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "nWl" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
@@ -14729,7 +14649,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "nWt" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -14740,13 +14660,13 @@
 "nWu" = (
 /obj/structure/sign/poster/contraband/tools,
 /turf/closed/wall/f13/store,
-/area/f13/city)
+/area/f13/building)
 "nXa" = (
 /obj/structure/disposalpipe/broken{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "nXA" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -12
@@ -14762,7 +14682,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/city)
+/area/f13/building)
 "nYb" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain0"
@@ -14791,13 +14711,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "nYM" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "nYN" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -14871,7 +14791,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "obo" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -14880,24 +14800,24 @@
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pestspray,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ocL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "ocM" = (
 /obj/structure/junk/machinery,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ocX" = (
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "odb" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14926,7 +14846,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "odP" = (
 /obj/structure/filingcabinet{
 	pixel_x = -6
@@ -14934,7 +14854,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "oec" = (
 /obj/structure/chair/bench,
 /obj/machinery/light,
@@ -15011,7 +14931,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "ojj" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -15028,7 +14948,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 4
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "ojM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15040,14 +14960,14 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "ojT" = (
 /obj/machinery/light/small{
 	dir = 1;
 	light_color = "red"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "oko" = (
 /obj/structure/fence,
 /obj/structure/fence/corner{
@@ -15065,17 +14985,17 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "okY" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "oli" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "onb" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
@@ -15115,7 +15035,7 @@
 /turf/open/floor/f13{
 	icon_state = "redsolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ooY" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
@@ -15127,7 +15047,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "oqu" = (
 /obj/structure/bookcase/random/fiction,
 /obj/structure/window/reinforced/tinted/frosted{
@@ -15147,7 +15067,7 @@
 "orF" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "orN" = (
 /obj/structure/curtain{
 	pixel_y = 32
@@ -15203,7 +15123,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "ouI" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -15231,7 +15151,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "ovP" = (
 /obj/structure/table,
 /obj/item/ammo_box/a40mmCS,
@@ -15244,13 +15164,13 @@
 /obj/structure/chair/f13chair2,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ovT" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ovZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
@@ -15269,7 +15189,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "oxi" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 8;
@@ -15279,14 +15199,14 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "oxk" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "oxu" = (
 /obj/structure/sign/warning/securearea{
 	name = "Restricted Area"
@@ -15296,7 +15216,7 @@
 "oxQ" = (
 /obj/structure/sign/warning/nosmoking/circle,
 /turf/closed/wall/f13/store,
-/area/f13/city)
+/area/f13/building)
 "oxW" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright1"
@@ -15312,7 +15232,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "oAa" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -12
@@ -15346,13 +15266,13 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "oBv" = (
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
 	},
-/area/f13/city)
+/area/f13/building)
 "oBS" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 9;
@@ -15381,7 +15301,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "oCX" = (
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/outside/water,
@@ -15408,7 +15328,7 @@
 	name = "Mutant Vines"
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "oEP" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -15432,17 +15352,17 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "oHU" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "oHW" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/darkbrown/corner,
-/area/f13/city)
+/area/f13/building)
 "oIa" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 4
@@ -15464,14 +15384,14 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "oJm" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "oKt" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/savannah,
@@ -15496,7 +15416,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "oMk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/overlay/junk/sink{
@@ -15505,13 +15425,13 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "oMq" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "oME" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/greenglow/radioactive,
@@ -15523,7 +15443,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/medical/surgical,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "oMJ" = (
 /obj/machinery/smartfridge/drying_rack{
 	pixel_y = 4
@@ -15546,10 +15466,10 @@
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "oOf" = (
 /turf/open/floor/plasteel/neutral,
-/area/f13/city)
+/area/f13/building)
 "oOn" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
@@ -15566,7 +15486,7 @@
 "oOM" = (
 /obj/structure/nest/radroach,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "oOY" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -15579,7 +15499,7 @@
 	pixel_x = 15
 	},
 /turf/closed/wall/r_wall/rust,
-/area/f13/city)
+/area/f13/building)
 "oPO" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/revolver/police,
@@ -15587,7 +15507,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "oPZ" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -15596,7 +15516,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "oQH" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4;
@@ -15611,14 +15531,14 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/barricade/wooden,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "oRf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "oRG" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -15642,7 +15562,7 @@
 /obj/structure/table/wood/fancy,
 /obj/item/storage/book/bible,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "oTd" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -15651,7 +15571,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "oTg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair2{
@@ -15660,7 +15580,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "oTi" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
@@ -15696,7 +15616,7 @@
 	pixel_y = 2
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/area/f13/building)
 "oUZ" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
@@ -15709,14 +15629,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "oVy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/pet_carrier,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "oVA" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
@@ -15732,13 +15652,13 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "oWg" = (
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/city)
+/area/f13/wasteland/warren)
 "oWn" = (
 /obj/structure/fence{
 	pixel_x = 1
@@ -15747,12 +15667,12 @@
 	dir = 4;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "oWu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/window,
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "oWz" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
@@ -15772,19 +15692,19 @@
 	pixel_x = 4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "oXF" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "oXN" = (
 /obj/structure/simple_door/tentflap_cloth{
 	pixel_y = 3
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "oXS" = (
 /obj/structure/closet,
 /obj/item/clothing/mask/gas/glass,
@@ -15806,7 +15726,7 @@
 "oYp" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "oYA" = (
 /obj/machinery/light{
 	dir = 4
@@ -15814,7 +15734,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "oZe" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15896,7 +15816,7 @@
 "pbY" = (
 /obj/structure/junk/small/tv,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pcB" = (
 /obj/effect/landmark/start/f13/ncrfirstsergeant,
 /turf/open/floor/plasteel/vault,
@@ -15908,7 +15828,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "pdP" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -16
@@ -15924,13 +15844,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "pdT" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 6;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "pee" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/sandbags,
@@ -15955,7 +15875,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "pfm" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/road{
@@ -15993,7 +15913,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "phL" = (
 /obj/structure/fence{
 	dir = 4
@@ -16007,7 +15927,7 @@
 	light_color = "#706891"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "pjr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16015,7 +15935,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "pjB" = (
 /obj/structure/chair/folding{
 	dir = 8
@@ -16024,11 +15944,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "pjM" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "pks" = (
 /obj/structure/fence/wooden,
 /obj/structure/fence/wooden{
@@ -16040,7 +15960,7 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/f13/hubologist,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "pkQ" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -16089,16 +16009,16 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "pmE" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/cocoon,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "pmS" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "pmU" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -16126,23 +16046,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ppV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/curtain,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "pqV" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "prm" = (
 /obj/structure/closet/crate/wicker,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "prv" = (
 /obj/structure/closet/locker/fridge,
 /obj/item/reagent_containers/food/snacks/meat/slab/gecko,
@@ -16154,7 +16074,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "psc" = (
 /obj/structure/simple_door/room{
 	name = "North River Apartments"
@@ -16162,41 +16082,36 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "puG" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
 	icon_state = "ruinswindowbrokenvertical"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pvv" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pwm" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "pwC" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
-"pxl" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/city)
 "pxo" = (
 /obj/structure/dresser,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pxw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fence{
@@ -16205,7 +16120,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "pxB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16215,7 +16130,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "pxS" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
@@ -16229,22 +16144,22 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "pys" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pyz" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/darkbrown/corner{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "pyG" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "pyI" = (
 /obj/structure/chair/sofa/right{
 	dir = 8;
@@ -16252,7 +16167,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "pAv" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag,
@@ -16267,7 +16182,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "pAJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -16295,7 +16210,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "pDB" = (
 /obj/structure/closet/crate/grave,
 /turf/open/indestructible/ground/outside/dirt,
@@ -16310,7 +16225,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "pEI" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -10
@@ -16353,7 +16268,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "pFU" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /turf/open/indestructible/ground/outside/savannah,
@@ -16369,7 +16284,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "pGi" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_x = -3;
@@ -16383,12 +16298,12 @@
 	pixel_y = 4
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "pGk" = (
 /obj/structure/bed/wooden,
 /obj/item/blanket/blanketalt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pGn" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -16401,7 +16316,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "pGE" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
@@ -16416,7 +16331,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pIk" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/fakelattice,
@@ -16436,7 +16351,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/f13/city)
+/area/f13/building)
 "pIH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16444,7 +16359,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "pIN" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -16458,7 +16373,7 @@
 	name = "handheld radio"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "pJS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -16470,7 +16385,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "pJX" = (
 /obj/structure/table/wood/settler,
 /obj/item/ammo_box/magazine/m556mm,
@@ -16513,7 +16428,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "pKE" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -16554,27 +16469,27 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "pLn" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "pLv" = (
 /obj/structure/closet/crate/footlocker,
 /obj/effect/spawner/lootdrop/f13/cash_ncr_low,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "pLF" = (
 /obj/item/radio/off,
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "pLS" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -16591,7 +16506,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "pOA" = (
 /obj/structure/closet/crate/bin{
 	pixel_x = 6;
@@ -16613,7 +16528,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "pPs" = (
 /obj/machinery/light{
 	dir = 8
@@ -16640,7 +16555,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "pQe" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -16648,7 +16563,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "pQf" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16658,7 +16573,7 @@
 "pQO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "pRa" = (
 /obj/machinery/light{
 	dir = 1
@@ -16683,7 +16598,7 @@
 "pSr" = (
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "pSP" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -12
@@ -16703,7 +16618,7 @@
 	name = "sloppy graffiti"
 	},
 /turf/closed/wall/mineral/brick,
-/area/f13/city)
+/area/f13/building)
 "pSU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -16733,7 +16648,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "pTl" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
@@ -16762,13 +16677,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "pVZ" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
 	},
-/area/f13/city)
+/area/f13/building)
 "pWr" = (
 /obj/structure/closet/crate/secure/gear{
 	anchored = 1;
@@ -16778,7 +16693,7 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
 /turf/open/floor/plasteel/elevatorshaft,
-/area/f13/city)
+/area/f13/building)
 "pWM" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowleft"
@@ -16788,17 +16703,17 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "pWR" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "pWT" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "pWU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16823,7 +16738,7 @@
 "pXz" = (
 /obj/item/stack/ore/lead,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "pXD" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -16840,7 +16755,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "pYB" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
@@ -16854,7 +16769,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "pYT" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -16892,7 +16807,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/paper/crumpled,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qcq" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -16907,7 +16822,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "qdy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
@@ -16918,12 +16833,12 @@
 	icon_state = "booth_east_south"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qes" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "qet" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/plantbgone,
@@ -16931,7 +16846,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qeA" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 4;
@@ -16945,7 +16860,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "qfm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
@@ -16955,12 +16870,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
 	},
-/area/f13/city)
+/area/f13/building)
 "qfA" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "qfI" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -16974,7 +16889,7 @@
 	pixel_y = -5
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "qgt" = (
 /obj/item/ammo_casing/c9mm{
 	dir = 4
@@ -16988,7 +16903,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "qhK" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom1"
@@ -16997,7 +16912,7 @@
 "qib" = (
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "qil" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -17006,7 +16921,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qiF" = (
 /obj/structure/fence{
 	dir = 4
@@ -17020,12 +16935,12 @@
 "qiG" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "qiW" = (
 /obj/item/soap/homemade,
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qjl" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -17063,7 +16978,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "qki" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/preopen,
@@ -17082,13 +16997,13 @@
 "qkS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "qlr" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "qlM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17102,7 +17017,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "qnv" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17137,7 +17052,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "qox" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -17151,7 +17066,7 @@
 	name = "Mutant Vines"
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "qpg" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -17161,7 +17076,7 @@
 	dir = 8;
 	icon_state = "blue"
 	},
-/area/f13/city)
+/area/f13/building)
 "qpk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17171,7 +17086,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qpN" = (
 /obj/machinery/door/poddoor/gate/preopen{
 	name = "fortress gate"
@@ -17179,7 +17094,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/city)
+/area/f13/building)
 "qpZ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
@@ -17209,7 +17124,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "qqW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/ausbushes/fernybush,
@@ -17227,20 +17142,20 @@
 	},
 /obj/machinery/light/broken,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qrG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/spacevine{
 	name = "Mutant Vines"
 	},
 /turf/closed/wall/rust,
-/area/f13/city)
+/area/f13/building)
 "qrT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "qrZ" = (
 /obj/structure/car/rubbish2{
 	pixel_x = 14
@@ -17265,7 +17180,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "qsY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
@@ -17279,13 +17194,13 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "qtk" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/cards/deck,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qto" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
@@ -17294,12 +17209,12 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "qud" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qvf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -17310,13 +17225,13 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "qvB" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "qvC" = (
 /obj/structure/sign/poster/contraband/punch_shit,
 /turf/closed/indestructible/f13vaultrusted{
@@ -17331,7 +17246,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qxm" = (
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -17346,7 +17261,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "qya" = (
 /obj/item/rack_parts,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17381,7 +17296,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "qyL" = (
 /obj/structure/table/booth,
 /obj/item/storage/box/drinkingglasses,
@@ -17390,7 +17305,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "qzg" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17401,7 +17316,7 @@
 /area/f13/wasteland/warren)
 "qzv" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/city)
+/area/f13/building)
 "qzD" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -17412,7 +17327,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "qzE" = (
 /obj/structure/decoration/clock{
 	pixel_y = 27
@@ -17421,7 +17336,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qzI" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -17433,7 +17348,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "qAQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "crossborder";
@@ -17502,23 +17417,23 @@
 "qDO" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qDS" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qDY" = (
 /obj/machinery/mineral/wasteland_vendor/medical,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "qEn" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/city)
+/area/f13/building)
 "qEu" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/effect/landmark/poster_spawner/pinup{
@@ -17534,7 +17449,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qEM" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -17544,7 +17459,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qER" = (
 /obj/structure/fence{
 	dir = 4
@@ -17562,7 +17477,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "qFq" = (
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
@@ -17584,7 +17499,7 @@
 	dir = 4;
 	icon_state = "blue"
 	},
-/area/f13/city)
+/area/f13/building)
 "qGG" = (
 /obj/structure/closet/cardboard,
 /obj/item/stack/ore/blackpowder/fifty,
@@ -17592,11 +17507,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "qHh" = (
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "qHk" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland/warren)
@@ -17610,7 +17525,7 @@
 "qHv" = (
 /obj/structure/bed,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "qHx" = (
 /obj/structure/table,
 /turf/open/floor/carpet/blue,
@@ -17670,7 +17585,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "qKM" = (
 /obj/structure/fence{
 	dir = 4
@@ -17683,7 +17598,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qLx" = (
 /obj/item/stack/rods,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17709,7 +17624,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "qMh" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/tires/two,
@@ -17749,19 +17664,19 @@
 /area/f13/wasteland/warren)
 "qOd" = (
 /turf/open/floor/plasteel/darkbrown,
-/area/f13/city)
+/area/f13/building)
 "qOi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "qOl" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/city)
+/area/f13/building)
 "qOq" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17779,12 +17694,12 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qPW" = (
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "qQh" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -17822,14 +17737,14 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "qQy" = (
 /obj/structure/filingcabinet,
 /obj/structure/filingcabinet{
 	pixel_x = 11
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "qQP" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -17840,7 +17755,7 @@
 /turf/open/floor/f13{
 	icon_state = "redchess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qQQ" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -17851,7 +17766,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "qRa" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ncr)
@@ -17884,23 +17799,21 @@
 /turf/open/floor/f13{
 	icon_state = "redsolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "qSX" = (
 /obj/structure/wreck/car/bike,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland/warren)
 "qTh" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/road,
+/area/f13/building)
 "qTE" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowtop"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "qUc" = (
 /obj/structure/sink{
 	dir = 4;
@@ -17915,7 +17828,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "qUh" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -17943,7 +17856,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "qWn" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -17962,7 +17875,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "qYZ" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/grass,
@@ -17975,7 +17888,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "qZp" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/topright,
@@ -18023,7 +17936,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "rcc" = (
 /obj/machinery/biogenerator,
 /turf/open/indestructible/ground/outside/savannah,
@@ -18036,7 +17949,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "rcM" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/poster_spawner/prewar{
@@ -18045,7 +17958,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "rcO" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -18058,7 +17971,7 @@
 "rcR" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rdo" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18081,7 +17994,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "ref" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -18098,20 +18011,20 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "reu" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /obj/effect/spawner/lootdrop/raiderloot,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rev" = (
 /mob/living/simple_animal/hostile/renegade/doc,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "reY" = (
 /obj/structure/table/wood/settler,
 /obj/structure/barricade/bars,
@@ -18176,7 +18089,7 @@
 /turf/open/floor/f13{
 	icon_state = "redchess"
 	},
-/area/f13/city)
+/area/f13/building)
 "rhQ" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -18191,17 +18104,17 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "riN" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
 	pixel_y = 3
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "rjo" = (
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "rjq" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/ncr_k_ration,
@@ -18255,13 +18168,13 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/wasteland/warren)
 "rlN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "rlT" = (
 /obj/machinery/light{
 	dir = 1;
@@ -18272,7 +18185,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "rlZ" = (
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/water,
@@ -18300,7 +18213,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "roa" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -18312,7 +18225,7 @@
 "rom" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "rpf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/sofa/corp/left{
@@ -18321,7 +18234,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rpz" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/ruins{
@@ -18335,7 +18248,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "rpU" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -18361,7 +18274,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "rqV" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18422,7 +18335,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "rto" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18432,7 +18345,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ruf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18440,7 +18353,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "rut" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18455,7 +18368,7 @@
 "rvf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "rvl" = (
 /obj/structure/closet/crate/hydroponics{
 	anchored = 1;
@@ -18489,7 +18402,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "rvz" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -18497,7 +18410,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "rvC" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4;
@@ -18516,13 +18429,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "rvP" = (
 /obj/structure/chair/sofa/corner{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "rxf" = (
 /obj/effect/decal/marking,
 /obj/structure/car/rubbish4,
@@ -18546,7 +18459,7 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "rxO" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18566,7 +18479,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "ryp" = (
 /obj/structure/closet/crate/footchest,
 /obj/item/ammo_box/c10mm/improvised,
@@ -18597,7 +18510,7 @@
 	pixel_x = -4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "ryO" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -18624,7 +18537,7 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rzH" = (
 /obj/structure/fence{
 	dir = 8;
@@ -18646,12 +18559,12 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "rAa" = (
 /obj/structure/junk/small/table,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rAc" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8"
@@ -18674,7 +18587,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "rAA" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -18692,7 +18605,7 @@
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rBn" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -18702,7 +18615,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "rBN" = (
 /obj/machinery/light{
 	dir = 1
@@ -18717,19 +18630,19 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "rCQ" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "rCU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rDb" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/savannah,
@@ -18748,7 +18661,7 @@
 /turf/open/floor/f13{
 	icon_state = "damaged1"
 	},
-/area/f13/city)
+/area/f13/building)
 "rEx" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18762,7 +18675,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/city)
+/area/f13/building)
 "rFA" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-12"
@@ -18777,7 +18690,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "rGu" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -18786,7 +18699,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "rHo" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -18796,7 +18709,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "rHF" = (
 /obj/structure/window/spawner/north,
 /obj/structure/table,
@@ -18810,7 +18723,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/junk/locker,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rHP" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
@@ -18846,7 +18759,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "rJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/high_chance,
@@ -18864,12 +18777,12 @@
 /turf/open/floor/f13{
 	icon_state = "damaged2"
 	},
-/area/f13/city)
+/area/f13/building)
 "rKL" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
 	},
-/area/f13/city)
+/area/f13/building)
 "rKR" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8"
@@ -18879,7 +18792,7 @@
 "rLd" = (
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "rLO" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -18900,7 +18813,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/office/light,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rOQ" = (
 /obj/structure/lamp_post{
 	dir = 1
@@ -18913,7 +18826,7 @@
 "rPh" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/plasteel,
-/area/f13/city)
+/area/f13/building)
 "rPq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -18944,7 +18857,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "rQw" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18971,7 +18884,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/city)
+/area/f13/building)
 "rRE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/secure/safe{
@@ -18987,7 +18900,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "rSD" = (
 /obj/machinery/light{
 	dir = 8
@@ -18995,7 +18908,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "rUv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
@@ -19006,7 +18919,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rUy" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
@@ -19038,7 +18951,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "rWM" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -18
@@ -19051,7 +18964,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rXL" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -19070,10 +18983,10 @@
 	icon_state = "ruinswindowvertical"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "rYz" = (
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "rYD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -19102,11 +19015,11 @@
 	icon_state = "storewindowleft"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "rZs" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "rZI" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -19157,7 +19070,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "sbW" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -12
@@ -19174,7 +19087,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "scw" = (
 /obj/structure/fence/cut/large{
 	dir = 4
@@ -19200,12 +19113,12 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "sdt" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /obj/structure/safe,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "sdG" = (
 /obj/structure/filingcabinet{
 	pixel_x = 11
@@ -19213,7 +19126,7 @@
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sef" = (
 /obj/structure/decoration/shock{
 	pixel_x = -32
@@ -19221,7 +19134,7 @@
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/junk/jukebox,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "sfe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
@@ -19237,7 +19150,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "sfz" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt,
@@ -19312,7 +19225,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "sli" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
@@ -19326,24 +19239,24 @@
 	},
 /obj/item/stack/rods/ten,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "slt" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "slF" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
 	},
-/area/f13/city)
+/area/f13/building)
 "slO" = (
 /obj/structure/chair/office/dark,
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "smb" = (
 /obj/structure/curtain{
 	pixel_y = 32
@@ -19357,7 +19270,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "snb" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
@@ -19368,13 +19281,13 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 1
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "snm" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "snq" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
@@ -19385,7 +19298,7 @@
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "soJ" = (
 /obj/structure/fence{
 	pixel_y = 1
@@ -19398,7 +19311,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "spQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet/secret/low_loot{
@@ -19412,7 +19325,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "sqj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19425,7 +19338,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "srq" = (
 /obj/structure/junk/locker,
 /turf/open/floor/f13{
@@ -19438,7 +19351,7 @@
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "ssy" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -19483,7 +19396,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "suo" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19502,7 +19415,7 @@
 	pixel_y = 14
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "suC" = (
 /obj/effect/landmark/start/f13/outsider,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19536,7 +19449,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "suT" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt,
@@ -19544,12 +19457,12 @@
 "svf" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "svn" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "svS" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -19560,12 +19473,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
-"swo" = (
-/turf/open/indestructible/ground/outside/graveldirt{
-	dir = 4
-	},
-/area/f13/raiders)
+/area/f13/building)
 "swR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/shoes/sneakers/white,
@@ -19573,7 +19481,7 @@
 /obj/item/storage/fancy/heart_box,
 /obj/item/clothing/neck/stripedgreenscarf,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sxa" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -19593,7 +19501,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "sxO" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19606,7 +19514,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "syT" = (
 /obj/machinery/light/small/broken{
 	dir = 8;
@@ -19619,7 +19527,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "szB" = (
 /obj/structure/debris/v3,
 /obj/structure/wreck/trash/engine,
@@ -19647,19 +19555,19 @@
 "sAr" = (
 /obj/structure/junk/small/table,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sAs" = (
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken2"
 	},
-/area/f13/city)
+/area/f13/building)
 "sAx" = (
 /obj/item/stamp/denied,
 /obj/item/folder/red{
 	pixel_x = 7
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "sAO" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -19674,7 +19582,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "sBu" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor3"
@@ -19710,7 +19618,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "sDs" = (
 /mob/living/simple_animal/hostile/wolf/playable,
 /turf/open/indestructible/ground/outside/road{
@@ -19731,7 +19639,7 @@
 "sEh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sEj" = (
 /obj/structure/railing/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19750,7 +19658,7 @@
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "sFb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -19763,7 +19671,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "sFC" = (
 /obj/structure/tires/five,
 /obj/effect/decal/cleanable/oil{
@@ -19773,7 +19681,7 @@
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 8
 	},
-/area/f13/city)
+/area/f13/building)
 "sFF" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/rust,
@@ -19791,7 +19699,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sHx" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -19803,7 +19711,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "sHR" = (
 /obj/machinery/door/window{
 	pixel_y = 10
@@ -19813,25 +19721,25 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "sIb" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "sIF" = (
 /obj/structure/stacklifter,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "sIO" = (
 /obj/item/rack_parts,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "sJg" = (
 /obj/machinery/light{
 	dir = 8
@@ -19861,7 +19769,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "sKT" = (
 /obj/structure/barricade/concrete,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19891,7 +19799,7 @@
 "sMf" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "sMj" = (
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/ncr)
@@ -19904,7 +19812,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "sNO" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -19917,7 +19825,7 @@
 "sOp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "sOO" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -19930,7 +19838,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "sPk" = (
 /obj/structure/fence{
 	dir = 4
@@ -19961,7 +19869,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "sQg" = (
 /obj/effect/landmark/start/f13/ncrconscript,
 /turf/open/indestructible/ground/outside/savannah,
@@ -19981,7 +19889,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "sQC" = (
 /obj/structure/decoration/rag{
 	desc = "Writing in your own blood seems like a bad idea.";
@@ -20017,7 +19925,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
-/area/f13/city)
+/area/f13/building)
 "sSf" = (
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
@@ -20030,7 +19938,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "sSt" = (
 /obj/item/reagent_containers/glass/beaker/waterbottle/empty,
 /obj/item/reagent_containers/glass/beaker/waterbottle{
@@ -20044,12 +19952,12 @@
 	pixel_x = 12
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sSL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "sTd" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
@@ -20075,7 +19983,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "sUd" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -20121,20 +20029,20 @@
 	dir = 8;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "sUG" = (
 /obj/structure/filingcabinet,
 /obj/structure/filingcabinet{
 	pixel_x = -10
 	},
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "sVo" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
 	},
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "sVx" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
@@ -20150,11 +20058,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "sVJ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "sVZ" = (
 /obj/item/reagent_containers/food/snacks/f13/canned/dog,
 /obj/item/reagent_containers/food/snacks/f13/canned/dog,
@@ -20163,7 +20071,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "sWO" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/fakelattice,
@@ -20193,7 +20101,7 @@
 	req_one_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "sYg" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -20201,7 +20109,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "sYl" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -20214,7 +20122,7 @@
 "sZg" = (
 /obj/structure/stairs/south,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "sZi" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
@@ -20245,12 +20153,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
-"tbu" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
-	},
-/area/f13/city)
+/area/f13/building)
 "tbI" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -20272,7 +20175,7 @@
 "tdl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/neutral,
-/area/f13/city)
+/area/f13/building)
 "tdO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleftbottom"
@@ -20289,12 +20192,12 @@
 /obj/item/lighter/gold,
 /obj/item/clothing/neck/necklace/dope,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "tft" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chalkboard,
 /turf/open/floor/plasteel/neutral/side,
-/area/f13/city)
+/area/f13/building)
 "tfS" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 4;
@@ -20304,7 +20207,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "tgc" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 6;
@@ -20323,7 +20226,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "thd" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -20345,14 +20248,14 @@
 "tix" = (
 /obj/structure/junk/micro,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
-/area/f13/city)
+/area/f13/building)
 "tiA" = (
 /obj/structure/obstacle/old_locked_door{
 	name = "Backend Books"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tiN" = (
 /obj/structure/fence/cut/large{
 	dir = 4
@@ -20418,7 +20321,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtycorner"
 	},
-/area/f13/city)
+/area/f13/building)
 "tnd" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
@@ -20432,17 +20335,17 @@
 	pixel_x = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "toc" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "toX" = (
 /mob/living/simple_animal/hostile/trog/sporecarrier,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "tpC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20462,7 +20365,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "trW" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -20472,7 +20375,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken4"
 	},
-/area/f13/city)
+/area/f13/building)
 "tsy" = (
 /obj/structure/closet/fridge/cannibal,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -20480,7 +20383,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "tsH" = (
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
@@ -20517,7 +20420,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "tuV" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -20537,14 +20440,14 @@
 	name = "Concrete wall";
 	smooth = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "twI" = (
 /turf/open/floor/plating,
-/area/f13/city)
+/area/f13/building)
 "txq" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "txu" = (
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/ncr)
@@ -20561,7 +20464,7 @@
 /area/f13/wasteland/warren)
 "tyI" = (
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "tzp" = (
 /obj/machinery/light{
 	dir = 4;
@@ -20575,7 +20478,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "tAr" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 4;
@@ -20592,7 +20495,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tBy" = (
 /obj/item/twohanded/baseball/golfclub{
 	pixel_y = 30
@@ -20602,7 +20505,7 @@
 	pixel_y = 31
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tBG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -20620,7 +20523,7 @@
 /obj/item/clothing/shoes/workboots,
 /obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "tCd" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -20634,7 +20537,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "tDi" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -20643,7 +20546,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
-/area/f13/city)
+/area/f13/building)
 "tDI" = (
 /obj/structure/fence{
 	max_integrity = 500;
@@ -20659,7 +20562,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "tEy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stacklifter,
@@ -20674,7 +20577,7 @@
 /area/f13/wasteland/warren)
 "tEK" = (
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "tEQ" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls";
@@ -20696,7 +20599,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "tFi" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20729,7 +20632,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "tGu" = (
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland/ncr)
@@ -20753,7 +20656,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tHr" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -20765,7 +20668,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "tIh" = (
 /obj/structure/fence/corner{
 	dir = 4
@@ -20790,7 +20693,7 @@
 "tIC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/brick,
-/area/f13/city)
+/area/f13/building)
 "tJc" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/r_wall,
@@ -20798,7 +20701,7 @@
 "tJF" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tJK" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -20814,7 +20717,7 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "tKc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermainbottom"
@@ -20850,7 +20753,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "tLO" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -20858,13 +20761,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "tMv" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "tMz" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/ncr,
@@ -20886,7 +20789,7 @@
 /obj/machinery/smartfridge/bottlerack/drug_storage,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "tMN" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -20904,12 +20807,12 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "tMY" = (
 /obj/structure/junk/locker,
 /obj/effect/spawner/lootdrop/wastelootgood,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tNh" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -20918,7 +20821,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 1
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "tNj" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -20932,7 +20835,7 @@
 "tNn" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tNM" = (
 /obj/structure/fence/corner{
 	pixel_x = 14;
@@ -20954,7 +20857,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "tOB" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -10
@@ -20982,24 +20885,24 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "tPJ" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "tPS" = (
 /obj/structure/chair/sofa/left{
 	dir = 1;
 	pixel_y = -5
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "tQa" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/area/f13/building)
 "tQy" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -21016,7 +20919,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "tRc" = (
 /obj/structure/wreck/trash/two_barrels,
 /obj/structure/lattice{
@@ -21037,7 +20940,7 @@
 	icon_state = "gibleg"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "tRq" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -21056,7 +20959,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "tSm" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -21064,11 +20967,11 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "tSu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/city)
+/area/f13/building)
 "tSG" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -21077,7 +20980,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/city)
+/area/f13/building)
 "tSW" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/vault,
@@ -21089,17 +20992,17 @@
 	name = "abraxo solution"
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "tTD" = (
 /obj/structure/simple_door/bunker{
 	name = "Water Treatment Plant"
 	},
 /turf/open/floor/plating/dirt/dark,
-/area/f13/city)
+/area/f13/building)
 "tTF" = (
 /obj/structure/simple_door/brokenglass,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "tUg" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -21139,13 +21042,13 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "tWH" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
 	},
-/area/f13/city)
+/area/f13/building)
 "tWV" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -21177,12 +21080,12 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "tXs" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
-/area/f13/city)
+/area/f13/building)
 "tXy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/button/door{
@@ -21193,7 +21096,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "tYa" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plasteel/dark,
@@ -21203,7 +21106,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "tYn" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	pixel_y = 6
@@ -21215,7 +21118,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "tZf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -21230,7 +21133,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "tZI" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -12
@@ -21256,7 +21159,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ubC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowright"
@@ -21302,7 +21205,7 @@
 "uce" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "uch" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
@@ -21347,7 +21250,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "uet" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -21375,7 +21278,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ugl" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/destructible/tribal_torch/wall{
@@ -21405,15 +21308,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "uht" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "uhu" = (
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "uhx" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -21440,12 +21343,12 @@
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/blueprintLowMid,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "uiy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/radroach,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "uiJ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -21466,7 +21369,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ujz" = (
 /obj/structure/closet/cabinet,
 /obj/item/megaphone,
@@ -21500,13 +21403,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ulu" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ulI" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -21545,16 +21448,13 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
-"umj" = (
-/turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/caves)
+/area/f13/building)
 "umk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood/bar,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "umo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink/kitchen{
@@ -21563,7 +21463,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "umW" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -21601,7 +21501,7 @@
 /area/f13/raiders)
 "uos" = (
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "uoL" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -21622,7 +21522,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "upx" = (
 /obj/item/flag/ncr{
 	pixel_y = 31
@@ -21638,13 +21538,13 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "upJ" = (
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "uqn" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -21664,23 +21564,23 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "urT" = (
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "usv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "usF" = (
 /obj/structure/fence/wooden{
 	dir = 4;
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "usQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -21688,7 +21588,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "usS" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light/small/broken{
@@ -21699,11 +21599,11 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "utQ" = (
 /obj/structure/table/rolling,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "uue" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/beret/ncr_dresscap,
@@ -21728,12 +21628,12 @@
 	pixel_x = -5
 	},
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "uus" = (
 /obj/structure/bed/dogbed,
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "uux" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21797,7 +21697,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "uyl" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -21815,21 +21715,21 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "uyV" = (
 /obj/structure/table/booth,
 /obj/item/broken_bottle,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
-/area/f13/city)
+/area/f13/building)
 "uzq" = (
 /obj/item/rack_parts,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/city)
+/area/f13/building)
 "uzu" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "uzA" = (
 /obj/machinery/microwave/stove,
 /obj/machinery/light{
@@ -21874,13 +21774,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
 	},
-/area/f13/city)
+/area/f13/building)
 "uBK" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "uBP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -21893,17 +21793,17 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "uCi" = (
 /obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "uCG" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "uCS" = (
 /obj/structure/sign/poster/prewar/poster69{
 	dir = 1;
@@ -21929,14 +21829,14 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "uDJ" = (
 /obj/structure/simple_door/interior{
 	name = "Novely News"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "uDK" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
@@ -21977,7 +21877,7 @@
 	pixel_y = -5
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "uFE" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -21996,7 +21896,7 @@
 	dir = 1;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "uFN" = (
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/f13/ncrconscript,
@@ -22035,14 +21935,14 @@
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "uJh" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "uJr" = (
 /obj/structure/chair/folding{
 	dir = 8
@@ -22051,15 +21951,11 @@
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "uKe" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/f13,
-/area/f13/city)
-"uKf" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/building)
 "uKx" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -22072,14 +21968,14 @@
 /obj/item/reagent_containers/pill/mentat,
 /obj/effect/mob_spawn/human/corpse/raider,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "uKR" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "uLj" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -22099,7 +21995,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "uMi" = (
 /obj/structure/fence{
 	dir = 4
@@ -22109,7 +22005,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "uMV" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 10
@@ -22121,7 +22017,7 @@
 "uNh" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "uNq" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/vault,
@@ -22137,7 +22033,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "uNJ" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 4;
@@ -22165,7 +22061,7 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "uPd" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
@@ -22180,7 +22076,7 @@
 /area/f13/ncr)
 "uPk" = (
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "uPI" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -22193,7 +22089,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "uQk" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -22211,7 +22107,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "uRa" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/graveldirt{
@@ -22230,13 +22126,13 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "uRK" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
 	},
 /turf/closed/wall/r_wall/rust,
-/area/f13/city)
+/area/f13/building)
 "uRZ" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -22257,7 +22153,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "uTV" = (
 /obj/structure/toilet,
 /obj/item/clothing/under/pants/f13/ghoul,
@@ -22268,28 +22164,28 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "uUd" = (
 /obj/structure/junk/machinery,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "uUe" = (
 /turf/closed/wall/f13/ruins,
-/area/f13/city)
+/area/f13/building)
 "uUh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/f13/cram_large,
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "uUt" = (
 /obj/structure/closet,
 /obj/item/storage/belt/military,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "uUy" = (
 /obj/machinery/light{
 	dir = 8
@@ -22304,7 +22200,7 @@
 "uVr" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "uVI" = (
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/ncr)
@@ -22313,7 +22209,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "uWf" = (
 /obj/structure/chair/stool,
 /obj/machinery/light/broken{
@@ -22322,7 +22218,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "uXj" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -22332,7 +22228,7 @@
 "uXU" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "uYf" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -22344,7 +22240,7 @@
 "uYo" = (
 /obj/item/chair/wood/modern,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "uYM" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22364,7 +22260,7 @@
 	pixel_x = 12
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "uZK" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -22396,7 +22292,7 @@
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "vak" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -22415,12 +22311,12 @@
 "vaG" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/store,
-/area/f13/city)
+/area/f13/building)
 "vaJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "vaY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -22433,7 +22329,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vbo" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
@@ -22445,7 +22341,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/f13/city)
+/area/f13/building)
 "vbY" = (
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/water,
@@ -22453,22 +22349,22 @@
 "vcj" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "vco" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vcp" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "vcC" = (
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "vcT" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -22504,7 +22400,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vfp" = (
 /obj/structure/sign/departments/chemistry{
 	pixel_y = -32
@@ -22543,7 +22439,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "vgR" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/glass,
@@ -22569,7 +22465,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "vhR" = (
 /obj/machinery/light{
 	dir = 1
@@ -22581,11 +22477,11 @@
 "vhU" = (
 /obj/structure/chair/office,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vim" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vit" = (
 /obj/structure/barricade/tentclothcorner{
 	pixel_y = 3
@@ -22593,19 +22489,19 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "vix" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "viz" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vjr" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meat/steak/plain/human,
@@ -22616,7 +22512,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vjD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -22627,7 +22523,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vjY" = (
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland/ncr)
@@ -22636,13 +22532,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vkE" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "vlm" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22683,14 +22579,14 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "vnn" = (
 /obj/structure/table,
 /obj/item/stack/f13Cash/random/ncr/med,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vnC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -22703,7 +22599,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vnJ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-24"
@@ -22722,7 +22618,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vol" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland/warren)
@@ -22732,7 +22628,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "voO" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -22749,7 +22645,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vpS" = (
 /obj/structure/chair/stool/f13stool{
 	icon_state = "bench_center";
@@ -22785,7 +22681,7 @@
 	light_color = "#d8b1b1"
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "vro" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 1;
@@ -22831,7 +22727,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/area/f13/city)
+/area/f13/building)
 "vsp" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/ncrcf{
@@ -22862,7 +22758,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
-/area/f13/city)
+/area/f13/building)
 "vsO" = (
 /obj/structure/sign/poster/prewar/poster73,
 /turf/closed/wall/r_wall/rust,
@@ -22874,7 +22770,7 @@
 	termtag = "Business"
 	},
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "vsX" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -22888,7 +22784,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright3"
 	},
-/area/f13/city)
+/area/f13/building)
 "vtc" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/dark,
@@ -22898,7 +22794,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vtl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/weldingtool/largetank,
@@ -22906,16 +22802,16 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "vuC" = (
 /obj/structure/window/fulltile/ruins,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "vuD" = (
 /turf/closed/wall/mineral/brick,
-/area/f13/city)
+/area/f13/building)
 "vuN" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -22946,7 +22842,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "vvP" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13/wood,
@@ -22996,7 +22892,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "vxx" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -23010,7 +22906,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vyB" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "ncrarmorygarage";
@@ -23025,7 +22921,7 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/city)
+/area/f13/building)
 "vzf" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -23050,7 +22946,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vAN" = (
 /obj/structure/junk/small/bed2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23062,13 +22958,13 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "vCp" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vCF" = (
 /obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23115,7 +23011,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vDb" = (
 /obj/structure/filingcabinet{
 	pixel_x = -10
@@ -23127,19 +23023,19 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vDi" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vDk" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "vDp" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -23166,7 +23062,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vDD" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
@@ -23182,7 +23078,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "vDU" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -23225,7 +23121,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vFB" = (
 /obj/structure/fence,
 /obj/structure/fence/corner,
@@ -23241,12 +23137,12 @@
 /obj/structure/table/wood,
 /obj/item/newspaper,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vGp" = (
 /obj/structure/closet/crate/large,
 /obj/item/shovel/trench,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "vGS" = (
 /obj/structure/toilet{
 	dir = 4
@@ -23254,13 +23150,13 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "vHi" = (
 /obj/structure/decoration/rag{
 	pixel_x = -14
 	},
 /turf/closed/wall/mineral/brick,
-/area/f13/city)
+/area/f13/building)
 "vHx" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -23270,7 +23166,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vHN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -23278,7 +23174,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "vIr" = (
 /obj/structure/toilet{
 	dir = 8
@@ -23286,7 +23182,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vIt" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old{
@@ -23306,7 +23202,7 @@
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "vIN" = (
 /obj/structure/junk/small/bed2,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -23342,7 +23238,7 @@
 "vMd" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "vMJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -23363,7 +23259,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vNc" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -23396,7 +23292,7 @@
 	dir = 9;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "vOG" = (
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -23406,16 +23302,16 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vOI" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/city)
+/area/f13/building)
 "vOU" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "vPk" = (
 /obj/structure/cargocrate,
 /obj/structure/cargocrate{
@@ -23430,14 +23326,14 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "vRd" = (
 /obj/structure/spirit_board{
 	anchored = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "vRk" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -23477,7 +23373,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "vSw" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -23487,7 +23383,7 @@
 "vTp" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vTB" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23505,14 +23401,14 @@
 	pixel_x = 6
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vTR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/purple{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "vUG" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -23551,7 +23447,7 @@
 	pixel_y = 2
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/city)
+/area/f13/building)
 "vVX" = (
 /turf/closed/wall/rust,
 /area/f13/raiders)
@@ -23561,16 +23457,16 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "vXo" = (
 /obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "vXJ" = (
 /turf/closed/wall/f13/wood/interior,
-/area/f13/city)
+/area/f13/building)
 "vYU" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -23655,16 +23551,16 @@
 	pixel_x = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "waH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/darkbrown,
-/area/f13/city)
+/area/f13/building)
 "wba" = (
 /obj/structure/table/wood/bar,
 /obj/item/paper/crumpled,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wcy" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -23672,7 +23568,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "wcG" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -23681,7 +23577,7 @@
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "wdj" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 1
@@ -23689,13 +23585,13 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "wdu" = (
 /obj/structure/obstacle/jammed_door,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "wep" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -23703,7 +23599,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "weA" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23716,7 +23612,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wfp" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	icon_state = "bloodpaw1"
@@ -23726,7 +23622,7 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "wfq" = (
 /obj/machinery/door/poddoor/gate/preopen{
 	id = "ncrgate";
@@ -23745,13 +23641,13 @@
 	icon_state = "skin"
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/area/f13/building)
 "wgq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "wgD" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -23770,7 +23666,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "wgN" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -23789,7 +23685,7 @@
 "whB" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "whQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertopleft"
@@ -23799,7 +23695,7 @@
 /obj/structure/table/wood/bar,
 /obj/item/pen,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wiB" = (
 /obj/item/flag/ncr,
 /turf/open/floor/plasteel/vault,
@@ -23814,7 +23710,7 @@
 	dir = 1;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "wiU" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -23823,19 +23719,19 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "wiX" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 13;
 	pixel_y = 11
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "wjZ" = (
 /obj/structure/table,
 /obj/item/weldingtool/mini,
 /turf/open/floor/plasteel/neutral,
-/area/f13/city)
+/area/f13/building)
 "wke" = (
 /obj/structure/sink{
 	dir = 4;
@@ -23847,13 +23743,13 @@
 /turf/open/floor/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "wkl" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "wkt" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/savannah/topright,
@@ -23875,13 +23771,13 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "wlz" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "wmr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13foldupchair{
@@ -23903,7 +23799,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/city)
+/area/f13/building)
 "wmW" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -23916,7 +23812,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
+/area/f13/wasteland/warren)
 "wnq" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -23932,12 +23828,12 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "woc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "wod" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23977,7 +23873,7 @@
 /obj/item/clothing/shoes/sneakers/white,
 /obj/item/reagent_containers/food/snacks/chocolatebar,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wpq" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23989,7 +23885,7 @@
 /obj/item/newspaper,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wpB" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -24014,7 +23910,7 @@
 	},
 /obj/effect/spawner/lootdrop/armylootbasic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "wqj" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/ruins,
@@ -24027,7 +23923,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "wrZ" = (
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
@@ -24060,7 +23956,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "wua" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -24081,13 +23977,13 @@
 "wvf" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/city)
+/area/f13/building)
 "wvA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "wvE" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -24103,7 +23999,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "wwI" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/small{
@@ -24148,7 +24044,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "wzx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -24159,14 +24055,14 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/city)
+/area/f13/building)
 "wzD" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "wzQ" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -24199,7 +24095,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "wAF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertopright"
@@ -24221,7 +24117,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "wBR" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/outside/savannah,
@@ -24255,14 +24151,14 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "wDa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "wDl" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -24279,27 +24175,27 @@
 	pixel_x = -4
 	},
 /turf/open/floor/carpet,
-/area/f13/city)
+/area/f13/building)
 "wEm" = (
 /obj/structure/closet/fridge,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wEL" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "wEZ" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "wFa" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wFo" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/light/small{
@@ -24314,12 +24210,12 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "wFI" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "wFO" = (
 /obj/structure/closet/crate{
 	anchored = 1;
@@ -24331,7 +24227,7 @@
 "wGb" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/area/f13/building)
 "wHY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -24344,7 +24240,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "wIM" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
@@ -24363,15 +24259,15 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "wJt" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "wJJ" = (
 /obj/item/stack/cable_coil/random,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "wKv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_5";
@@ -24414,7 +24310,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "wLp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -24433,7 +24329,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "wMf" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -24462,7 +24358,7 @@
 	icon_state = "ruinswindowbroken"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "wMt" = (
 /obj/structure/campfire/barrel,
 /obj/item/stack/sheet/mineral/wood,
@@ -24475,7 +24371,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "wMN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -24483,25 +24379,25 @@
 	pixel_x = 6
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wMQ" = (
 /obj/structure/railing/wood,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/city)
+/area/f13/building)
 "wNh" = (
 /obj/structure/disposalpipe/broken{
 	dir = 4
 	},
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "wOb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "wOg" = (
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
@@ -24515,7 +24411,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "wPa" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -24526,7 +24422,7 @@
 "wPk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/ruins,
-/area/f13/city)
+/area/f13/building)
 "wPQ" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -24553,7 +24449,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wRP" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -24579,10 +24475,10 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "wSU" = (
 /turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/city)
+/area/f13/building)
 "wTJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
@@ -24605,7 +24501,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "wUd" = (
 /obj/structure/lamp_post{
 	dir = 1
@@ -24618,7 +24514,7 @@
 "wUw" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "wUz" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/clock/old,
@@ -24633,14 +24529,14 @@
 	max_mobs = 2
 	},
 /turf/open/floor/carpet/red,
-/area/f13/city)
+/area/f13/building)
 "wUT" = (
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "wVK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
-/area/f13/city)
+/area/f13/building)
 "wWL" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -24652,7 +24548,7 @@
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "wXB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -24677,7 +24573,7 @@
 	pixel_x = -14
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "wYM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair2{
@@ -24689,7 +24585,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "xax" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -24701,7 +24597,7 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "xaA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/armor/f13/ncrarmor/ncr_dressjack,
@@ -24727,7 +24623,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xbz" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -24743,13 +24639,7 @@
 /area/f13/raiders)
 "xbR" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/city)
-"xcy" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
-	},
-/turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/caves)
+/area/f13/building)
 "xcW" = (
 /obj/item/soap,
 /turf/open/floor/f13{
@@ -24777,17 +24667,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "xeH" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "xeI" = (
 /obj/structure/window/fulltile/ruins,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "xeQ" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -24801,7 +24691,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "xeU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -24812,14 +24702,14 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
 	},
-/area/f13/city)
+/area/f13/building)
 "xfP" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xfV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24827,7 +24717,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "xgf" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -24847,7 +24737,7 @@
 "xgv" = (
 /obj/structure/junk/drawer,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xgP" = (
 /obj/machinery/light/small,
 /obj/item/reagent_containers/pill/patch/bitterdrink{
@@ -24872,7 +24762,7 @@
 "xgT" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xhb" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small{
@@ -24890,7 +24780,7 @@
 "xhj" = (
 /obj/structure/sign/poster/official/safety_eye_protection,
 /turf/closed/wall/f13/store,
-/area/f13/city)
+/area/f13/building)
 "xhu" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -24898,14 +24788,14 @@
 "xhw" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xhS" = (
 /obj/structure/curtain{
 	color = "#845f58"
 	},
 /obj/structure/decoration/rag,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xiD" = (
 /obj/machinery/shower{
 	dir = 8
@@ -24926,12 +24816,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/mattress,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xjg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "xjp" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/f13{
@@ -24957,20 +24847,20 @@
 	pixel_y = 19
 	},
 /turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "xjK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/darkbrown/corner{
 	dir = 1
 	},
-/area/f13/city)
+/area/f13/building)
 "xku" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/terminal,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xkY" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -24980,7 +24870,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "xlt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright3"
@@ -25019,7 +24909,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xmq" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -25028,7 +24918,7 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "xnk" = (
 /obj/machinery/door/unpowered/celldoor/outlaw{
 	name = "barred door"
@@ -25040,7 +24930,7 @@
 "xnl" = (
 /obj/structure/chair/folding,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "xnR" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -25050,7 +24940,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland/warren)
+/area/f13/building)
 "xnT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/security/glass{
@@ -25085,7 +24975,7 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "xos" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -25101,7 +24991,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xpg" = (
 /obj/structure/lattice{
 	pixel_x = -19
@@ -25127,14 +25017,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
-/area/f13/city)
+/area/f13/building)
 "xpS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "xqa" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/raiders)
@@ -25147,7 +25037,7 @@
 "xqf" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "xqx" = (
 /obj/structure/stairs/west{
 	dir = 2
@@ -25159,11 +25049,11 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/city)
+/area/f13/building)
 "xrd" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/city)
+/area/f13/building)
 "xrt" = (
 /obj/structure/noticeboard{
 	pixel_x = 32
@@ -25186,7 +25076,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "xsP" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -25195,7 +25085,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/caves)
+/area/f13/wasteland/ncr)
 "xth" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermainbottom"
@@ -25209,7 +25099,7 @@
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/venus_human_trap,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "xuf" = (
 /obj/machinery/door/poddoor/gate{
 	id = "Workshop";
@@ -25218,7 +25108,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "xuh" = (
 /obj/machinery/light{
 	dir = 1;
@@ -25233,10 +25123,10 @@
 	},
 /area/f13/ncr)
 "xuq" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2right"
+/turf/open/indestructible/ground/outside/dirt/dark{
+	icon_state = "dirtfull_dark"
 	},
-/area/f13/city)
+/area/f13/wasteland/warren)
 "xuB" = (
 /obj/machinery/door/unpowered/securedoor/outlaw,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -25262,22 +25152,22 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xvB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/city)
+/area/f13/building)
 "xvH" = (
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "xwS" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xxi" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4;
@@ -25305,7 +25195,7 @@
 "xyc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "xyj" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
@@ -25319,7 +25209,7 @@
 	termtag = "Public"
 	},
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "xyU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -25328,7 +25218,7 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/city)
+/area/f13/building)
 "xyV" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /turf/open/floor/plating/rust,
@@ -25358,7 +25248,7 @@
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/machinery/iv_drip,
 /turf/open/floor/f13,
-/area/f13/city)
+/area/f13/building)
 "xzG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/atmospherics/pipe/simple,
@@ -25373,12 +25263,12 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "xzN" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "xzR" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -25422,20 +25312,20 @@
 /obj/structure/table/wood/bar,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xCX" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor1-old"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xDt" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain{
 	pixel_x = 5
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xEt" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/glass{
@@ -25444,7 +25334,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
-/area/f13/city)
+/area/f13/building)
 "xEN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrightbottom"
@@ -25465,7 +25355,7 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "xFh" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -25473,7 +25363,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/city)
+/area/f13/building)
 "xFY" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 4;
@@ -25484,7 +25374,7 @@
 "xGJ" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city)
+/area/f13/building)
 "xGT" = (
 /obj/structure/fence/end/wooden{
 	dir = 4
@@ -25508,7 +25398,7 @@
 /turf/open/floor/f13{
 	icon_state = "redchess"
 	},
-/area/f13/city)
+/area/f13/building)
 "xHj" = (
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
@@ -25525,12 +25415,12 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xIn" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
 	},
-/area/f13/city)
+/area/f13/building)
 "xIr" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
@@ -25541,7 +25431,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xJk" = (
 /obj/structure/decoration/hatch,
 /turf/open/indestructible/ground/outside/road{
@@ -25561,12 +25451,12 @@
 /turf/open/floor/plasteel{
 	icon_state = "asteroidfloor"
 	},
-/area/f13/city)
+/area/f13/building)
 "xJH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xKx" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -25610,7 +25500,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xNG" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal";
@@ -25628,7 +25518,7 @@
 /area/f13/raiders)
 "xOe" = (
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/city)
+/area/f13/building)
 "xOq" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
@@ -25642,7 +25532,7 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "catwalk"
 	},
-/area/f13/city)
+/area/f13/building)
 "xOs" = (
 /obj/structure/junk/small,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -25669,7 +25559,7 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
+/area/f13/building)
 "xQr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25686,7 +25576,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/city)
+/area/f13/building)
 "xQS" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -25699,13 +25589,13 @@
 	icon_state = "housewindowvertical"
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xRX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/city)
+/area/f13/building)
 "xSc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/retro/black,
@@ -25716,7 +25606,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xSI" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/oil,
@@ -25732,11 +25622,11 @@
 	pixel_x = -4
 	},
 /turf/open/floor/carpet/black,
-/area/f13/city)
+/area/f13/building)
 "xTc" = (
 /obj/machinery/door/poddoor/shutters/preopen,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/city)
+/area/f13/building)
 "xTm" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 4
@@ -25748,7 +25638,7 @@
 "xTB" = (
 /obj/structure/junk/jukebox,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xTH" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -25765,7 +25655,7 @@
 "xUJ" = (
 /obj/machinery/mineral/wasteland_vendor/clothing,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/area/f13/building)
 "xUR" = (
 /obj/structure/fence{
 	dir = 4
@@ -25795,7 +25685,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "xWR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25803,7 +25693,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/city)
+/area/f13/building)
 "xXu" = (
 /obj/structure/fence,
 /obj/structure/barricade/wooden,
@@ -25847,7 +25737,7 @@
 "xYA" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xYF" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25857,12 +25747,12 @@
 "xYL" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/dark,
-/area/f13/city)
+/area/f13/building)
 "xYZ" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "xZc" = (
 /obj/structure/wreck/trash/one_tire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25882,14 +25772,11 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
 	},
-/area/f13/raiders)
-"xZk" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/city)
+/area/f13/wasteland/warren)
 "xZE" = (
 /obj/structure/chair/sofa,
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "yah" = (
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
@@ -25900,7 +25787,7 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/rd,
 /turf/open/floor/carpet/purple,
-/area/f13/city)
+/area/f13/building)
 "ybe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -25919,7 +25806,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ybT" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/indestructible/ground/outside/savannah,
@@ -25929,7 +25816,7 @@
 /obj/item/paper/crumpled,
 /obj/item/pen,
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "ycy" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/dark,
@@ -25943,7 +25830,7 @@
 	pixel_x = 12
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/area/f13/building)
 "ydv" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/chem_tin/waterpuretablet,
@@ -25966,13 +25853,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/city)
+/area/f13/building)
 "yeF" = (
 /obj/structure/bed/mattress{
 	pixel_y = 5
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "yeV" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
@@ -25983,7 +25870,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 "yff" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -26019,7 +25906,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ygL" = (
 /obj/item/reagent_containers/glass/bucket/plastic{
 	pixel_x = 5;
@@ -26028,7 +25915,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "ygX" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -16
@@ -26038,7 +25925,7 @@
 	pixel_y = -28
 	},
 /turf/closed/wall/r_wall/rust,
-/area/f13/city)
+/area/f13/building)
 "ygY" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2bottom"
@@ -26053,7 +25940,7 @@
 /turf/open/floor/plasteel/freezer{
 	name = "bathroom tiles"
 	},
-/area/f13/city)
+/area/f13/building)
 "yhK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -26062,7 +25949,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/city)
+/area/f13/building)
 "yiF" = (
 /obj/structure/railing{
 	dir = 4
@@ -26071,14 +25958,14 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/city)
+/area/f13/building)
 "yiH" = (
 /mob/living/simple_animal/chicken{
 	faction = list("raider");
 	name = "Estebans chicken"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/city)
+/area/f13/building)
 "yiM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool{
@@ -26088,13 +25975,13 @@
 /turf/open/floor/f13{
 	icon_state = "cafeteria"
 	},
-/area/f13/city)
+/area/f13/building)
 "yjs" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland/warren)
+/area/f13/building)
 "yjH" = (
 /obj/structure/window/spawner/north,
 /obj/structure/chair/office/light{
@@ -26109,7 +25996,7 @@
 /turf/open/floor/f13{
 	icon_state = "damaged2"
 	},
-/area/f13/city)
+/area/f13/building)
 "ykB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -26123,7 +26010,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/city)
+/area/f13/building)
 "ykS" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -26138,7 +26025,7 @@
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/city)
+/area/f13/building)
 
 (1,1,1) = {"
 jLg
@@ -26858,12 +26745,12 @@ pLS
 xbR
 rtJ
 rtJ
-cBd
+nux
 dYJ
 wEm
 vXJ
 koX
-cBd
+nux
 wQX
 iql
 vIt
@@ -27103,12 +26990,12 @@ uos
 oHU
 oHU
 qAm
-cBd
+nux
 qQy
 xbR
 vhU
 dbu
-cBd
+nux
 cBi
 pLS
 pLS
@@ -27116,7 +27003,7 @@ xbR
 vjr
 feW
 cpT
-cBd
+nux
 gOS
 vXJ
 ayw
@@ -27360,12 +27247,12 @@ oHU
 pVF
 oHU
 xbR
-cBd
+nux
 sdG
 xbR
 qzE
-cBd
-cBd
+nux
+nux
 nFt
 pLS
 pLS
@@ -27617,10 +27504,10 @@ xbR
 xbR
 xbR
 xbR
-cBd
-cBd
+nux
+nux
 jWa
-cBd
+nux
 dbu
 dbu
 cBi
@@ -27628,13 +27515,13 @@ dgH
 jsX
 xbR
 pbY
-cBd
-cBd
-cBd
+nux
+nux
+nux
 xCX
 xhw
-cBd
-cBd
+nux
+nux
 xgv
 xbR
 pLS
@@ -27869,15 +27756,15 @@ hLa
 hLa
 xbR
 mvj
-cBd
+nux
 xNF
-cBd
+nux
 ocM
 xbR
 aEg
 qud
 rAX
-cBd
+nux
 cpT
 dbu
 cBi
@@ -28126,17 +28013,17 @@ hLa
 hLa
 xbR
 uos
-cBd
+nux
 kBK
 kiS
-cBd
+nux
 xbR
-cBd
+nux
 dbu
 jWa
-cBd
-cBd
-cBd
+nux
+nux
+nux
 xbR
 dgH
 lsq
@@ -28384,16 +28271,16 @@ hLa
 xbR
 oOM
 uos
-cBd
+nux
 dbu
-cBd
-cBd
-cBd
+nux
+nux
+nux
 dbu
 mvj
 yiF
 bIC
-cBd
+nux
 jJN
 lsq
 wvb
@@ -28642,15 +28529,15 @@ xbR
 mvj
 aEg
 bmj
-cBd
+nux
 uos
 vFP
-cBd
-cBd
+nux
+nux
 xhw
-cBd
-cBd
-cBd
+nux
+nux
+nux
 xbR
 lsq
 xbR
@@ -28899,11 +28786,11 @@ xbR
 xbR
 kAI
 aVg
-cBd
-cBd
+nux
+nux
 lAl
-cBd
-cBd
+nux
+nux
 xbR
 xbR
 xbR
@@ -28915,15 +28802,15 @@ dVO
 rcM
 dVO
 frw
-cBd
+nux
 eWo
 xbR
 vgk
 xbR
-cBd
-cBd
-cBd
-cBd
+nux
+nux
+nux
+nux
 rHL
 xbR
 uch
@@ -29179,8 +29066,8 @@ lsq
 xbR
 fUV
 iBM
-cBd
-cBd
+nux
+nux
 tMY
 xbR
 uch
@@ -29428,7 +29315,7 @@ dpj
 dVO
 ehw
 dVO
-cBd
+nux
 dbu
 kPL
 xbR
@@ -29682,19 +29569,19 @@ lMO
 vMJ
 wXB
 vTp
-cBd
-cBd
+nux
+nux
 dbu
 xIz
-cBd
+nux
 oXF
 dnk
 lsq
 xbR
 miR
 dbu
-cBd
-cBd
+nux
+nux
 sSH
 jTE
 uch
@@ -29940,10 +29827,10 @@ oGm
 wXB
 oaV
 fqJ
-cBd
+nux
 akI
 aWV
-cBd
+nux
 oXF
 xbR
 lsq
@@ -29952,7 +29839,7 @@ xbR
 dsH
 xbR
 dbu
-cBd
+nux
 mvj
 uch
 qhK
@@ -30209,7 +30096,7 @@ wcy
 rpP
 xbR
 idr
-cBd
+nux
 xbR
 ipp
 qhK
@@ -30969,7 +30856,7 @@ wXB
 wgn
 uIZ
 dbu
-cBd
+nux
 xbR
 sdj
 lNk
@@ -31226,7 +31113,7 @@ wXB
 xgT
 jcc
 dbu
-cBd
+nux
 xbR
 ioI
 pYE
@@ -31237,7 +31124,7 @@ wcy
 oMk
 xbR
 fds
-cBd
+nux
 mvj
 uch
 nFf
@@ -31738,7 +31625,7 @@ pbp
 jfK
 wXB
 vTp
-cBd
+nux
 dbu
 dbu
 xbR
@@ -31749,9 +31636,9 @@ lsq
 xbR
 miR
 dbu
-cBd
-cBd
-cBd
+nux
+nux
+nux
 cBi
 ipp
 qhK
@@ -31996,16 +31883,16 @@ jfK
 wXB
 eOz
 iRp
-cBd
-cBd
+nux
+nux
 xhw
-cBd
+nux
 reu
 xbR
 lsq
 mvj
-cBd
-cBd
+nux
+nux
 ixV
 dbu
 pbY
@@ -32244,7 +32131,7 @@ xbR
 xbR
 xbR
 xbR
-cBd
+nux
 xbR
 uch
 qhK
@@ -32263,9 +32150,9 @@ lsq
 xbR
 cgA
 sSH
-cBd
-cBd
-cBd
+nux
+nux
+nux
 mvj
 ddT
 qhK
@@ -32501,7 +32388,7 @@ cJg
 gkt
 rHo
 aXN
-cBd
+nux
 eOz
 uch
 kQH
@@ -33015,7 +32902,7 @@ eEJ
 atw
 eEJ
 wVK
-cBd
+nux
 cBi
 uch
 nFf
@@ -33272,7 +33159,7 @@ uyV
 gqb
 tXs
 lJZ
-cBd
+nux
 xbR
 uch
 qhK
@@ -33537,8 +33424,8 @@ lMO
 xJk
 wXB
 bKX
-cBd
-cBd
+nux
+nux
 dbu
 xbR
 rvz
@@ -33548,9 +33435,9 @@ bVD
 xgv
 xbR
 uus
-cBd
-cBd
-cBd
+nux
+nux
+nux
 xbR
 uch
 nFf
@@ -33781,11 +33668,11 @@ uPk
 dXb
 uPk
 wYC
-cBd
+nux
 dbu
 hwC
-cBd
-cBd
+nux
+nux
 sEh
 cBi
 uch
@@ -33804,7 +33691,7 @@ mvj
 qpk
 dbu
 xhw
-cBd
+nux
 dbu
 dbu
 leW
@@ -34238,7 +34125,7 @@ jfK
 wXB
 aTg
 lSm
-cBd
+nux
 lSm
 jRG
 eTy
@@ -34294,8 +34181,8 @@ uPk
 yiH
 uPk
 uPk
-cBd
-cBd
+nux
+nux
 rCU
 dVk
 sEh
@@ -34310,9 +34197,9 @@ wXB
 xgT
 miR
 dbu
-cBd
+nux
 xhw
-cBd
+nux
 eym
 xbR
 ceE
@@ -34555,7 +34442,7 @@ gic
 hAK
 qeh
 ldh
-cBd
+nux
 hAK
 qrv
 eOz
@@ -34567,7 +34454,7 @@ wXB
 xbR
 wEm
 rcR
-cBd
+nux
 egf
 okH
 bKp
@@ -34575,10 +34462,10 @@ xbR
 cmB
 wOj
 jpP
-cBd
-cBd
-cBd
-cBd
+nux
+nux
+nux
+nux
 xbR
 ddT
 qhK
@@ -34756,7 +34643,7 @@ dbu
 nhL
 dbu
 lfh
-cBd
+nux
 mEA
 uch
 lHY
@@ -34812,7 +34699,7 @@ cBi
 nWe
 ihz
 sEh
-cBd
+nux
 qtk
 aEC
 wgn
@@ -35009,7 +34896,7 @@ dwu
 wXB
 aTg
 hKR
-cBd
+nux
 ird
 cgz
 dbu
@@ -35068,7 +34955,7 @@ uPk
 bQe
 cVP
 kDb
-cBd
+nux
 sEh
 fhA
 nbM
@@ -35267,7 +35154,7 @@ wXB
 aTg
 tNn
 jaQ
-cBd
+nux
 mco
 eTy
 oNz
@@ -35325,7 +35212,7 @@ oPZ
 xbR
 xbR
 xbR
-cBd
+nux
 wgn
 xbR
 xbR
@@ -35522,10 +35409,10 @@ nFf
 vsD
 wXB
 aTg
-cBd
+nux
 xDt
-cBd
-cBd
+nux
+nux
 vXJ
 vXJ
 aTg
@@ -35781,10 +35668,10 @@ wXB
 aTg
 xYZ
 jMx
-cBd
-cBd
-cBd
-cBd
+nux
+nux
+nux
+nux
 tiA
 uch
 vfB
@@ -36038,7 +35925,7 @@ wXB
 aTg
 vTP
 uSU
-cBd
+nux
 dbu
 wMN
 kRx
@@ -36811,7 +36698,7 @@ igV
 aTg
 aTg
 mGc
-cBd
+nux
 inf
 aTg
 pxS
@@ -36870,7 +36757,7 @@ ceg
 xQS
 pbt
 vuD
-cBd
+nux
 umk
 izE
 kNj
@@ -37064,10 +36951,10 @@ nFf
 dwu
 wXB
 aTg
-cBd
+nux
 jaQ
 sEh
-cBd
+nux
 fnv
 inf
 aTg
@@ -37128,7 +37015,7 @@ ceg
 ujC
 fJP
 xjb
-cBd
+nux
 suv
 vXJ
 hbf
@@ -37324,7 +37211,7 @@ aTg
 xJH
 cQo
 obC
-cBd
+nux
 iuu
 sEh
 uDJ
@@ -37609,9 +37496,9 @@ twI
 gcd
 dgH
 uUe
-his
-his
-his
+qTh
+qTh
+qTh
 wiX
 uUe
 uch
@@ -37866,9 +37753,9 @@ fps
 gcd
 dgH
 uUe
-his
+qTh
 pyG
-his
+qTh
 haK
 gOZ
 uch
@@ -37900,19 +37787,19 @@ pbt
 vuD
 cJd
 rpf
-cBd
-cBd
-cBd
+nux
+nux
+nux
 pIh
-cBd
+nux
 nfY
 wpk
 hbK
 fSu
 mZF
-cBd
+nux
 eTh
-cBd
+nux
 dYJ
 qDO
 xfM
@@ -38081,7 +37968,7 @@ hZy
 pLS
 jOK
 eIc
-cBd
+nux
 tJF
 mGc
 nvS
@@ -38159,13 +38046,13 @@ vXJ
 vXJ
 vXJ
 vXJ
-cBd
+nux
 qbY
 dbu
-cBd
-cBd
-cBd
-cBd
+nux
+nux
+nux
+nux
 dbu
 dbu
 dbu
@@ -38339,7 +38226,7 @@ pLS
 jOK
 eJy
 ehj
-cBd
+nux
 dbu
 vpH
 jOK
@@ -38381,8 +38268,8 @@ gcd
 lsq
 uUe
 utQ
-his
-his
+qTh
+qTh
 vcj
 xeI
 uch
@@ -38412,21 +38299,21 @@ ceg
 ceg
 oec
 qDO
-cBd
+nux
 dYJ
-cBd
+nux
 dbu
-cBd
-cBd
-cBd
+nux
+nux
+nux
 dbu
 dbu
-cBd
+nux
 dbu
-cBd
-cBd
-cBd
-cBd
+nux
+nux
+nux
+nux
 dbu
 qDO
 xfM
@@ -38596,9 +38483,9 @@ hZy
 jOK
 hkH
 dbu
-cBd
+nux
 dbu
-cBd
+nux
 jOK
 sfe
 uch
@@ -38638,7 +38525,7 @@ dgH
 obo
 uUe
 qkS
-his
+qTh
 vcj
 hKu
 uUe
@@ -38851,11 +38738,11 @@ pcK
 pcK
 hZy
 jOK
-cBd
-cBd
-cBd
-cBd
-cBd
+nux
+nux
+nux
+nux
+nux
 mUw
 cjT
 uch
@@ -38939,9 +38826,9 @@ ehj
 nEZ
 ehj
 pIh
-cBd
+nux
 dbu
-cBd
+nux
 tIC
 vuD
 uch
@@ -39110,9 +38997,9 @@ hZy
 jOK
 orF
 dbu
-cBd
+nux
 eVr
-cBd
+nux
 dOV
 wha
 uch
@@ -39195,9 +39082,9 @@ fFq
 bRZ
 cEX
 ixN
-cBd
-cBd
-cBd
+nux
+nux
+nux
 dbu
 pIS
 vHi
@@ -39452,10 +39339,10 @@ fFq
 bRZ
 nor
 mIm
-cBd
+nux
 loR
 iYq
-cBd
+nux
 loR
 vuD
 aXE
@@ -39700,18 +39587,18 @@ vuD
 aSo
 dbu
 nFQ
-cBd
+nux
 dbu
 dbu
-cBd
-cBd
+nux
+nux
 dbu
-cBd
-cBd
+nux
+nux
 dbu
-cBd
-cBd
-cBd
+nux
+nux
+nux
 dbu
 cTu
 vuD
@@ -39957,7 +39844,7 @@ vuD
 dbu
 dbu
 dbu
-cBd
+nux
 fFq
 bRZ
 fFq
@@ -39966,7 +39853,7 @@ fFq
 bRZ
 xCQ
 ehj
-cBd
+nux
 bYP
 loR
 swR
@@ -43749,9 +43636,9 @@ kbz
 nqZ
 kbz
 nQR
-kwt
-kwt
-xZk
+lsq
+lsq
+vol
 vol
 uch
 nFf
@@ -44006,9 +43893,9 @@ iiF
 kbz
 xHh
 tws
-kwt
-kwt
-xZk
+lsq
+lsq
+vol
 vol
 uch
 nFf
@@ -44080,7 +43967,7 @@ xbR
 sNq
 xbR
 mkf
-cBd
+nux
 xYA
 xgT
 uch
@@ -44263,9 +44150,9 @@ qSE
 nqZ
 kbz
 tws
-kwt
-kwt
-xZk
+lsq
+lsq
+vol
 vol
 uch
 nFf
@@ -44520,9 +44407,9 @@ vXJ
 bZl
 vXJ
 tws
-kwt
-kwt
-xZk
+lsq
+lsq
+vol
 vol
 kDZ
 nFf
@@ -44593,8 +44480,8 @@ xbR
 cGE
 eFL
 aET
-cBd
-cBd
+nux
+nux
 iEf
 xbR
 uch
@@ -44777,9 +44664,9 @@ kbq
 hjf
 wUw
 tws
-kwt
-kwt
-xZk
+lsq
+lsq
+vol
 vol
 gRk
 nFf
@@ -44851,7 +44738,7 @@ xbR
 xbR
 xbR
 xbR
-cBd
+nux
 dpt
 xgT
 uch
@@ -45034,9 +44921,9 @@ tEK
 jgA
 tEK
 ubq
-kwt
-kwt
-xZk
+lsq
+lsq
+vol
 vol
 uch
 vVp
@@ -45108,7 +44995,7 @@ wLH
 oHU
 oHU
 vkm
-cBd
+nux
 dwr
 xgT
 uch
@@ -45291,9 +45178,9 @@ vXJ
 vXJ
 lqV
 tws
-xZk
-xZk
-xZk
+vol
+vol
+vol
 vol
 uch
 ily
@@ -45622,8 +45509,8 @@ bZj
 oHU
 uCG
 eMY
-cBd
-cBd
+nux
+nux
 xbR
 uch
 gnT
@@ -45879,7 +45766,7 @@ gVI
 oHU
 oHU
 uJh
-cBd
+nux
 eoB
 oQK
 uch
@@ -46136,8 +46023,8 @@ vnn
 oHU
 oHU
 mDQ
-cBd
-cBd
+nux
+nux
 dOV
 sgI
 qhK
@@ -50200,10 +50087,10 @@ wXB
 aXE
 jWt
 vTp
-cBd
-cBd
-cBd
-cBd
+nux
+nux
+nux
+nux
 dbu
 foo
 gUQ
@@ -50457,11 +50344,11 @@ wXB
 boQ
 boQ
 vTp
-cBd
-cBd
+nux
+nux
 dbu
-cBd
-cBd
+nux
+nux
 foo
 gUQ
 fKY
@@ -50971,10 +50858,10 @@ wXB
 ceg
 dxk
 fGR
-cBd
-cBd
-cBd
-cBd
+nux
+nux
+nux
+nux
 dbu
 fGR
 rAj
@@ -51230,7 +51117,7 @@ xHj
 foo
 gIx
 oHQ
-cBd
+nux
 gIx
 uxQ
 foo
@@ -51460,7 +51347,7 @@ sAO
 fIv
 nqM
 uOP
-cBd
+nux
 mku
 cRn
 cRn
@@ -51485,11 +51372,11 @@ wXB
 lVT
 gUQ
 foo
-cBd
+nux
 dbu
 dbu
-cBd
-cBd
+nux
+nux
 foo
 ubK
 hLa
@@ -51717,7 +51604,7 @@ sfe
 sfe
 nqM
 uOP
-cBd
+nux
 mku
 cRn
 mSp
@@ -51974,7 +51861,7 @@ sfe
 sfe
 nqM
 uOP
-cBd
+nux
 mku
 cRn
 cRn
@@ -54288,8 +54175,8 @@ qZx
 qZx
 pLS
 lRg
-cBd
-cBd
+nux
+nux
 kkF
 kvR
 kvR
@@ -55554,10 +55441,10 @@ wkO
 qox
 nOz
 dkL
-nxO
-swo
+nHQ
+kvR
 fRH
-jdx
+xuq
 vVX
 wOg
 wOg
@@ -55811,8 +55698,8 @@ nxO
 mfU
 mfU
 lkP
-nxO
-swo
+nHQ
+kvR
 ajd
 pdT
 xNK
@@ -56070,8 +55957,8 @@ luW
 hZx
 snh
 snh
-swo
-nxO
+kvR
+nHQ
 vVX
 vVX
 vVX
@@ -56317,16 +56204,16 @@ jLg
 jLg
 aAj
 rQf
-mfU
+yfO
 pdT
 snh
 snh
 snh
 snh
-swo
+kvR
 snh
 snh
-nxO
+nHQ
 snh
 lRa
 vsO
@@ -56574,13 +56461,13 @@ jLg
 jLg
 aAj
 ltC
-lkP
-swo
-swo
-nxO
-nxO
+fNh
+kvR
+kvR
+nHQ
+nHQ
 tyI
-nxO
+nHQ
 snh
 snh
 snh
@@ -56831,8 +56718,8 @@ jLg
 jLg
 qZx
 ltC
-lkP
-nxO
+fNh
+nHQ
 vOq
 sUD
 sUD
@@ -56841,7 +56728,7 @@ sUD
 sUD
 kyn
 snh
-swo
+kvR
 ajd
 vVX
 wOg
@@ -57088,14 +56975,14 @@ jLg
 jLg
 qZx
 ltC
-lkP
+fNh
 snh
 uFH
-jdx
-jdx
+xuq
+xuq
 lOk
-jdx
-jdx
+xuq
+xuq
 blF
 snh
 snh
@@ -57345,17 +57232,17 @@ jLg
 jLg
 aAj
 ltC
-lkP
-swo
+fNh
+kvR
 dAn
-jdx
+xuq
 vkE
-jdx
-jdx
-jdx
+xuq
+xuq
+xuq
 uMi
 snh
-nxO
+nHQ
 lRa
 vVX
 gHK
@@ -57375,7 +57262,7 @@ qZx
 qZx
 qZx
 qZx
-anJ
+iDm
 rlG
 rlG
 rlG
@@ -57602,16 +57489,16 @@ jLg
 jLg
 aAj
 peu
-lkP
-nxO
+fNh
+nHQ
 kSG
-jdx
-jdx
-jdx
-jdx
-jdx
+xuq
+xuq
+xuq
+xuq
+xuq
 nVj
-swo
+kvR
 snh
 fRH
 vVX
@@ -57633,12 +57520,12 @@ anJ
 anJ
 anJ
 anJ
-cze
-nux
+yeV
+boQ
 bDA
-nux
-nux
-kpo
+boQ
+boQ
+pHs
 wdu
 qrT
 aQG
@@ -57859,17 +57746,17 @@ jLg
 jLg
 aAj
 ltC
-lkP
+fNh
 snh
 cUs
-jdx
-jdx
-jdx
+xuq
+xuq
+xuq
 vkE
-jdx
+xuq
 lgQ
-swo
-nxO
+kvR
+nHQ
 fRH
 vVX
 muq
@@ -57890,12 +57777,12 @@ lGF
 uhu
 uhu
 caQ
-iDm
-pxl
+uch
+nFf
 his
-tbu
-tbu
-qTh
+pDT
+pDT
+wXB
 anJ
 dmf
 akK
@@ -58116,16 +58003,16 @@ jLg
 jLg
 qZx
 ltC
-lkP
-swo
+fNh
+kvR
 wiE
-jdx
-jdx
-jdx
+xuq
+xuq
+xuq
 lOk
-jdx
+xuq
 xZi
-swo
+kvR
 snh
 fRH
 vVX
@@ -58147,12 +58034,12 @@ vsP
 kVN
 uhu
 bPp
-iDm
-pxl
+uch
+nFf
 his
 his
-lDG
-czO
+jfK
+dKP
 anJ
 fsv
 fsv
@@ -58373,8 +58260,8 @@ jLg
 jLg
 qZx
 pWT
-lkP
-swo
+fNh
+kvR
 iOd
 oWn
 fKB
@@ -58382,8 +58269,8 @@ fKB
 fKB
 fKB
 gZT
-swo
-nxO
+kvR
+nHQ
 fRH
 hbd
 wOg
@@ -58404,8 +58291,8 @@ izd
 uhu
 uhu
 anJ
-iDm
-pxl
+uch
+nFf
 his
 his
 his
@@ -58631,16 +58518,16 @@ jLg
 aAj
 grE
 pdT
-swo
-nxO
-nxO
-swo
-swo
-nxO
-swo
-nxO
-swo
-nxO
+kvR
+nHQ
+nHQ
+kvR
+kvR
+nHQ
+kvR
+nHQ
+kvR
+nHQ
 fRH
 vVX
 hdQ
@@ -58661,17 +58548,17 @@ eFB
 uhu
 uhu
 mys
-iDm
-pxl
+uch
+nFf
 mKO
 his
 his
 his
-his
+qTh
 alW
 alW
 vaJ
-his
+qTh
 lMO
 tHr
 pbp
@@ -58888,16 +58775,16 @@ jLg
 fpe
 isU
 snh
-swo
-nxO
-nxO
-swo
-nxO
-swo
+kvR
+nHQ
+nHQ
+kvR
+nHQ
+kvR
 snh
-nxO
+nHQ
 snh
-swo
+kvR
 fRH
 vVX
 xOC
@@ -58918,17 +58805,17 @@ uhu
 uhu
 kVN
 anJ
-iDm
-pxl
+uch
+nFf
 eKj
 eKj
 his
 his
-his
+qTh
 kWF
 kWF
 kWF
-his
+qTh
 lMO
 pbp
 pbp
@@ -59144,17 +59031,17 @@ jLg
 jLg
 fpe
 isU
-swo
+kvR
 kEw
 xbI
 juH
 hYD
 pKl
 cNe
-nxO
+nHQ
 snh
-nxO
-swo
+nHQ
+kvR
 fRH
 vVX
 ixi
@@ -59175,12 +59062,12 @@ uhu
 kVN
 sSL
 caQ
-iDm
-pxl
+uch
+nFf
 his
 eKj
 his
-jDH
+oKA
 anJ
 wmP
 oBv
@@ -59401,7 +59288,7 @@ jLg
 jLg
 gzt
 mFn
-swo
+kvR
 ijy
 iTK
 jdx
@@ -59409,9 +59296,9 @@ jdx
 iCp
 rcO
 snh
-nxO
+nHQ
 snh
-nxO
+nHQ
 ajd
 vVX
 vVX
@@ -59432,12 +59319,12 @@ uhu
 kVN
 kVN
 bPp
-iDm
-fsH
+uch
+pkQ
 his
 eKj
 his
-qTh
+wXB
 iRE
 lqi
 lqi
@@ -59658,17 +59545,17 @@ jLg
 jLg
 aAj
 wng
-swo
+kvR
 drK
 aiJ
 jdx
 jdx
 jdx
 dvD
-nxO
+nHQ
 snh
-nxO
-nxO
+nHQ
+nHQ
 tNh
 wCg
 oOo
@@ -59689,12 +59576,12 @@ oBs
 uhu
 uhu
 anJ
-iDm
-ddv
-fNh
-xvB
+uch
+vfB
+mRP
+pbp
 his
-qTh
+wXB
 anJ
 fsv
 fsv
@@ -59915,7 +59802,7 @@ jLg
 jLg
 qZx
 dKp
-swo
+kvR
 raa
 tjc
 jHk
@@ -59946,12 +59833,12 @@ anJ
 anJ
 cdm
 anJ
-iDm
-ddv
-vaJ
-xvB
+uch
+vfB
+uHQ
+pbp
 his
-qTh
+wXB
 anJ
 vSu
 hle
@@ -59965,9 +59852,9 @@ pbp
 wXB
 fGR
 rtJ
-cBd
-cBd
-cBd
+nux
+nux
+nux
 fGR
 woQ
 oIa
@@ -60203,12 +60090,12 @@ anJ
 iEa
 uhu
 anJ
-iDm
-ddv
-alW
-alW
+uch
+vfB
+lMO
+lMO
 his
-qTh
+wXB
 aae
 ehT
 slO
@@ -60222,9 +60109,9 @@ pbp
 wXB
 foo
 hDG
-cBd
-cBd
-cBd
+nux
+nux
+nux
 vTp
 kmn
 kmn
@@ -60460,12 +60347,12 @@ mys
 kYD
 uhu
 anJ
-iDm
-ddv
-alW
+uch
+vfB
+lMO
 oWg
 his
-qTh
+wXB
 anJ
 rlT
 acj
@@ -60479,8 +60366,8 @@ pbp
 wXB
 fGR
 bLk
-cBd
-cBd
+nux
+nux
 ulu
 fGR
 kmn
@@ -60717,12 +60604,12 @@ anJ
 wEZ
 kVN
 anJ
-iDm
-xuq
+uch
+lHY
 oWg
-alW
+lMO
 his
-qTh
+wXB
 anJ
 acj
 acj
@@ -60736,7 +60623,7 @@ pbp
 wXB
 foo
 pGk
-cBd
+nux
 pxo
 cFc
 foo
@@ -60974,12 +60861,12 @@ anJ
 anJ
 cdm
 anJ
-iDm
-pxl
-xvB
-hZD
+uch
+nFf
+pbp
+tHr
 his
-qTh
+wXB
 anJ
 ojh
 acj
@@ -61231,12 +61118,12 @@ dUo
 bjp
 qrT
 anJ
-iDm
-pxl
-xvB
-xvB
+uch
+nFf
+pbp
+pbp
 his
-qTh
+wXB
 anJ
 ehT
 ehT
@@ -61488,12 +61375,12 @@ qrT
 qrT
 laj
 anJ
-iDm
-pxl
+uch
+nFf
 his
 his
 his
-qTh
+wXB
 anJ
 clq
 ehT
@@ -61745,12 +61632,12 @@ jAx
 qrT
 tXy
 anJ
-nHQ
-pxl
-xvB
-xvB
+vDD
+nFf
+pbp
+pbp
 his
-qTh
+wXB
 anJ
 acj
 ava
@@ -62002,12 +61889,12 @@ slt
 vHN
 qrT
 xuf
-tbu
-xvB
+pDT
+pbp
 his
 his
 his
-qTh
+wXB
 anJ
 aiD
 eQe
@@ -62260,11 +62147,11 @@ vHN
 ehT
 ehT
 his
-xvB
+pbp
 his
 his
 his
-qTh
+wXB
 anJ
 anJ
 anJ
@@ -62318,10 +62205,10 @@ eWC
 osv
 aQW
 fiK
-dMc
+wBg
 qiG
 txq
-gTa
+cLw
 usF
 cLw
 cEK
@@ -62518,15 +62405,15 @@ qrT
 ehT
 his
 nPB
-bIN
-bIN
-bIN
-qTh
-kwt
-kwt
-kwt
-gem
-fhf
+snq
+snq
+snq
+wXB
+lsq
+lsq
+lsq
+gQo
+nvY
 kZw
 uHQ
 lMO
@@ -62574,11 +62461,11 @@ hLa
 eWC
 osv
 msi
-xcy
-gTa
-gTa
-gTa
-gTa
+suF
+cLw
+cLw
+cLw
+cLw
 nNB
 cLw
 cEK
@@ -62773,17 +62660,17 @@ mZS
 qrT
 qrT
 anJ
-wmP
-wmP
-wmP
-wmP
-wmP
+jWt
+jWt
+jWt
+jWt
+jWt
 dhl
-kwt
-kwt
-kwt
-kwt
-fhf
+lsq
+lsq
+lsq
+lsq
+nvY
 hsZ
 uHQ
 naZ
@@ -62831,11 +62718,11 @@ hLa
 eWC
 osv
 tJc
-umj
+eRl
 qiG
-gTa
+cLw
 rZs
-gTa
+cLw
 usF
 cLw
 vmf
@@ -63088,10 +62975,10 @@ hLa
 eWC
 osv
 aQW
-umj
-gTa
-dMc
-gTa
+eRl
+cLw
+wBg
+cLw
 qiG
 usF
 sQg
@@ -63346,10 +63233,10 @@ eWC
 osv
 aQW
 fOd
-gIF
+kHs
 fyW
-gIF
-gIF
+kHs
+kHs
 iKc
 xsP
 ezR
@@ -63603,11 +63490,11 @@ eWC
 osv
 nyO
 dIS
-mvy
+qto
 pmS
-mvy
-mvy
-mvy
+qto
+qto
+qto
 whB
 aRQ
 fZl
@@ -63863,8 +63750,8 @@ pSQ
 hxv
 dDl
 dDl
-uKf
-mvy
+fyE
+qto
 eGw
 pSQ
 fZl


### PR DESCRIPTION
## About The Pull Request
Many of the interiors on Warren were using the 'city' area, which is really intended as an outdoor area - while it blocks weather (for some reason) it washes away graffiti and such inside it, which was a bug report. These areas are now the 'building' area, and I've also added a few more exterior areas where it makes sense (under hole in raider compound roof, renegade courtyard) which were previously marked as city.

Also fixed two buildings at the back of the NCR Outpost just having no roof, for some reason.

## Why It's Good For The Game
Another report resolved and better quality map. While I don't want to work too much on maps that are going to be switched over (quite honestly I'd prefer not to touch Warren again after this) it's nice to do little fixes if it doesn't take too long.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
fix: Fixed some mapping errors in Warren. Graffiti should stay now.
/:cl: