### PR TITLE
MAGAZINE BALANCE PATCH (Kind of important?)

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -70,8 +70,10 @@
 
 /obj/item/ammo_box/magazine/m556mm/drum
 	name = "rifle drum magazine (5.56mm)"
+	desc = "A large drum magazine chambered for 5.56."
 	icon_state = "mdrum"
 	max_ammo = 50
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/m556mm/drum/empty
 	start_empty = 1
@@ -90,20 +92,24 @@
 
 /obj/item/ammo_box/magazine/m5mm/drum
 	name = "rifle drum magazine (5mm)"
+	desc = "A large drum magazine chambered for 5mm."
 	icon_state = "mdrum"
 	max_ammo = 50
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/m5mm/drum/empty
 	start_empty = 1
 
 /obj/item/ammo_box/magazine/mg11
 	name = "g11 magazine (5mm)"
+	desc = "A large polymer magazine made for the G11 rifle. The empty casings are automatically stored inside when fired."
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "mg11"
 	ammo_type = /obj/item/ammo_casing/a5mm
 	caliber = "a5mm"
 	max_ammo = 50
 	multiple_sprites = 2
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/mg11/empty
 	start_empty = 1
@@ -164,15 +170,18 @@
 	start_empty = 1
 
 /obj/item/ammo_box/magazine/m2mm
-	name = "2mm electromagnetic magazine"
+	name = "gauss rifle magazine (2mm)"
+	desc = "A large magazine filled with composite finned rail munitions and a heavy internal power cell, meant to be shot out of a \"gauss\" gun."
 	icon_state = "2mm"
 	ammo_type = /obj/item/ammo_casing/c2mm
 	caliber = "2mm"
 	max_ammo = 10
 	multiple_sprites = 2
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/m2mm/blender
 	name = "2mm \"Blender\" electromagnetic magazine"
+	desc = "A large special magazine filled with fragmenting finned rail munitions and a heavy internal power cell, meant to be shot out of a \"gauss\" gun."
 	ammo_type = /obj/item/ammo_casing/c2mm/blender
 	max_ammo = 10
 	multiple_sprites = 2

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -1,30 +1,32 @@
 /obj/item/ammo_box/magazine/amr
 	name = "Anti-materiel rifle magazine (.50)"
+	desc = "A large eight-round magazine chambered for .50 MG, designed to fit in the AMR."
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "50mag"
 	max_ammo = 8
 	ammo_type = /obj/item/ammo_casing/a50MG
 	caliber = "a50MG"
 	multiple_sprites = 2
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/amr/empty
 	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/amr/incindiary
-	name = "Anti-materiel magazine (Incindiary)"
-	desc = "A .50 anti-materiel rifle magazine loaded with incindiary ammo."
+	name = "Anti-materiel magazine (Incendiary)"
+	desc = "A large eight-round magazine chambered for .50 MG, filled with Armor-Piercing Incendiary munitions that ignite the target."
 	special_ammo = TRUE
 	ammo_type = /obj/item/ammo_casing/a50MG/incendiary
 
 /obj/item/ammo_box/magazine/amr/penetrator
-	name = "Anti-materiel magazine (penetrator)"
-	desc = "A .50 anti-materiel rifle magazine loaded with wall-penetrating ammo."
+	name = "Anti-materiel magazine (Penetrator)"
+	desc = "A large eight-round magazine chambered for .50 MG, filled with exceedingly rare High-Velocity Armor-Piercing Fin Discarding Sabot munitions. It just means that they can go through a vault door, a Legion snake, and a tank at the same time."
 	special_ammo = TRUE
 	ammo_type = /obj/item/ammo_casing/a50MG/penetrator
 
 /obj/item/ammo_box/magazine/amr/uranium
-	name = "Anti-materiel magazine (uranium)"
-	desc = "A .50 anti-materiel rifle magazine loaded with crimes against god."
+	name = "Anti-materiel magazine (Uranium)"
+	desc = "A large eight-round magazine chambered for .50 MG, filled with enriched uranium payloads that fragment on the target and dump lethal doses of radiation in their bodies."
 	special_ammo = TRUE
 	ammo_type = /obj/item/ammo_casing/a50MG/uraniumtipped
 /*


### PR DESCRIPTION
### Drum magazines
Made 5.56 drums and 5mm drums normal-sized.

### 2mm magazines
Renamed 2mm magazines to "gauss rifle magazine" and made them normal-sized.

### AMR magazines
Added descriptions to AMR magazines and made them normal-sized. I'm pretty sure I did this when the AMR rebalance got merged but IG not?

### G11 magazines
Made G11 magazines normal-sized.

### The why
The AMR and gauss rifle are both power weapons that should have comparatively bad ammo economy when going against other long-range weapons like the sniper rifle, rangemaster, ratslayer, et cetera. 

Drum magazines, and the G11 by extension, provide an amount of relative firepower that should carry some form of punishment with it. By making fifty-round magazines normal-sized, we force people to sacrifice a backpack slot instead of the nigh-infinite belt and pouch slots.