### PR TITLE
Slight Tribal Nerf

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1083,7 +1083,7 @@
 		desc = "A compendium of knowledge passed down from the elders. It looks to be in poor condition."
 
 /obj/item/book/granter/trait/selection/tribal/attack_self(mob/user)
-	var/list/choices = list("Hit Them With Sticks","Pugilist","Brahmin Tender","Fireant Rituals","Fisting Expert","Spiritual Mending")
+	var/list/choices = list("Hit Them With Sticks","Pugilist","Brahmin Tender","Bow Proficiency","Fisting Expert","Spiritual Mending")
 	if(granted_trait == null)
 		var/choice = input("Choose a trait:") in choices
 		switch(choice)
@@ -1098,8 +1098,8 @@
 			if("Brahmin Tender")
 				granted_trait = TRAIT_CALCIUM_HEALER //Heal from milk.
 				traitname = "drinking milk"
-			if("Fireant Rituals")
-				granted_trait = TRAIT_IGNOREDAMAGESLOWDOWN //Removes the slowdown from being injured, but not from fractures, stamdamage/etc.
+			if("Bow Proficiency") //ORIGINALLY: Trait "Ignore Damage Slowdown" - Comically OP in practice, deserved removal
+				granted_trait = TRAIT_AUTO_DRAW //Automatically draws the next arrow in the weapons internal magazine, removing the need for manual cycling.
 				traitname = "...pain resistance"
 			if("Fisting Expert") //ORIGINALLY: Trait "Hard Yards" - Tribals spawn with this trait, so it was useless
 				granted_trait = TRAIT_PERFECT_ATTACKER //Makes all punches do the highet possible damage roll, where-as Iron-fist buffs the raw damage you can do.

--- a/code/modules/jobs/job_types/tribal.dm
+++ b/code/modules/jobs/job_types/tribal.dm
@@ -24,7 +24,6 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	ADD_TRAIT(H, TRAIT_HERBAL_AFFINITY,  REF(src))
 	ADD_TRAIT(H, TRAIT_TRAPPER,  REF(src))
 	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS,  REF(src))
-	ADD_TRAIT(H, TRAIT_AUTO_DRAW,  REF(src))
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, REF(src))
 	H.grant_language(/datum/language/tribal)
 	var/list/recipes = list(


### PR DESCRIPTION
## About The Pull Request
Let's be real here. On spawn permanent no-damage slowdown is ridiculous and notably OP. Has to go. And with all the traits Tribal already has access to, Auto_Draw is a trait far more fitting for the trait book than the no dam slowdown- especially with how good bows are. Not every tribal is a godly bow user in the same way not every tribal has Grognak learnt by default and is a godly melee user.

## Why It's Good For The Game
Tribals less OP. Was gonna happen eventually- and I did say I was gonna do it.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑
del: Deletes 'Fireant Rituals' (permanent no damage slowdown) from the Trait Book
remove: Removes 'AUTO_DRAW' as an on-spawn trait for all tribals
balance: Shuffles 'AUTO_DRAW' in place of Fireant Rituals in the Trait Book
🆑 