### PR TITLE
Faster Book Reading

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -9,7 +9,7 @@
 	var/oneuse = TRUE //default this is true, but admins can var this to 0 if we wanna all have a pass around of the rod form book
 	var/used = FALSE //only really matters if oneuse but it might be nice to know if someone's used it for admin investigations perhaps
 	var/select = FALSE
-	var/time_per_page = 5 SECONDS
+	var/time_per_page = 2.5 SECONDS
 
 /obj/item/book/granter/proc/turn_page(mob/user)
 	playsound(user, pick('sound/effects/pageturn1.ogg','sound/effects/pageturn2.ogg','sound/effects/pageturn3.ogg'), 30, 1)

--- a/code/modules/jobs/loadout_ingame.dm
+++ b/code/modules/jobs/loadout_ingame.dm
@@ -110,6 +110,8 @@
 	selected_datum.spawn_at(duffelkit)
 	M.dropItemToGround(token)
 	QDEL_NULL(token)
+	for (var/obj/item/book/granter/granter in duffelkit) //Auto consumes any books you spawn in with.
+		granter.on_reading_finished(M)
 	M.put_in_hands(duffelkit)
 	M.disable_loadout_select()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Halved reading times for trait/recipe books.
Books that you get from loadouts are automatically consumed now.

## Why It's Good For The Game

Having to stand still to read a recipe book adds nothing of value to the experience. It is not engaging. It does not contribute to roleplay. NO MORE.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Books that are part of loadouts are now automatically consumed.
tweak: Halved book reading time (15s to 7.5s)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
