### PR TITLE
Admins can disable Deadchat (SPEEDMERGE)

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -11,6 +11,7 @@ GLOBAL_VAR_INIT(hub_visibility, FALSE)
 GLOBAL_VAR_INIT(ooc_allowed, TRUE)	// used with admin verbs to disable ooc - not a config option apparently
 GLOBAL_VAR_INIT(looc_allowed, TRUE)
 GLOBAL_VAR_INIT(dooc_allowed, TRUE)
+GLOBAL_VAR_INIT(dsay_allowed, TRUE)
 GLOBAL_VAR_INIT(aooc_allowed, FALSE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(shuttle_frozen, FALSE)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -234,7 +234,6 @@ SUBSYSTEM_DEF(ticker)
 				current_state = GAME_STATE_FINISHED
 				toggle_ooc(TRUE) // Turn it on
 				toggle_dooc(TRUE)
-				toggle_deadchat(TRUE)
 				declare_completion(force_ending)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -234,6 +234,7 @@ SUBSYSTEM_DEF(ticker)
 				current_state = GAME_STATE_FINISHED
 				toggle_ooc(TRUE) // Turn it on
 				toggle_dooc(TRUE)
+				toggle_deadchat(TRUE)
 				declare_completion(force_ending)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -625,6 +625,16 @@
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead OOC", "[GLOB.dooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/toggledeadchat()
+	set category = "Server"
+	set desc="Toggle dis bitch"
+	set name="Toggle Deadchat"
+	toggle_deadchat()
+
+	log_admin("[key_name(usr)] toggled Deadchat.")
+	message_admins("[key_name_admin(usr)] toggled Deadchat.")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Deadchat", "[GLOB.dsay_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /datum/admins/proc/toggleaooc()
 	set category = "Server"
 	set desc="Toggle to bitch"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -29,6 +29,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
 	/datum/admins/proc/toggleooclocal,	/*toggles looc on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
+	/datum/admins/proc/toggledeadchat,  /*toggles ooc on/off for everyone who is dead*/
 	/datum/admins/proc/toggleaooc,		/*toggles antag ooc on/off*/
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/
 	/datum/admins/proc/toggleguests,	/*toggles whether guests can join the current game*/

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -98,7 +98,6 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	else
 		GLOB.looc_allowed = !GLOB.looc_allowed
 
-
 /proc/toggle_dooc(toggle = null)
 	if(toggle != null)
 		if(toggle != GLOB.dooc_allowed)
@@ -107,6 +106,16 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 			return
 	else
 		GLOB.dooc_allowed = !GLOB.dooc_allowed
+
+/proc/toggle_deadchat(toggle = null)
+	if(toggle != null) //if we're specifically en/disabling dchat
+		if(toggle != GLOB.dsay_allowed)
+			GLOB.dsay_allowed = toggle
+		else
+			return
+	else //otherwise just toggle it
+		GLOB.dsay_allowed = !GLOB.dsay_allowed
+	to_chat(world, "<B>Dead-chat has been globally [GLOB.dsay_allowed ? "enabled" : "disabled"].</B>")
 
 /client/proc/set_ooc(newColor as color)
 	set name = "Set Player OOC Color"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -170,6 +170,10 @@
 			to_chat(src, "<span class='danger'>You cannot talk in deadchat (muted).</span>")
 			return
 
+		if(!GLOB.dsay_allowed)
+			to_chat(src, "<span class='danger'>Deadchat globally muted.</span>")
+			return
+
 		if(src.client.handle_spam_prevention(message,MUTE_DEADCHAT))
 			return
 


### PR DESCRIPTION
## About The Pull Request
Does as it says on the tin.

## Why It's Good For The Game
Admins can obliterate any and all dchat toxicity instantly. By straight up disabling the method through which it's conveyed.
![image](https://github.com/f13babylon/f13babylon/assets/76122712/13753954-63fc-4eed-957f-e1dadd6d5711)
DSay for admins works regardless on if Dchat is enabled or not still, as is intended.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
:CL

add: Deadchat Muting
🆑 