### PR TITLE
Kebab & Mall Bunker Tweaks

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -44,6 +44,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"aaC" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "aaE" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -2871,24 +2876,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/ahs)
-"dlE" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/mob/living/simple_animal/hostile/renegade{
-	loot = list();
-	melee_damage_lower = 10;
-	melee_damage_upper = 20;
-	rapid_melee = 2;
-	health = 300;
-	maxHealth = 300;
-	armour_penetration = 0.3
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "dmB" = (
 /obj/structure/chair/f13foldupchair,
 /obj/machinery/light{
@@ -3492,18 +3479,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dVk" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/mob/living/simple_animal/hostile/renegade{
-	loot = list();
-	melee_damage_lower = 10;
-	melee_damage_upper = 20;
-	rapid_melee = 2;
-	health = 300;
-	maxHealth = 300;
-	armour_penetration = 0.3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "dVs" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
@@ -5734,6 +5714,24 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"gwD" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/mob/living/simple_animal/hostile/renegade{
+	loot = list();
+	melee_damage_lower = 10;
+	melee_damage_upper = 20;
+	rapid_melee = 2;
+	health = 300;
+	maxHealth = 300;
+	armour_penetration = 0.3
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "gyj" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /obj/effect/decal/remains/human,
@@ -6596,12 +6594,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
-"htk" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "htO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7724,6 +7716,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"iDB" = (
+/mob/living/simple_animal/hostile/renegade/defender{
+	armour_penetration = 0.6
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "iDC" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
@@ -9500,14 +9500,6 @@
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
-"kyQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/obj/item/stack/ore/blackpowder/twenty,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "kzg" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -9656,6 +9648,16 @@
 	pixel_x = 5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/bunker)
+"kEE" = (
+/mob/living/simple_animal/hostile/renegade/grunt{
+	extra_projectiles = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/bunker)
 "kEJ" = (
 /obj/item/flag/bos,
@@ -16048,6 +16050,14 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"rkQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/item/stack/ore/blackpowder/twenty,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "rkV" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -16238,6 +16248,19 @@
 	icon_state = "dirt"
 	},
 /area/f13/caves)
+"ryB" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/mob/living/simple_animal/hostile/renegade{
+	loot = list();
+	melee_damage_lower = 10;
+	melee_damage_upper = 20;
+	rapid_melee = 2;
+	health = 300;
+	maxHealth = 300;
+	armour_penetration = 0.3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ryH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16310,6 +16333,18 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/city)
+"rCb" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/engie{
+	extra_projectiles = 1;
+	environment_smash = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/bunker)
 "rCt" = (
 /obj/item/storage/backpack/duffelbag/med/surgery{
 	pixel_y = 11;
@@ -17503,14 +17538,6 @@
 	dir = 8
 	},
 /area/f13/vault)
-"sXm" = (
-/mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.6
-	},
-/turf/open/floor/f13{
-	icon_state = "freezerfloor"
-	},
-/area/f13/city)
 "sXN" = (
 /obj/item/crafting/abraxo,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
@@ -17681,11 +17708,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/underground/cave)
-"teZ" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "tfn" = (
 /obj/effect/turf_decal/caution,
 /turf/open/floor/f13/wood,
@@ -18886,6 +18908,7 @@
 "uue" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -19664,7 +19687,7 @@
 /area/f13/bunker)
 "vfR" = (
 /obj/structure/lattice,
-/turf/closed/indestructible/f13vaultrusted,
+/turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "vfZ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -28291,11 +28314,11 @@ dJD
 mKT
 kjM
 oqm
-hrZ
-hrZ
 oqm
 oqm
 oqm
+tKw
+tKw
 tPQ
 vtn
 vtn
@@ -28545,12 +28568,12 @@ oqm
 rnd
 ucH
 lwy
-ucH
+lad
 ifA
-oqm
-oqm
-oqm
-oqm
+tKw
+tKw
+tKw
+tKw
 arI
 fgN
 uUF
@@ -29063,7 +29086,7 @@ ucH
 ucH
 lwy
 tZf
-lad
+rCb
 hch
 lwy
 lwy
@@ -29470,7 +29493,7 @@ akh
 oPX
 akh
 vCf
-dVk
+ryB
 akh
 mxj
 sfc
@@ -29573,12 +29596,12 @@ oqm
 lwy
 ucH
 lwy
-lwy
+kEE
 ifA
-oqm
-oqm
-oqm
-oqm
+tKw
+tKw
+tKw
+tKw
 arI
 pMc
 pEe
@@ -29833,17 +29856,17 @@ uue
 kDc
 kjM
 oqm
-hrZ
-hrZ
 oqm
 oqm
 oqm
+tKw
+tKw
 rTj
 rYk
 ucH
 lwy
 vjd
-oqm
+tKw
 oqm
 hrZ
 hrZ
@@ -30092,7 +30115,7 @@ oqm
 hrZ
 hrZ
 hrZ
-hrZ
+oqm
 oqm
 vfR
 vfR
@@ -30509,7 +30532,7 @@ sfc
 sfc
 lOD
 hTg
-kyQ
+rkQ
 vMb
 gHL
 tGX
@@ -38712,7 +38735,7 @@ tGX
 uLm
 sfc
 sfc
-teZ
+aaC
 sfc
 sfc
 sfc
@@ -38969,7 +38992,7 @@ tGX
 tGX
 sfc
 sfc
-htk
+dVk
 sfc
 sfc
 sfc
@@ -39762,7 +39785,7 @@ pYx
 jBt
 pYx
 hEL
-sXm
+iDB
 pYx
 tGX
 tGX
@@ -41294,7 +41317,7 @@ iEs
 khx
 iEs
 gLT
-dlE
+gwD
 lOD
 pYx
 uUV

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -104,7 +104,9 @@
 "adl" = (
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -224,7 +226,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
 "ajC" = (
-/mob/living/simple_animal/hostile/renegade/engie,
+/mob/living/simple_animal/hostile/renegade/engie{
+	extra_projectiles = 1;
+	environment_smash = 4
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "akg" = (
@@ -1105,7 +1110,9 @@
 "bpH" = (
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -2208,8 +2215,7 @@
 /area/f13/city)
 "cFT" = (
 /mob/living/simple_animal/hostile/renegade/grunt{
-	extra_projectiles = 4;
-	minimum_distance = 1
+	extra_projectiles = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker)
@@ -2865,6 +2871,24 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/ahs)
+"dlE" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/mob/living/simple_animal/hostile/renegade{
+	loot = list();
+	melee_damage_lower = 10;
+	melee_damage_upper = 20;
+	rapid_melee = 2;
+	health = 300;
+	maxHealth = 300;
+	armour_penetration = 0.3
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "dmB" = (
 /obj/structure/chair/f13foldupchair,
 /obj/machinery/light{
@@ -3263,9 +3287,7 @@
 "dJD" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/item/gun/ballistic/rocketlauncher{
-	pixel_y = 9
-	},
+/obj/effect/spawner/lootdrop/f13/bomb/top_tier,
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -3470,9 +3492,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "dVk" = (
-/obj/structure/ladder/unbreakable/transition,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/mob/living/simple_animal/hostile/renegade{
+	loot = list();
+	melee_damage_lower = 10;
+	melee_damage_upper = 20;
+	rapid_melee = 2;
+	health = 300;
+	maxHealth = 300;
+	armour_penetration = 0.3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "dVs" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/tunnel{
@@ -3968,8 +3999,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/floor/f13/wood,
@@ -4037,9 +4068,10 @@
 	retreat_distance = 2;
 	check_friendly_fire = 0;
 	aggro_vision_range = 14;
-	armour_penetration = 0.5;
-	extra_projectiles = 6;
-	rapid_melee = 2
+	armour_penetration = 0.8;
+	extra_projectiles = 7;
+	rapid_melee = 2;
+	environment_smash = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -5345,18 +5377,9 @@
 /area/f13/vault)
 "fYw" = (
 /obj/structure/table,
-/obj/item/ammo_casing/caseless/rocket/hedp{
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/obj/item/ammo_casing/caseless/rocket/hedp{
-	pixel_y = -3;
-	pixel_x = -5
-	},
-/obj/item/ammo_casing/caseless/rocket/hedp{
-	pixel_y = 5;
-	pixel_x = 4
-	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -5996,8 +6019,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -6116,7 +6139,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/gun/ballistic/automatic/lmg/m1919,
+/obj/effect/spawner/lootdrop/weapons/experimental,
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -6394,6 +6417,7 @@
 /area/f13/vault)
 "hjM" = (
 /obj/structure/table/optable,
+/obj/machinery/iv_drip,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -6427,7 +6451,9 @@
 "hlY" = (
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -6570,6 +6596,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ahs)
+"htk" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "htO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7308,9 +7340,10 @@
 	retreat_distance = 2;
 	check_friendly_fire = 0;
 	aggro_vision_range = 14;
-	armour_penetration = 0.5;
-	extra_projectiles = 6;
-	rapid_melee = 2
+	armour_penetration = 0.8;
+	extra_projectiles = 7;
+	rapid_melee = 2;
+	environment_smash = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -8448,9 +8481,10 @@
 	retreat_distance = 2;
 	check_friendly_fire = 0;
 	aggro_vision_range = 14;
-	armour_penetration = 0.5;
-	extra_projectiles = 6;
-	rapid_melee = 2
+	armour_penetration = 0.8;
+	extra_projectiles = 7;
+	rapid_melee = 2;
+	environment_smash = 4
 	},
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -8606,8 +8640,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/floor/f13{
@@ -8862,7 +8896,7 @@
 "jPy" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -9281,7 +9315,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -9466,6 +9500,14 @@
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
+"kyQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/item/stack/ore/blackpowder/twenty,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "kzg" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -9527,16 +9569,16 @@
 	aggro_vision_range = 15;
 	vision_range = 15;
 	minimum_distance = 0;
-	extra_projectiles = 4;
+	extra_projectiles = 7;
 	rapid_melee = 2;
 	name = "The Boss";
 	obj_damage = 500;
 	retreat_distance = 0;
-	melee_damage_upper = 40;
-	maxHealth = 1000;
-	health = 1000;
+	melee_damage_upper = 50;
+	maxHealth = 1250;
+	health = 1250;
 	environment_smash = 4;
-	armour_penetration = 0.4
+	armour_penetration = 0.8
 	},
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -10111,7 +10153,9 @@
 /obj/machinery/hydroponics/soil/crafted,
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -10806,7 +10850,9 @@
 /area/f13/city)
 "lQG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/east,
+/obj/structure/stairs/east{
+	max_integrity = 5000
+	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
@@ -10863,7 +10909,9 @@
 	},
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -13576,9 +13624,10 @@
 	retreat_distance = 2;
 	check_friendly_fire = 0;
 	aggro_vision_range = 14;
-	armour_penetration = 0.5;
-	extra_projectiles = 6;
-	rapid_melee = 2
+	armour_penetration = 0.8;
+	extra_projectiles = 7;
+	rapid_melee = 2;
+	environment_smash = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -14246,7 +14295,9 @@
 "ptp" = (
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -15449,7 +15500,7 @@
 "qHp" = (
 /obj/structure/chair/f13foldupchair,
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -15942,8 +15993,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
@@ -16321,7 +16372,7 @@
 /area/f13/ncr)
 "rFo" = (
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -16579,7 +16630,10 @@
 /area/f13/vault)
 "rWK" = (
 /obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/renegade/engie,
+/mob/living/simple_animal/hostile/renegade/engie{
+	extra_projectiles = 1;
+	environment_smash = 4
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "rXh" = (
@@ -17219,7 +17273,6 @@
 	},
 /area/f13/ahs)
 "sGU" = (
-/obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -17450,6 +17503,14 @@
 	dir = 8
 	},
 /area/f13/vault)
+"sXm" = (
+/mob/living/simple_animal/hostile/renegade/defender{
+	armour_penetration = 0.6
+	},
+/turf/open/floor/f13{
+	icon_state = "freezerfloor"
+	},
+/area/f13/city)
 "sXN" = (
 /obj/item/crafting/abraxo,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
@@ -17575,8 +17636,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
@@ -17620,6 +17681,11 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/underground/cave)
+"teZ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "tfn" = (
 /obj/effect/turf_decal/caution,
 /turf/open/floor/f13/wood,
@@ -17850,7 +17916,9 @@
 /obj/structure/chair/bench,
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -18041,7 +18109,7 @@
 "tFv" = (
 /obj/structure/chair/office/dark,
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -18278,16 +18346,16 @@
 	aggro_vision_range = 15;
 	vision_range = 15;
 	minimum_distance = 0;
-	extra_projectiles = 4;
+	extra_projectiles = 7;
 	rapid_melee = 2;
 	name = "The Boss";
 	obj_damage = 500;
 	retreat_distance = 0;
-	melee_damage_upper = 40;
-	maxHealth = 1000;
-	health = 1000;
+	melee_damage_upper = 50;
+	maxHealth = 1250;
+	health = 1250;
 	environment_smash = 4;
-	armour_penetration = 0.4
+	armour_penetration = 0.8
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -18379,7 +18447,6 @@
 /area/f13/wasteland)
 "tZf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -18482,6 +18549,7 @@
 "ufz" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/defibrillator/primitive,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker)
 "ufL" = (
@@ -18828,6 +18896,9 @@
 /obj/structure/table,
 /obj/item/clothing/glasses/night/f13,
 /obj/item/storage/box/stockparts/deluxe,
+/obj/item/clothing/glasses/night/f13,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/part_replacer,
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -19065,7 +19136,7 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
@@ -19463,7 +19534,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -20174,6 +20245,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/autolathe,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "vMI" = (
@@ -20281,7 +20357,9 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker)
@@ -20614,6 +20692,14 @@
 /area/f13/ahs)
 "wop" = (
 /obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "wow" = (
@@ -21243,8 +21329,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/floor/f13/wood,
@@ -22037,6 +22123,10 @@
 /obj/structure/table/reinforced,
 /obj/item/defibrillator/compact/loaded,
 /obj/effect/spawner/lootdrop/f13/medical/surgical,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 11;
+	pixel_x = 3
+	},
 /turf/open/floor/f13{
 	icon_state = "freezerfloor"
 	},
@@ -29379,8 +29469,8 @@ akh
 akh
 oPX
 akh
-akh
-khx
+vCf
+dVk
 akh
 mxj
 sfc
@@ -30419,7 +30509,7 @@ sfc
 sfc
 lOD
 hTg
-vMb
+kyQ
 vMb
 gHL
 tGX
@@ -32475,7 +32565,7 @@ sfc
 mNS
 bke
 mNS
-sfc
+ajC
 uWG
 uLm
 tGX
@@ -34001,7 +34091,7 @@ mxj
 sfc
 cja
 tij
-sfc
+rFo
 cLr
 nfw
 jKU
@@ -35813,7 +35903,7 @@ leL
 lOD
 tij
 tFv
-pIZ
+wop
 wnA
 sfc
 sfc
@@ -36687,7 +36777,7 @@ oqm
 izt
 ykp
 qKO
-dVk
+oqm
 oqm
 oqm
 tKw
@@ -38622,7 +38712,7 @@ tGX
 uLm
 sfc
 sfc
-pIZ
+teZ
 sfc
 sfc
 sfc
@@ -38879,7 +38969,7 @@ tGX
 tGX
 sfc
 sfc
-pIZ
+htk
 sfc
 sfc
 sfc
@@ -39672,7 +39762,7 @@ pYx
 jBt
 pYx
 hEL
-pYx
+sXm
 pYx
 tGX
 tGX
@@ -40174,7 +40264,7 @@ bVH
 uRL
 khx
 rDA
-akh
+vCf
 vCf
 nph
 lOD
@@ -41203,8 +41293,8 @@ uRL
 iEs
 khx
 iEs
-akh
-hiB
+gLT
+dlE
 lOD
 pYx
 uUV

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -1059,7 +1059,7 @@
 /area/f13/followers)
 "aMy" = (
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
@@ -1379,7 +1379,9 @@
 "bue" = (
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -5008,8 +5010,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/floor/f13{
@@ -6044,8 +6046,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/floor/f13{
@@ -6088,7 +6090,9 @@
 "cOQ" = (
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
@@ -7111,7 +7115,9 @@
 "enC" = (
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
@@ -7803,8 +7809,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/indestructible/ground/inside/subway,
@@ -8945,7 +8951,9 @@
 /obj/structure/chair/f13foldupchair,
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
@@ -8975,7 +8983,9 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/guardian{
 	extra_projectiles = 2;
-	melee_queue_distance = 2
+	melee_queue_distance = 2;
+	armour_penetration = 0.5;
+	rapid_melee = 2
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -9489,7 +9499,7 @@
 /area/f13/building/massfusion)
 "ial" = (
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -11443,7 +11453,10 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
 "ldj" = (
-/mob/living/simple_animal/hostile/renegade/engie,
+/mob/living/simple_animal/hostile/renegade/engie{
+	extra_projectiles = 1;
+	environment_smash = 4
+	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "ldo" = (
@@ -12240,7 +12253,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -14170,9 +14183,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
-"psc" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/bunker)
 "psT" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -16095,7 +16105,10 @@
 /area/f13/tunnel/bighorn)
 "sou" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/renegade/engie,
+/mob/living/simple_animal/hostile/renegade/engie{
+	extra_projectiles = 1;
+	environment_smash = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -16785,8 +16798,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/indestructible/ground/inside/subway,
@@ -16937,8 +16950,8 @@
 	melee_damage_lower = 10;
 	melee_damage_upper = 20;
 	rapid_melee = 2;
-	health = 200;
-	maxHealth = 200;
+	health = 300;
+	maxHealth = 300;
 	armour_penetration = 0.3
 	},
 /turf/open/indestructible/ground/inside/subway,
@@ -18979,7 +18992,7 @@
 /area/f13/tunnel)
 "wJg" = (
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
@@ -19139,7 +19152,7 @@
 "wUB" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/defender{
-	armour_penetration = 0.4
+	armour_penetration = 0.6
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -28061,7 +28074,7 @@ boU
 aIk
 aMy
 aae
-aae
+aaa
 vox
 jLO
 jLO
@@ -28849,8 +28862,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aae
+aak
+aak
 aae
 aae
 aae
@@ -29105,10 +29118,10 @@ aae
 aae
 aae
 aak
-aae
-aae
 aaa
-aaa
+aae
+aak
+aak
 aae
 aae
 aae
@@ -29362,13 +29375,13 @@ aak
 aak
 aak
 aak
+aaa
+aaa
+aae
+aae
+aae
 aak
-aae
-aae
-aae
-aaa
-aaa
-aae
+aak
 aae
 aae
 aae
@@ -29612,21 +29625,21 @@ aaa
 aae
 aae
 aae
-psc
-psc
-psc
-psc
-psc
-psc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
 aae
 aae
 aak
-aae
-aae
-aae
-aae
-aaa
-aaa
+aak
 aae
 aae
 aae
@@ -29869,24 +29882,24 @@ aae
 aae
 aae
 aae
-psc
-psc
-psc
-psc
-psc
-psc
+aae
+aae
+aae
+aae
+aae
+aae
 aak
 aak
+aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aak
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aaa
-aaa
-aaa
 aae
 aae
 aae
@@ -30134,19 +30147,19 @@ dQa
 rNQ
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
 aaa
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aak
 aae
 aae
 aae
@@ -30392,19 +30405,19 @@ rNQ
 aae
 aak
 aae
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aaa
-aaa
+aak
+aak
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aak
+aak
 aae
 aae
 aae
@@ -30649,21 +30662,21 @@ rNQ
 aae
 aak
 aae
-aae
-aae
-aae
-aak
-aak
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
 aaa
-aaa
+aae
+aae
+aak
+aak
+aak
+aak
+aae
+aae
+aae
+aae
+aae
+aak
+aak
+aak
 aaa
 bFx
 aah
@@ -30906,7 +30919,7 @@ rNQ
 aae
 aae
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -31163,7 +31176,7 @@ rNQ
 aae
 aae
 aae
-aak
+aaa
 aak
 aae
 aae
@@ -31420,7 +31433,7 @@ rNQ
 aae
 aae
 aae
-aae
+aaa
 aak
 aak
 aae
@@ -31677,7 +31690,7 @@ azI
 aae
 aae
 aak
-aae
+aaa
 aak
 aak
 aak
@@ -31934,7 +31947,7 @@ rNQ
 aae
 aak
 aak
-aae
+aaa
 aak
 aak
 aak
@@ -32191,7 +32204,7 @@ rNQ
 aae
 aak
 aae
-aae
+aaa
 aak
 aak
 aae
@@ -32448,8 +32461,8 @@ qgP
 aae
 aak
 aae
-aae
-aak
+aaa
+aaa
 aak
 aae
 aak
@@ -32706,7 +32719,7 @@ aae
 aae
 aae
 aae
-aak
+aaa
 aak
 aae
 aae
@@ -32962,8 +32975,8 @@ pGr
 aae
 aak
 aae
-aae
-aak
+aaa
+aaa
 aak
 aae
 aae
@@ -33219,7 +33232,7 @@ qgP
 aae
 aak
 aae
-aae
+aaa
 aak
 aak
 aae
@@ -33476,7 +33489,7 @@ qgP
 aae
 aae
 aae
-aae
+aaa
 aak
 aak
 aae
@@ -33733,7 +33746,7 @@ aae
 aae
 aae
 aak
-aak
+aaa
 aak
 aak
 aae
@@ -33990,7 +34003,7 @@ aae
 aae
 aae
 aak
-aae
+aaa
 aak
 aak
 aae
@@ -34246,8 +34259,8 @@ aae
 aae
 aae
 aae
-aae
-aae
+aaa
+aaa
 aae
 aak
 aak
@@ -34503,7 +34516,7 @@ aae
 aae
 aae
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -34760,7 +34773,7 @@ aak
 aak
 aak
 aae
-aae
+aaa
 aak
 aae
 aae
@@ -35016,8 +35029,8 @@ aae
 aae
 aae
 aae
-aae
-aae
+aaa
+aaa
 aae
 aak
 aae
@@ -35273,7 +35286,7 @@ aae
 aak
 aak
 aae
-aae
+aaa
 aae
 aae
 aak
@@ -35530,7 +35543,7 @@ aae
 aak
 aak
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -35786,8 +35799,8 @@ aae
 aae
 aak
 aae
-aae
-aae
+aaa
+aaa
 aae
 aae
 aae
@@ -36043,7 +36056,7 @@ aae
 aae
 aak
 aae
-aae
+aaa
 aae
 aae
 aak
@@ -36300,7 +36313,7 @@ aae
 aae
 aak
 aae
-aae
+aaa
 aae
 aak
 aak
@@ -36556,8 +36569,8 @@ aae
 aae
 aae
 aak
-aak
-aae
+aaa
+aaa
 aae
 aae
 aak
@@ -36812,8 +36825,8 @@ aaa
 aae
 aae
 aae
-aae
-aak
+aaa
+aaa
 aae
 aae
 aae
@@ -37068,8 +37081,8 @@ aae
 aae
 aaa
 aae
-aae
-aae
+aaa
+aaa
 aae
 aak
 aak
@@ -38096,7 +38109,7 @@ aae
 aae
 boU
 aae
-aaB
+aae
 aae
 aaa
 aae

--- a/code/modules/fallout/themed_loot_tables.dm
+++ b/code/modules/fallout/themed_loot_tables.dm
@@ -305,7 +305,8 @@
 	loot = list(
 		/obj/item/gun/ballistic/automatic/m72 = 10,
 		/obj/item/gun/ballistic/revolver/m29/peacekeeper = 10,
-		/obj/item/encminigunpack = 10,
+		/obj/item/gun/ballistic/automatic/pistol/deagle/elcapitan = 10,
+		/obj/item/gun/energy/laser/plasma/caster = 10,
 		)
 
 


### PR DESCRIPTION
## About The Pull Request
A number of tweaks to up the difficulty of both Kebab Town and the mall bunker- while also tweaking the loot of both (albeit only slightly by removal of static spawns in place of other spawners in the latter and slight kebab additions in the former). This also changes the experimental spawner to shuffle out the gatling laser for the plascaster and El Capitan- two very stronk guns since the Gatling Laser kind of just sucked ass. Full changelog will be below.

![image](https://github.com/f13babylon/f13babylon/assets/76122712/541d4b5d-6a5d-4df9-820b-896cf1e31b49)
![image](https://github.com/f13babylon/f13babylon/assets/76122712/c720d535-f12c-401e-9999-44cbf7bca7b5)
![image](https://github.com/f13babylon/f13babylon/assets/76122712/7ff14eb4-1d02-4862-9678-d83104c2a6cd)

## Why It's Good For The Game
Bunkers? Hard. Especially these two. Now that's more clear through the edits made to both bunkers renegades (they will ruin your day). Both will still be worth the effort (and slightly more manageable now there's going to be on-site equipment you can get running in both)

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑 
add: Extra renegade soldier and prospect to both entries to Kebab
add: Extra renegade engineer to the Kebab prison
add: Extra renegade defender to Kebab bar
add: Extra renegade defender to Kebab clinic
add: Extra renegade grunt (x2) to end Meister boss room in the mall
add: Superhigh Ballistic Weapon spawner to end Meister boss room in the mall
add: Extra renegade engi next to The Boss in the mall bunker
add: Extra NVG and parts box (and an RPED) to end clinic loot
add: surgery bag in the medbay of the clinic in kebab
add: defib in the mall bunker clinic
add: basic ammo bench in the kebab armory
add: ammo spawners in both kebab and mall bunker
del: a single renegade grunt in the mall bunker (fuck this guy in specific)
fix: Upped the stair integrity to 5k in the mall bunker
tweak: Made some walls at the boss room in the mall bunker breakable
tweak: Renegade Prospect HP from 200 to 300
tweak: Renegade Engineer Extra Projectiles from 0 to 1
tweak: Renegade Engineers can now break reinforced walls
tweak: Renegade Defender melee AP from 0.4 to 0.6
tweak: Renegade Guardian melee AP from 0 to 0.5
tweak: Renegade Guardian rapidmelee from 1 to 2
tweak: Renegade Meister melee AP from 0.5 to 0.8
tweak: Renegade Meisters can now break reinforced walls
tweak: Renegade Meisters extra projectiles from 6 to 7
tweak: 'The Boss' health from 1000 to 1250
tweak: 'The Boss' melee AP from 0.4 to 0.8
tweak: 'The Boss' maximum melee damage from 40 to 50
tweak: 'The Boss' extra projectiles from 4 to 7
balance: Replaced static M1919 spawner with Experimental Weapon Spawner
balance: Replaced static rocket launcher spawner with Tier 5 Explosive Spawner
remove: Gatling Laser from the Experimental Spawner
add: El Capitan to the Experimental Spawner
add: Plasma Caster to the Experimental Spawner
🆑 