### PR TITLE
Headset Modernization

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -7,79 +7,79 @@
 
 #define RADIO_CHANNEL_SECURITY "BDF"
 #define RADIO_KEY_SECURITY "s"
-#define RADIO_TOKEN_SECURITY ":s"
+#define RADIO_TOKEN_SECURITY ".s"
 
 #define RADIO_CHANNEL_ENGINEERING "Engineering"
 #define RADIO_KEY_ENGINEERING "e"
-#define RADIO_TOKEN_ENGINEERING ":e"
+#define RADIO_TOKEN_ENGINEERING ".e"
 
 #define RADIO_CHANNEL_COMMAND "Command"
 #define RADIO_KEY_COMMAND "c"
-#define RADIO_TOKEN_COMMAND ":c"
+#define RADIO_TOKEN_COMMAND ".c"
 
 #define RADIO_CHANNEL_SCIENCE "Science"
 #define RADIO_KEY_SCIENCE "n"
-#define RADIO_TOKEN_SCIENCE ":n"
+#define RADIO_TOKEN_SCIENCE ".n"
 
 #define RADIO_CHANNEL_MEDICAL "Followers"
 #define RADIO_KEY_MEDICAL "m"
-#define RADIO_TOKEN_MEDICAL ":m"
+#define RADIO_TOKEN_MEDICAL ".m"
 
 #define RADIO_CHANNEL_SUPPLY "Supply"
 #define RADIO_KEY_SUPPLY "u"
-#define RADIO_TOKEN_SUPPLY ":u"
+#define RADIO_TOKEN_SUPPLY ".u"
 
 #define RADIO_CHANNEL_SERVICE "Service"
 #define RADIO_KEY_SERVICE "v"
-#define RADIO_TOKEN_SERVICE ":v"
+#define RADIO_TOKEN_SERVICE ".v"
 
 #define RADIO_CHANNEL_AI_PRIVATE "AI Private"
 #define RADIO_KEY_AI_PRIVATE "o"
-#define RADIO_TOKEN_AI_PRIVATE ":o"
+#define RADIO_TOKEN_AI_PRIVATE ".o"
 
 #define RADIO_CHANNEL_SYNDICATE "Syndicate"
 #define RADIO_KEY_SYNDICATE "t"
-#define RADIO_TOKEN_SYNDICATE ":t"
+#define RADIO_TOKEN_SYNDICATE ".t"
 
 #define RADIO_CHANNEL_CENTCOM "CentCom"
 #define RADIO_KEY_CENTCOM "y"
-#define RADIO_TOKEN_CENTCOM ":y"
+#define RADIO_TOKEN_CENTCOM ".y"
 
 #define RADIO_CHANNEL_VAULT "Vault"
 #define RADIO_KEY_VAULT "b"
-#define RADIO_TOKEN_VAULT ":b"
+#define RADIO_TOKEN_VAULT ".b"
 
 #define RADIO_CHANNEL_NCR "NCR"
 #define RADIO_KEY_NCR "w"
-#define RADIO_TOKEN_NCR ":w"
+#define RADIO_TOKEN_NCR ".w"
 
 #define RADIO_CHANNEL_RANGER "Ranger"
 #define RADIO_KEY_RANGER "r"
-#define RADIO_TOKEN_RANGER ":r"
+#define RADIO_TOKEN_RANGER ".r"
 
 #define RADIO_CHANNEL_BOS "BOS"
 #define RADIO_KEY_BOS "q"
-#define RADIO_TOKEN_BOS ":q"
+#define RADIO_TOKEN_BOS ".q"
 
 #define RADIO_CHANNEL_ENCLAVE "Enclave"
 #define RADIO_KEY_ENCLAVE "z"
-#define RADIO_TOKEN_ENCLAVE ":z"
+#define RADIO_TOKEN_ENCLAVE ".z"
 
 #define RADIO_CHANNEL_TOWN "Town"
 #define RADIO_KEY_TOWN "f"
-#define RADIO_TOKEN_TOWN ":f"
+#define RADIO_TOKEN_TOWN ".f"
 
 #define RADIO_CHANNEL_LEGION "Legion"
 #define RADIO_KEY_LEGION "l"
-#define RADIO_TOKEN_LEGION ":l"
+#define RADIO_TOKEN_LEGION ".l"
 
 #define RADIO_CHANNEL_KHANS "Khans"
 #define RADIO_KEY_KHANS "a"
-#define RADIO_TOKEN_KHANS ":a"
+#define RADIO_TOKEN_KHANS ".a"
 
 #define RADIO_CHANNEL_DEN "Den"
 #define RADIO_KEY_DEN "j"
-#define RADIO_TOKEN_DEN ":j"
+#define RADIO_TOKEN_DEN ".j"
 
 #define RADIO_CHANNEL_CTF_RED "Red Team"
 #define RADIO_CHANNEL_CTF_BLUE "Blue Team"

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -18,7 +18,7 @@
 
 #define MODE_BINARY "binary"
 #define MODE_KEY_BINARY "b"
-#define MODE_TOKEN_BINARY ":b"
+#define MODE_TOKEN_BINARY ".b"
 
 #define MODE_WHISPER "whisper"
 #define MODE_WHISPER_CRIT "whispercrit"
@@ -27,7 +27,7 @@
 
 #define MODE_DEPARTMENT "department"
 #define MODE_KEY_DEPARTMENT "h"
-#define MODE_TOKEN_DEPARTMENT ":h"
+#define MODE_TOKEN_DEPARTMENT ".h"
 
 #define MODE_ADMIN "admin"
 #define MODE_KEY_ADMIN "p"
@@ -40,7 +40,7 @@
 
 #define MODE_CHANGELING "changeling"
 #define MODE_KEY_CHANGELING "g"
-#define MODE_TOKEN_CHANGELING ":g"
+#define MODE_TOKEN_CHANGELING ".g"
 
 #define MODE_VOCALCORDS "cords"
 #define MODE_KEY_VOCALCORDS "x"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -96,7 +96,6 @@
 
 /obj/item/encryptionkey/heads/qm
 	name = "\proper the quartermaster's encryption key"
-	desc = "An encryption key for a radio headset.  Channels are as follows: :u - supply, :c - command."
 	icon_state = "hop_cypherkey"
 	channels = list(RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_COMMAND = 1)
 
@@ -131,80 +130,67 @@
 
 /obj/item/encryptionkey/headset_vault
 	name = "vault radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the vault channel, use :b."
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_VAULT = 1)
 
 /obj/item/encryptionkey/headset_vault_security
 	name = "\proper the Security encryption key"
-	desc = "An encryption key for a radio headset.  Channels are as follows: :b - vault, :s - security"
 	icon_state = "sec_cypherkey"
 	channels = list(RADIO_CHANNEL_VAULT = 1, RADIO_CHANNEL_SECURITY = 1)
 
 /obj/item/encryptionkey/headset_overseer
 	name = "\proper the Overseer's encryption key"
-	desc = "An encryption key for a radio headset.  Channels are as follows: :b - vault, :c - command, :s - security, :e - engineering, :m - medical, :n - science."
 	icon_state = "cap_cypherkey"
 	channels = list(RADIO_CHANNEL_VAULT = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1)
 
 /obj/item/encryptionkey/headset_vault_hos
 	name = "\proper the Head of Security's encryption key"
-	desc = "An encryption key for a radio headset.  Channels are as follows: :b - vault, :c - command, :s - security"
 	icon_state = "hos_cypherkey"
 	channels = list(RADIO_CHANNEL_VAULT = 1, RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1)
 
 /obj/item/encryptionkey/headset_ncr
-	name = "NCR radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the NCR channel, use :w."
+	name = "\improper NCR radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_NCR = 1)
 
 /obj/item/encryptionkey/headset_ranger
-	name = "Ranger radio encryption key"
-	desc = "An encryption key for a radio headset. To access the NCR channel, use :w. To access the Ranger channel, use :r."
+	name = "ranger radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_NCR = 1, RADIO_CHANNEL_RANGER = 1)
 
 /obj/item/encryptionkey/headset_bos
-	name = "Brotherhood radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Brotherhood channel, use :q."
+	name = "brotherhood radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_BOS = 1)
 
 /obj/item/encryptionkey/headset_enclave
-	name = "Enclave radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Enclave channel, use :z."
+	name = "enclave radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_ENCLAVE = 1)
 
 /obj/item/encryptionkey/headset_town
-	name = "Town radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Town channel, use :f."
+	name = "town radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_TOWN = 1)
 
 /obj/item/encryptionkey/headset_den
-	name = "Den radio encryption key"
-	desc = "An encryption key for a radio headset. To access the Den channel, use :j."
+	name = "den radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_DEN = 1)
 
 /obj/item/encryptionkey/headset_legion
-	name = "Legion radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Legion channel, use :l."
+	name = "legion radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_LEGION = 1)
 
 /obj/item/encryptionkey/headset_cent
-	name = "\improper CentCom radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the CentCom channel, use :y."
+	name = "\improper Vault-Tec radio encryption key"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list(RADIO_CHANNEL_CENTCOM = 1)
 
 /obj/item/encryptionkey/headset_khans
-	name = "Khan radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Khan channel, use :h."
+	name = "khan radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_KHANS = 1)
 

--- a/code/modules/fallout/equipment/headsets.dm
+++ b/code/modules/fallout/equipment/headsets.dm
@@ -10,7 +10,7 @@
 
 /obj/item/radio/headset/headset_vault_hos
 	name = "\proper the chief of security's radio headset"
-	desc = "The headset of the man in charge of keeping order and protecting the vault.\nChannels are as follows: .b - Vault, .c - Command, .s - Security."
+	desc = "The headset of the man in charge of keeping order and protecting the Vault.\nChannels are as follows: .b - Vault, .c - Command, .s - Security."
 	icon_state = "com_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault_hos
 	frequency = FREQ_VAULT

--- a/code/modules/fallout/equipment/headsets.dm
+++ b/code/modules/fallout/equipment/headsets.dm
@@ -89,6 +89,7 @@
 	factionized = TRUE
 
 /obj/item/radio/headset/headset_legion/command
+	name = "legion command radio headset"
 	desc = "This is used by the Command of Caesar's Legion. Protects ears from flashbangs.\nUse .l To access the Legion channel."
 	icon_state = "sec_headset_alt"
 	item_state = "sec_headset_alt"

--- a/code/modules/fallout/equipment/headsets.dm
+++ b/code/modules/fallout/equipment/headsets.dm
@@ -1,7 +1,7 @@
 //FALLOUT
 /obj/item/radio/headset/headset_overseer
 	name = "\proper the overseer's radio headset"
-	desc = "This is used by the vault overseer.\nChannels are as follows: :v - vault, :c - command, :s - security, :e - engineering, :m - medical, :n - science."
+	desc = "This is used by the vault overseer.\nChannels are as follows: .b - Vault, .c - Command, .s - Security, .e - Engineering, .m - Medical, .n - Science."
 	icon_state = "com_headset"
 	keyslot = new /obj/item/encryptionkey/headset_overseer
 	frequency = FREQ_VAULT
@@ -10,7 +10,7 @@
 
 /obj/item/radio/headset/headset_vault_hos
 	name = "\proper the chief of security's radio headset"
-	desc = "The headset of the man in charge of keeping order and protecting the vault.\nChannels are as follows: :v - vault, :c - command, :s - security."
+	desc = "The headset of the man in charge of keeping order and protecting the vault.\nChannels are as follows: .b - Vault, .c - Command, .s - Security."
 	icon_state = "com_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault_hos
 	frequency = FREQ_VAULT
@@ -23,7 +23,7 @@
 
 /obj/item/radio/headset/headset_vault
 	name = "\proper vault radio headset"
-	desc = "A vault-tec radio.\nChannels are as follows: :v - vault."
+	desc = "A vault-tec radio.\nUse .b To access the Vault channel."
 	keyslot = new /obj/item/encryptionkey/headset_vault
 	frequency = FREQ_VAULT
 	freerange = TRUE
@@ -31,7 +31,7 @@
 
 /obj/item/radio/headset/headset_vaultsec
 	name = "security radio headset"
-	desc = "This is used by your elite security force.\nTo access the security channel, use :s. To access the vault channel, use :v."
+	desc = "This is used by your elite security force.\nChannels are as follows: .b - Vault, .s - Security."
 	icon_state = "sec_headset"
 	keyslot = new /obj/item/encryptionkey/headset_vault_security
 	frequency = FREQ_VAULT
@@ -44,7 +44,7 @@
 
 /obj/item/radio/headset/headset_vault_hos/alt
 	name = "\proper the head of security's bowman headset"
-	desc = "The headset of the man in charge of keeping order and protecting the station. Protects ears from flashbangs.\nTo access the security channel, use :s. For command, use :c. For vault, use :v"
+	desc = "The headset of the man in charge of keeping order and protecting the station. Protects ears from flashbangs.\nChannels are as follows: .b - Vault, .c - Command, .s - Security."
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 	frequency = FREQ_VAULT
@@ -52,62 +52,55 @@
 	freqlock = TRUE
 
 /obj/item/radio/headset/headset_ncr
-	name = "NCR radio headset"
-	desc = "This is used by the New California Republic.\nTo access the NCR channel, use :w."
+	name = "\improper NCR radio headset"
+	desc = "This is used by the New California Republic.\nUse .w To access the NCR channel."
 	icon_state = "mine_headset"
 	keyslot = new /obj/item/encryptionkey/headset_ncr
 	linked_faction = FACTION_NCR
 	factionized = TRUE
 
 /obj/item/radio/headset/headset_ranger
-	name = "Ranger radio headset"
-	desc = "This is used by the New California Republic.\nTo access the NCR channel, use :w. \nTo access the Ranger channel, use :r. Protects ears from flashbangs."
+	name = "ranger radio headset"
+	desc = "This is used by the Rangers of the New California Republic.\nChannels are as follows: .w - NCR, .r - Ranger."
 	icon_state = "mine_headset"
 	keyslot = new /obj/item/encryptionkey/headset_ranger
 	linked_faction = FACTION_NCR
 	factionized = TRUE
 
-/obj/item/radio/headset/headset_ranger/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
-
-
-/obj/item/radio/headset/headset_ncr_com
-	name = "NCR Command radio headset"
-	desc = "This is used by the New California Republic.\nTo access the NCR channel, use :w. \nTo access the Ranger channel, use :r. Protects ears from flashbangs."
+/obj/item/radio/headset/headset_ncr/command
+	name = "\improper NCR command radio headset"
+	desc = "This is used by the Command of the New California Republic. Protects ears from flashbangs.\nChannels are as follows: .w - NCR, .r - Ranger."
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
 	keyslot = new /obj/item/encryptionkey/headset_ranger
-	linked_faction = FACTION_NCR
-	factionized = TRUE
 	command = TRUE
 
-/obj/item/radio/headset/headset_ncr_com/ComponentInitialize()
+/obj/item/radio/headset/headset_ncr/command/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/radio/headset/headset_legion
-	name = "Legion radio headset"
-	desc = "This is used by Caesar's Legion.\nTo access the Legion channel, use :l."
+	name = "legion radio headset"
+	desc = "This is used by Caesar's Legion.\nUse .l To access the Legion channel."
 	icon_state = "sec_headset"
 	item_state = "headset_alt"
 	keyslot = new /obj/item/encryptionkey/headset_legion
 	linked_faction = FACTION_LEGION
 	factionized = TRUE
 
-/obj/item/radio/headset/headset_legion/cent
-	desc = "This is used by the Centurion of Caesar's Legion.\nTo access the Legion channel, use :l. Protects ears from flashbangs."
-	command = TRUE
+/obj/item/radio/headset/headset_legion/command
+	desc = "This is used by the Command of Caesar's Legion. Protects ears from flashbangs.\nUse .l To access the Legion channel."
 	icon_state = "sec_headset_alt"
 	item_state = "sec_headset_alt"
+	command = TRUE
 
-/obj/item/radio/headset/headset_legion/cent/ComponentInitialize()
+/obj/item/radio/headset/headset_legion/command/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/radio/headset/headset_bos
 	name = "brotherhood radio headset"
-	desc = "This is used by the brotherhood of steel.\nTo access the BOS channel, use :q. Protects ears from flashbangs."
+	desc = "This is used by the Brotherhood of Steel. Protects ears from flashbangs.\nUse .q To access the Brotherhood channel."
 	icon_state = "cent_headset"
 	keyslot = new /obj/item/encryptionkey/headset_bos
 	linked_faction = FACTION_BROTHERHOOD
@@ -118,12 +111,14 @@
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/radio/headset/headset_bos/command
+	name = "brotherhood command radio headset"
+	desc = "This is used by the leaders of the Brotherhood of Steel. Protects ears from flashbangs.\nUse .q To access the Brotherhood channel."
 	command = TRUE
 	icon_state = "cent_headset_alt"
 
 /obj/item/radio/headset/headset_enclave
 	name = "enclave radio headset"
-	desc = "This is used by the enclave.\nTo access the enclave channel, use :z. Protects ears from flashbangs."
+	desc = "This is used by the Enclave. Protects ears from flashbangs.\nUse .z To access the Enclave channel."
 	icon_state = "syndie_headset"
 	keyslot = new /obj/item/encryptionkey/headset_enclave
 	linked_faction = FACTION_ENCLAVE
@@ -134,46 +129,46 @@
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/radio/headset/headset_enclave/command
-	linked_faction = FACTION_ENCLAVE
-	factionized = TRUE
+	name = "enclave command radio headset"
+	desc = "This is used by the Command of the Enclave. Protects ears from flashbangs.\nUse .z To access the Enclave channel."
 	command = TRUE
 
 /obj/item/radio/headset/headset_khans
 	name = "khan radio headset"
-	desc = "This is used by the Khans.\nTo access the Khan channel, use :h."
+	desc = "This is used by the Khans.\nUse .a To access the Khan channel."
 	icon_state = "syndie_headset"
 	item_state = "headset_alt"
 	keyslot = new /obj/item/encryptionkey/headset_khans
 
 /obj/item/radio/headset/headset_town
 	name = "town radio headset"
-	desc = "This is used by the town.\nTo access the town channel, use :f."
+	desc = "This is used by the town.\nUse .f To access the Town channel."
 	icon_state = "mine_headset"
 	keyslot = new /obj/item/encryptionkey/headset_town
 
 /obj/item/radio/headset/headset_sheriff
-	name = "town radio headset"
-	desc = "This is used by the Sheriff and their deputy force."
+	name = "peacekeeper radio headset"
+	desc = "This is used by the peacekeeping force of the town.\nChannels are as follows: .f - Town, .s - Security."
 	icon_state = "sec_headset"
 	keyslot = new /obj/item/encryptionkey/headset_sec
 	keyslot2 = new /obj/item/encryptionkey/headset_town
 
 /obj/item/radio/headset/headset_followers
 	name = "followers radio headset"
-	desc = "This is used by the followers.\nTo access the town channel, use :f. \nTo access the medical channel, use :m"
+	desc = "This is used by the followers.\nChannels are as follows: .f - Town, .m - Medical."
 	icon_state = "med_headset"
 	keyslot = new /obj/item/encryptionkey/headset_med
 	keyslot2 = new /obj/item/encryptionkey/headset_town
 
 /obj/item/radio/headset/headset_den
 	name = "den radio headset"
-	desc = "This is used by the den. \nTo access the den channel, use :j."
+	desc = "This is used by the den.\nUse .j To access the Den channel."
 	icon_state = "mine_headset"
 	keyslot = new /obj/item/encryptionkey/headset_den
 
 /obj/item/radio/headset/headset_cent
 	name = "\improper Vault-Tec headset"
-	desc = "A headset used by the upper echelons of Vault-Tec.\nTo access the Vault-Tec channel, use :y."
+	desc = "A headset used by the upper echelons of Vault-Tec.\nUse .y To access the Vault-Tec channel."
 	icon_state = "cent_headset"
 	keyslot = new /obj/item/encryptionkey/headset_com
 	keyslot2 = new /obj/item/encryptionkey/headset_cent
@@ -187,7 +182,7 @@
 
 /obj/item/radio/headset/headset_cent/alt
 	name = "\improper Vault-Tec bowman headset"
-	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs.\nTo access the Vault-Tec channel, use :y."
+	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs.\nUse .y To access the Vault-Tec channel."
 	icon_state = "cent_headset_alt"
 	item_state = "cent_headset_alt"
 	keyslot = null

--- a/code/modules/fallout/equipment/headsets.dm
+++ b/code/modules/fallout/equipment/headsets.dm
@@ -67,6 +67,16 @@
 	linked_faction = FACTION_NCR
 	factionized = TRUE
 
+/obj/item/radio/headset/headset_ncr/alt
+	name = "\improper NCR bowman radio headset"
+	icon_state = "com_headset_alt"
+	item_state = "com_headset_alt"
+	desc = "This is used by the New California Republic. Protects ears from flashbangs.\nUse .w To access the NCR channel."
+
+/obj/item/radio/headset/headset_ncr/alt/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
+
 /obj/item/radio/headset/headset_ncr/command
 	name = "\improper NCR command radio headset"
 	desc = "This is used by the Command of the New California Republic. Protects ears from flashbangs.\nChannels are as follows: .w - NCR, .r - Ranger."

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -238,7 +238,7 @@
 	return TRUE
 
 /datum/job/proc/radio_help_message(mob/M)
-	to_chat(M, "<b>Prefix your message with :h to speak on your department's radio. To see other prefixes, look closely at your headset.</b>")
+	to_chat(M, "<b>Prefix your message with .h to speak on your department's radio. To see other prefixes, look closely at your headset.</b>")
 
 /datum/job/proc/standard_assign_skills(datum/mind/M)
 	if(!starting_modifiers)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -135,7 +135,7 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	l_hand = /obj/item/tank/internals/oxygen
 	backpack = null
 	satchel = null
-	ears = /obj/item/radio/headset/headset_legion/cent
+	ears = /obj/item/radio/headset/headset_legion/command
 	box = /obj/item/storage/box/legate
 
 
@@ -285,7 +285,7 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13centurion
 	id = /obj/item/card/id/dogtag/legcenturion
 	mask = /obj/item/clothing/mask/bandana/legion/legcenturion
-	ears = /obj/item/radio/headset/headset_legion/cent
+	ears = /obj/item/radio/headset/headset_legion/command
 	gloves = /obj/item/clothing/gloves/legion/plated
 	glasses = /obj/item/clothing/glasses/night/polarizing
 	shoes = /obj/item/clothing/shoes/f13/military/plated
@@ -389,7 +389,7 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	neck = /obj/item/storage/belt/holster
 	gloves = /obj/item/clothing/gloves/legion/plated
 	glasses = /obj/item/clothing/glasses/legiongoggles
-	ears = /obj/item/radio/headset/headset_legion/cent
+	ears = /obj/item/radio/headset/headset_legion/command
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	shoes = /obj/item/clothing/shoes/f13/military/plated
 	r_pocket = /obj/item/flashlight/lantern

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -183,7 +183,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	id = /obj/item/card/id/dogtag/ncrcaptain
 	uniform	= /obj/item/clothing/under/f13/ncr/ncr_officer
 	head = /obj/item/clothing/head/beret/ncr
-	ears = /obj/item/radio/headset/headset_ncr_com
+	ears = /obj/item/radio/headset/headset_ncr/command
 	glasses = /obj/item/clothing/glasses/night/ncr
 	gloves = /obj/item/clothing/gloves/f13/leather
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
@@ -259,7 +259,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	neck = /obj/item/storage/belt/holster/legholster
 	glasses = /obj/item/clothing/glasses/night/ncr
 	gloves = /obj/item/clothing/gloves/f13/leather
-	ears = /obj/item/radio/headset/headset_ncr_com
+	ears = /obj/item/radio/headset/headset_ncr/command
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/lieutenant
 	r_pocket = /obj/item/binoculars
 	backpack_contents = list(
@@ -604,7 +604,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	shoes =	/obj/item/clothing/shoes/f13/military/leather
 	glasses	= /obj/item/clothing/glasses/sunglasses
 	neck = /obj/item/storage/belt/holster
-	ears = /obj/item/radio/headset/headset_ranger
+	ears = /obj/item/radio/headset/headset_ncr/command
 	mask = /obj/item/clothing/mask/gas/ranger
 	r_pocket = /obj/item/binoculars
 	backpack_contents = list(
@@ -1267,7 +1267,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	neck = /obj/item/storage/belt/holster/legholster
 	glasses = /obj/item/clothing/glasses/hud/health/f13
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile
-	ears = /obj/item/radio/headset/headset_ncr_com
+	ears = /obj/item/radio/headset/headset_ncr/command
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/labcoat
 	belt = /obj/item/storage/belt/military/assault/ncr
 	r_hand = /obj/item/storage/backpack/duffelbag/med/surgery

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -794,6 +794,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	accessory =	/obj/item/clothing/accessory/ncr/SPC
 	gloves = /obj/item/clothing/gloves/f13/leather/fingerless
 	neck = /obj/item/storage/belt/holster/legholster
+	ears = /obj/item/radio/headset/headset_ncr/alt
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
 		/obj/item/ammo_box/magazine/m45exp = 2,


### PR DESCRIPTION
Things of note:
- Headset examine message cleanup. Instead of suggesting :[channel key], it will suggest .[channel key]. This should make players less prone to saying ";hKilling everyone in Town soon." over the Common radio channel. Both methods still work.
- Ranger headsets lose ear protection
- Heavy Gunner receives a headset with ear protection
- NCR and Legion command headsets turned into children of base headsets of those factions (code stuff)