### PR TITLE
Preacher + Mayor + Secretary Pipboys

### DIFF
--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -72,7 +72,6 @@ Mayor
 		/obj/item/pen/fountain/captain = 1,
 		/obj/item/storage/bag/money/small/mayor = 1, //Cash for payouts. Incredible amount, seeing as next to the Banker, he's the closest thing to a treasury keeper.
 		/obj/item/pda = 1,
-		/obj/item/card/id/selfassign = 1,
 		)
 /*--------------------------------------------------------------*/
 /datum/job/bighorn/f13sheriff
@@ -553,7 +552,6 @@ Mayor
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		/obj/item/storage/fancy/candle_box = 1,
 		/obj/item/pda = 1,
-		/obj/item/card/id/selfassign = 1,
 		/obj/item/storage/bag/money/small/settler = 1,
 		)
 //end preacher
@@ -694,5 +692,4 @@ Mayor
 	/obj/item/clothing/gloves/evening = 1,
 	/obj/item/clothing/gloves/color/white = 1,
 	/obj/item/pda = 1,
-	/obj/item/card/id/selfassign = 1,
 	)

--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -66,11 +66,14 @@ Mayor
 	suit = 		/obj/item/clothing/suit/armor/f13/kit
 	head = 		/obj/item/clothing/head/fedora
 	backpack_contents = list(
-		/obj/item/clothing/head/f13/town/big = 1, \
-		/obj/item/storage/box/citizenship_permits = 1, \
-		/obj/item/ammo_box/a357=2, \
+		/obj/item/clothing/head/f13/town/big = 1,
+		/obj/item/storage/box/citizenship_permits = 1,
+		/obj/item/ammo_box/a357 = 2,
 		/obj/item/pen/fountain/captain = 1,
-		/obj/item/storage/bag/money/small/mayor = 1,)//Cash for payouts. Incredible amount, seeing as next to the Banker, he's the closest thing to a treasury keeper.
+		/obj/item/storage/bag/money/small/mayor = 1, //Cash for payouts. Incredible amount, seeing as next to the Banker, he's the closest thing to a treasury keeper.
+		/obj/item/pda = 1,
+		/obj/item/card/id/selfassign = 1,
+		)
 /*--------------------------------------------------------------*/
 /datum/job/bighorn/f13sheriff
 	title = "Sheriff"
@@ -545,11 +548,14 @@ Mayor
 	backpack =		/obj/item/storage/backpack/cultpack
 	satchel = 		/obj/item/storage/backpack/cultpack
 	backpack_contents = list(
-		/obj/item/camera/spooky = 1, \
-		/obj/item/reagent_containers/food/drinks/flask=1, \
-		/obj/item/reagent_containers/hypospray/medipen/stimpak=2, \
-		/obj/item/storage/fancy/candle_box, \
-		/obj/item/storage/bag/money/small/settler)
+		/obj/item/camera/spooky = 1,
+		/obj/item/reagent_containers/food/drinks/flask = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
+		/obj/item/storage/fancy/candle_box = 1,
+		/obj/item/pda = 1,
+		/obj/item/card/id/selfassign = 1,
+		/obj/item/storage/bag/money/small/settler = 1,
+		)
 //end preacher
 
 /datum/outfit/job/bighorn/f13settler
@@ -686,4 +692,7 @@ Mayor
 	backpack_contents = list(/obj/item/clothing/under/f13/classdress = 1,
 	/obj/item/clothing/under/suit/black_really = 1,
 	/obj/item/clothing/gloves/evening = 1,
-	/obj/item/clothing/gloves/color/white = 1)
+	/obj/item/clothing/gloves/color/white = 1,
+	/obj/item/pda = 1,
+	/obj/item/card/id/selfassign = 1,
+	)


### PR DESCRIPTION
## About The Pull Request
Gives the Mayor, Preacher and Secretary on-spawn pipboys

## Why It's Good For The Game
They now have an easier time preaching / negotiating / speaking with people through non radio communication.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑 
add: pipboy for mayor
add: pipboy for secretary
add: pipboy for preacher
🆑 