### PR TITLE
Khan Tweaks/Nerfs

### DIFF
--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -274,6 +274,7 @@
 		/obj/item/stack/sheet/leather/twenty = 1,
 		/obj/item/stack/sheet/cloth/thirty = 1,
 		/obj/item/stack/sheet/prewar/twenty = 1,
+		/obj/item/book/granter/trait/explosives = 1,
 		/obj/item/book/granter/trait/selection = 1,
 		)
 

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -155,7 +155,7 @@
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
 		/obj/item/twohanded/baseball/spiked = 1,
-		/obj/item/ammo_box/shotgun/buck = 4,
+		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/book/granter/trait/selection = 1)
 
 /datum/outfit/loadout/soldierb
@@ -166,7 +166,7 @@
 	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
 	head = /obj/item/clothing/head/helmet/f13/khan/bandana
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/msmg9mm = 3,
+		/obj/item/ammo_box/magazine/msmg9mm = 2,
 		/obj/item/book/granter/trait/trekking = 1,
 		/obj/item/book/granter/trait/selection = 1)
 

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -238,6 +238,8 @@
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/w308 = 3,
 		/obj/item/melee/onehanded/knife/bowie = 1,
+		/obj/item/storage/belt/utility/full/engi = 1,
+		/obj/item/stack/crafting/armor_plate/ten = 1,
 		)
 
 

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -236,7 +236,7 @@
 	glasses = /obj/item/clothing/glasses/night/ncr
 	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/w308 = 3,
+		/obj/item/ammo_box/magazine/w308 = 2,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/storage/belt/utility/full/engi = 1,
 		/obj/item/stack/crafting/armor_plate/ten = 1,

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -135,14 +135,12 @@
 /datum/outfit/job/khan/senior_enforcer
 	name = "Senior Enforcer"
 	jobtype = /datum/job/khan/senior_enforcer
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/leader
-	head = /obj/item/clothing/head/helmet/f13/khan/leader
-	belt = /obj/item/storage/belt/bandolier
+	belt = /obj/item/storage/belt/military/assault
 	backpack_contents = list(
 		/obj/item/storage/box/medicine/stimpaks/stimpaks5 = 1,
-		/obj/item/stack/f13Cash/caps/fivezerozero = 1,//500 Caps.
-		/obj/item/pda,
-		/obj/item/card/id/selfassign
+		/obj/item/storage/bag/money/small/khan = 1,
+		/obj/item/pda = 1,
+		/obj/item/card/id/selfassign = 1,
 		)
 
 
@@ -158,7 +156,6 @@
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
 		/obj/item/twohanded/baseball/spiked = 1,
 		/obj/item/ammo_box/shotgun/buck = 4,
-		/obj/item/book/granter/trait/bigleagues = 1,
 		/obj/item/book/granter/trait/selection = 1)
 
 /datum/outfit/loadout/soldierb
@@ -215,25 +212,32 @@
 
 /datum/outfit/loadout/seniora
 	name = "Teachings of Regis"
-	suit_store = /obj/item/gun/ballistic/automatic/shotgun/riot/boss
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/leader
+	head = /obj/item/clothing/head/helmet/f13/khan/leader
+	suit_store = /obj/item/gun/ballistic/automatic/shotgun/riot
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/d12g = 2,
 		)
 
 /datum/outfit/loadout/seniorb
 	name = "Teachings of Jessup"
-	suit_store = /obj/item/gun/ballistic/automatic/assault_rifle/r91/infiltrator
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
+	suit_store = /obj/item/gun/ballistic/automatic/assault_rifle/r91
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556mm = 2,
+		/obj/item/storage/survivalkit_aid_adv = 1,
 		)
 
 /datum/outfit/loadout/seniorc
 	name = "Teachings of Melissa"
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
+	head = /obj/item/clothing/head/helmet/f13/khan/bandana
+	glasses = /obj/item/clothing/glasses/night/ncr
 	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/w308 = 3,
-		/obj/item/gun/ballistic/automatic/pistol/deagle = 1,
-		/obj/item/ammo_box/magazine/m44 = 2,
+		/obj/item/melee/onehanded/knife/bowie = 1,
 		)
 
 


### PR DESCRIPTION
## About The Pull Request
This PR does four things; 

- Nerfs the S.E's weaponry down following complaints I agree with regarding the Left Hand and overall loadouts.
- Tweaks the S.E's loadouts and on-spawn gear to make the other options genuinely viable and not side/downgrades
- Removes the Grognak book from the lever action shotgun enforcer loadout
- Ports the explosive book addition from the Loadout PR to armorer to avoid merge conflicts

Changelog has the specifics of these four things, but it's overall a nerf more than a tweak given the Senior Enforcer is losing the infiltrator and left hand riot shotgun alongside it's on-spawn 500 caps, while the normal enforcer is losing its grognak book on the lever action shotgun loadout. Senior Enforcer gets an actual belt now, but that's not much of a buff lmao. Below is a visualized image of the loadouts in-game.

EDIT: Sniper Magazines bumped from 3 to 2 on request of Mazz

![image](https://github.com/f13babylon/f13babylon/assets/76122712/5e419ff7-59b6-440b-8f74-bdc7756611c3)

## Why It's Good For The Game
Senior Enforcer has more varied loadout options outside of different cool gun and is nerfed by losing their unique-tier comical guns (Heavy, Frontline and Support if one were to give them terms outside of their teachings), Lever loadout for the Enforcer is less desirable due to not having an extra book like the other two, Armorer can actually make explosives. Overall Q-o-L things that should hopefully make the Khans more balanced than they currently are. Definitely overdid it a bit with the Left Hand lmao.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑 
balance: swapped 'Left Hand' riot shotgun for a normal riot shotgun
balance: swapped Infiltrator for a normal R91
balance: swapped 500 caps on spawn from senior enforcer to a khan money pouch
balance: swapped bandolier for an assault belt
balance: swapped Jessup loadouts armor for a battlecoat and fullhelm
add: adv. first aid kit to Jessup loadout
del: grognak book from heavy enforcer loadout
add: explosive book to khan armorer
balance: swapped Melissa loadouts armor to basic jacket and bandana
remove: deagle from melissa loadout
add: 10 armor plates to melissa loadout
add: nvg sunglasses to melissa loadout
add: full engineering belt to melissa loadout
add: bowie knife to melissa loadout
tweak: melissa loadout sniper mags from 3 to 2
balance: all loadout ammo boxes / mags to 2
🆑 