### PR TITLE
Casing Cleaner Subsystem

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -49,5 +49,6 @@ GLOBAL_LIST_EMPTY(rockpaperscissors_players)
 
 GLOBAL_LIST_EMPTY(trash_piles)						//list of all trash_piles
 GLOBAL_LIST_EMPTY(money_piles)
+GLOBAL_LIST_EMPTY(spent_bullet_casings)				//list of all spent bullet casings
 
 GLOBAL_LIST_EMPTY(lamppost)							//list of all lampposts

--- a/code/controllers/subsystem/casingcleaner.dm
+++ b/code/controllers/subsystem/casingcleaner.dm
@@ -1,0 +1,21 @@
+/*
+Deletes spent ammo casings stored in the global spent_bullet_casings list.
+Certain casings are a bigger priority for deletion, their calibers are stored in var/priority_casings_list.
+These are usually casings that are prone to being spammed by high-firerate guns, therefore causing lag. They get deleted every time the Casing Cleaner is fired.
+var/deleting_all_casings determines if any casings not in var/priority_casings_list need to be deleted, such as casings from rifle rounds. These casings get deleted on every second Casing Cleaner fire.
+*/
+
+SUBSYSTEM_DEF(casingcleaner)
+	name = "Casing Cleaner"
+	wait = 150 SECONDS
+	var/priority_casings_list = list("10mm", "9mm", ".22lr", ".45")
+	var/deleting_all_casings = FALSE
+
+/datum/controller/subsystem/casingcleaner/fire(resumed = 0)
+	cleanup_casings()
+	deleting_all_casings = !deleting_all_casings
+
+/datum/controller/subsystem/casingcleaner/proc/cleanup_casings()
+	for(var/obj/item/ammo_casing/iter_casing in GLOB.spent_bullet_casings)
+		if((iter_casing.caliber in priority_casings_list) || deleting_all_casings)
+			qdel(iter_casing)

--- a/code/controllers/subsystem/casingcleaner.dm
+++ b/code/controllers/subsystem/casingcleaner.dm
@@ -17,5 +17,5 @@ SUBSYSTEM_DEF(casingcleaner)
 
 /datum/controller/subsystem/casingcleaner/proc/cleanup_casings()
 	for(var/obj/item/ammo_casing/iter_casing in GLOB.spent_bullet_casings)
-		if((iter_casing.caliber in priority_casings_list) || deleting_all_casings)
+		if(((iter_casing.caliber in priority_casings_list) || deleting_all_casings) && isturf(iter_casing.loc))
 			qdel(iter_casing)

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -39,6 +39,8 @@
 /obj/item/ammo_casing/Destroy()
 	if(BB)
 		QDEL_NULL(BB)
+	else if (src in GLOB.spent_bullet_casings)
+		GLOB.spent_bullet_casings -= src
 	return ..()
 
 /obj/item/ammo_casing/update_icon_state()

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -70,6 +70,7 @@
 		BB.preparePixelProjectile(target, user, params, spread)
 	BB.fire(null, direct_target)
 	BB = null
+	GLOB.spent_bullet_casings += src
 	return 1
 
 /obj/item/ammo_casing/proc/spread(turf/target, turf/current, distro)

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -314,6 +314,7 @@
 #include "code\controllers\subsystem\autotransfer.dm"
 #include "code\controllers\subsystem\blackbox.dm"
 #include "code\controllers\subsystem\callback.dm"
+#include "code\controllers\subsystem\casingcleaner.dm"
 #include "code\controllers\subsystem\chat.dm"
 #include "code\controllers\subsystem\communications.dm"
 #include "code\controllers\subsystem\dbcore.dm"


### PR DESCRIPTION
Adds a new subsystem responsible for cleaning spent casings en-masse.

Pistol-caliber casings (usually the primary cause of lag due to some guns using them having very high fire rates) get deleted every 150 seconds.

All other casings get deleted every 300 seconds (5 minutes).