### PR TITLE
Buffs María, Pew Pew, and the Ratslayer

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -151,12 +151,11 @@
 
 //Maria									Keywords: UNIQUE, 9mm, Semi-auto, 10 round magazine. Special modifiers: fire delay -1, damage +10, penetration +0.2
 /obj/item/gun/ballistic/automatic/pistol/ninemil/maria
-	name = "Maria"
+	name = "María"
 	desc = "An ornately-decorated pre-war Browning Hi-power 9mm pistol with a pearl grip that displays a rendition of the Virgin Mary. Prone to give someone an eighteen-karat run of bad luck."
 	icon_state = "maria"
-	fire_delay = 2
 	extra_damage = 10
-	extra_penetration = 0.15
+	extra_penetration = 0.3
 
 
 //Sig Sauer P220						Keywords: 9mm, Semi-auto, 10 round magazine

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -351,6 +351,7 @@
 	desc = "A modified varmint rifle with better stopping power, a scope, and suppressor. Oh, don't forget the sick paint job."
 	icon_state = "ratslayer"
 	item_state = "ratslayer"
+	fire_delay = 3
 	suppressed = 1
 	zoomable = TRUE
 	zoom_amt = 10
@@ -358,7 +359,12 @@
 	fire_sound = 'sound/weapons/Gunshot_large_silenced.ogg'
 	extra_penetration = 0.3
 	extra_damage = 10
-	extra_speed = 800 //pew
+	extra_speed = 800
+
+/obj/item/gun/ballistic/rifle/mag/varmint/ratslayer/shoot_live_shot(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
+	..()
+	if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
+		src.pump(user)
 
 //Anti-Material Rifle						Keywords: .50, Bolt-action, 8 round magazine
 /obj/item/gun/ballistic/rifle/mag/antimateriel

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -292,6 +292,7 @@
 	name = "Pew Pew"
 	desc = "An especially modified AEP-7 pistol that seems to have been previously owned by some kind of aficionado. The focus adjustment knob on the rear of the gun has a Sunset Sarsaparilla bottle cap with a crudely drawn star attached by a screw. Underneath the bottle cap are the words 'HAD IT COMING' etched into the casing."
 	icon_state = "pewpew"
+	fire_delay = 5
 	weapon_weight = WEAPON_LIGHT
 	slowdown = 0.05
 	equipsound = 'sound/f13weapons/equipsounds/aer14equip.ogg'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -361,10 +361,11 @@
 	impact_type = /obj/effect/projectile/impact/laser
 
 /obj/item/projectile/beam/laser/pistol/hitscan/pewpew
-	name = "overtuned laser beam"
-	damage = 35
-	bare_wound_bonus = 25
-	armour_penetration = 0.45
+	name = "PEW!"
+	damage = 50
+	armour_penetration = 0.5
+	wound_bonus = 10
+	bare_wound_bonus = 12 //AEP7 x 2
 	tracer_type = /obj/effect/projectile/tracer/pulse
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
 	impact_type = /obj/effect/projectile/impact/pulse


### PR DESCRIPTION
### The Why
These three weapons, all unique, are genuinely, unironically, without a shadow of a doubt, just kind of poopoo caca. You usually have to force people to pick them up, and they hog unique loot pools so they should be in accordance to their rarity.

### María
Name changed from "Maria" to "María".
Armor penetration **upped to 30%**, from 15%. - Take note of 9mm's damage dropoff variable.
Removed redundant fire_delay var as it's inherited from pistol/ninemil

### Pew Pew
Damage **upped to 50**, from 35.
Armor penetration **upped to 50%** from 45%
Added **10** wound bonus. 
Made bare wound bonus 12 (twice the value of the AEP7) **instead** of 25
Firing delay **decreased to 5** (From 4)

### Ratslayer
Firing delay **increased to 3** from 4 (Because it was slower than the craftable variant somehow)
The "Neo-Russian Rifleman's Primer" book now affects the Ratslayer, making it the second gun that can be turned semi-automatic with the book - next to the AMR.

### The Raw Numbers
María will deal 18 ₍₁₇.₈₁₎ damage to someone wearing Reinforced Combat Armor at point-blank range. This value decreases with distance.

Pew Pew will deal 39 ₍₃₈.₇₅₎ damage to someone wearing Reinforced Combat Armor.