### PR TITLE
Expands Loadout + Clothing UI

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -205,7 +205,7 @@
 	<A href='?src=[REF(user)];mach_close=mob[REF(src)]'>Close</A>
 	"}
 
-	var/datum/browser/popup = new(user, "mob[REF(src)]", "[src]", 440, 510)
+	var/datum/browser/popup = new(user, "mob[REF(src)]", "[src]", 440, 550)
 	popup.set_content(dat.Join())
 	popup.open()
 

--- a/tgui/packages/tgui/interfaces/LoadoutSelect.js
+++ b/tgui/packages/tgui/interfaces/LoadoutSelect.js
@@ -5,7 +5,7 @@ import { Button, Flex, Tabs, Section, Stack } from '../components';
 export const LoadoutSelect = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-    <Window width={500} height={450} resizable="false">
+    <Window width={1400} height={750} resizable="false">
       <Window.Content>
         <Stack vertical fill fitted>
           <Stack.Item>
@@ -30,7 +30,7 @@ export const LoadoutSelect = (props, context) => {
                     <Stack.Item as="div" style={{ "-ms-transform": "scale(1.5)", "image-rendering": "pixelated", "-ms-interpolation-mode": "nearest-neighbor", "vertical-align": "middle", "height": "32px", "width": "32px" }} class={item.icon} />
                     <Stack.Item as="div" style={{ "display": "block", "vertical-align": "middle", "line-height": "32px", "margin": "auto" }}>
                       {item.name} {item.quantity > 1
-                      && (`x${item.quantity}`)}<br />
+                        && (`x${item.quantity}`)}<br />
                     </Stack.Item>
                   </Stack>))}
               </Section>


### PR DESCRIPTION
## About The Pull Request
![2446](https://github.com/f13babylon/f13babylon/assets/132588088/f8a7d2cb-a969-46e6-a587-0834a4618717)
Increased the height and width of the loadout UI, and the height of the clothing UI.
## Why It's Good For The Game
Some much-needed QoL. The loadout UI would always have to be manually stretched out on roundstart to see your options for the vast majority of classes, whereas now you can see all the tabs even for the huge choice roles like wastelander. And the clothing UI was *just* short enough to cut off the 'close' option and add a scrollbar, so it's a lot aesthetically better now.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
## Changelog
:cl:
fix: Fixed the size of some UI elements.
/:cl:
