### PR TITLE
Fixes Power Plant Access

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -26694,8 +26694,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
-	req_one_access_txt = null;
-	req_access_txt = "25"
+	req_one_access_txt = "138";
+	name = "Bighorn Power Plant"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -44717,20 +44717,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/village)
-"lrl" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Bighorn Power Plant";
-	req_one_access_txt = "138"
-	},
-/turf/closed/indestructible/rock{
-	color = "#b09168";
-	desc = "An extremely tough wall.";
-	icon = 'icons/fallout/turfs/walls/house.dmi';
-	icon_state = "house0";
-	icon_type_smooth = "house";
-	name = "reinforced wooden wall"
-	},
-/area/f13/city/bighorn)
 "lrr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/nest/molerat,
@@ -75292,8 +75278,8 @@
 /area/f13/caves)
 "xSv" = (
 /obj/machinery/door/airlock/highsecurity{
-	req_one_access_txt = null;
-	req_access_txt = "25"
+	req_one_access_txt = "138";
+	name = "Bighorn Power Plant"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -96471,7 +96457,7 @@ bzB
 bzB
 pat
 pat
-lrl
+pat
 wok
 nqb
 nqb

--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -194,7 +194,7 @@ Mayor
 	/datum/outfit/loadout/richmantender,
 	/datum/outfit/loadout/diner)
 
-	access = list(ACCESS_BAR, ACCESS_KITCHEN, ACCESS_TOWN_BAR, ACCESS_TOWN)
+	access = list(ACCESS_BAR, ACCESS_KITCHEN, ACCESS_TOWN_BAR, ACCESS_TOWN, ACCESS_FUSION)
 	minimal_access = list(ACCESS_BAR, ACCESS_KITCHEN, ACCESS_TOWN_BAR, ACCESS_TOWN)
 	matchmaking_allowed = list(
 		/datum/matchmaking_pref/friend = list(
@@ -275,7 +275,7 @@ Mayor
 	exp_requirements = 400
 
 	outfit = /datum/outfit/job/bighorn/f13shopkeeper
-	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_TOWN, ACCESS_SHOPKEEP)
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_TOWN, ACCESS_SHOPKEEP, ACCESS_FUSION)
 	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_TOWN, ACCESS_SHOPKEEP)
 	matchmaking_allowed = list(
 		/datum/matchmaking_pref/friend = list(
@@ -386,7 +386,7 @@ Mayor
 	/datum/outfit/loadout/cleanser		//Just some bombs.
 	)
 
-	access = list(ACCESS_BAR, ACCESS_TOWN, ACCESS_CHAPEL_OFFICE)		//we can expand on this and make alterations as people suggest different loadouts
+	access = list(ACCESS_BAR, ACCESS_TOWN, ACCESS_CHAPEL_OFFICE, ACCESS_FUSION)		//we can expand on this and make alterations as people suggest different loadouts
 	minimal_access = list(ACCESS_BAR, ACCESS_TOWN, ACCESS_CHAPEL_OFFICE)
 	matchmaking_allowed = list(
 		/datum/matchmaking_pref/friend = list(
@@ -674,7 +674,7 @@ Mayor
 	exp_type = EXP_TYPE_BIGHORN
 	exp_requirements = 200
 	outfit = /datum/outfit/job/bighorn/f13secretary
-	access = list(ACCESS_BAR, ACCESS_FORENSICS_LOCKERS)
+	access = list(ACCESS_BAR, ACCESS_FORENSICS_LOCKERS, ACCESS_FUSION)
 	minimal_access = list(ACCESS_BAR, ACCESS_FORENSICS_LOCKERS)
 
 /datum/outfit/job/bighorn/f13secretary


### PR DESCRIPTION
## About The Pull Request
#461 changed power plant access from the power plant tag to the town tag, which let more town roles in but locked the followers out. This works better - restores the power plant tag, but gives it to the town roles that were missing it.

Also removes a power plant door that was just stuck in a wall. : )
## Why It's Good For The Game
Now everyone in Town and Follower factions can access the plant. Problem solved.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog
:cl:
fix: Fixes Bighorn Power Plant access.
/:cl:
