### PR TITLE
Super Mutant & Sentry Bot damage hotfix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -65,7 +65,7 @@
 			return
 		var/obj/item/grenade/flashbang/sentry/S = new /obj/item/grenade/flashbang/sentry(flashbang_turf)
 		S.preprime(user = null)
-	if(prob(75) || Proj.damage > 26) //prob(x) = chance for proj to actually do something, adjust depending on how OP you want sentrybots to be
+	if(prob(75) || Proj.damage > 25) //prob(x) = chance for proj to actually do something, adjust depending on how OP you want sentrybots to be
 		return ..()
 	else
 		visible_message(span_danger("\The [Proj] bounces off \the [src]'s armor plating!"))
@@ -133,7 +133,7 @@
 /mob/living/simple_animal/hostile/securitron/sentrybot/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		CRASH("[src] sentrybot invoked bullet_act() without a projectile")
-	if(prob(5) || Proj.damage > 30) //prob(x) = chance for proj to actually do something, adjust depending on how OP you want it to be.
+	if(prob(5) || Proj.damage > 25) //prob(x) = chance for proj to actually do something, adjust depending on how OP you want it to be.
 		return ..()
 	else
 		visible_message(span_danger("\The [Proj] shatters on \the [src]'s armor plating!"))

--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -61,7 +61,7 @@
 /mob/living/simple_animal/hostile/supermutant/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		return
-	if(prob(85) || Proj.damage > 26)
+	if(prob(85) || Proj.damage > 25)
 		return ..()
 	else
 		visible_message("<span class='danger'>\The [Proj] is deflected harmlessly by \the [src]'s thick skin!</span>")
@@ -487,7 +487,7 @@
 /mob/living/simple_animal/hostile/supermutant/rangedmutant/heavy/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		CRASH("[src] heavy supermutant invoked bullet_act() without a projectile")
-	if(prob(15) || Proj.damage > 30)
+	if(prob(15) || Proj.damage > 25)
 		return ..()
 	else
 		visible_message("<span class='danger'>\The [Proj] bounces off \the [src]'s armor plating!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -214,7 +214,7 @@
 /mob/living/simple_animal/hostile/handy/robobrain/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		CRASH("[src] robobrain invoked bullet_act() without a projectile")
-	if(prob(15) || Proj.damage > 32)
+	if(prob(15) || Proj.damage > 25)
 		return ..()
 	else
 		visible_message("<span class='danger'>\The [Proj] shatters on \the [src]'s armor plating!</span>")


### PR DESCRIPTION
## About The Pull Request
New gun PR made 556 do one less damage. This made 556 unable to hurt mutants. This fixes that and in turn makes it so sentries can also be hurt by 556.

## Why It's Good For The Game
You can actually do damage.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑
fix: 5.56 not damaging mutants
balance: 5.56 now hurts sentries
balance: 5.56 now hurts robobrains