### PR TITLE
New! ENCLAVE Radium free instant coffee, cocoa, and tea! Buy now!

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -882,12 +882,22 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/item/reagent_containers/food/drinks/bottle/instacoffee{
-	pixel_x = -8
-	},
 /obj/item/crafting/coffee_pot{
 	pixel_x = 9;
 	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee/enclave{
+	step_x = -10;
+	step_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instacocoa/enclave{
+	step_x = -10;
+	step_y = -6;
+	layer = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/instatea/enclave{
+	step_x = -10;
+	step_y = 2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/enclave/mess)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -450,6 +450,12 @@
 	icon_state = "instatea"
 	list_reagents = list(/datum/reagent/toxin/teapowder = 98, /datum/reagent/radium = 2)
 
+/obj/item/reagent_containers/food/drinks/bottle/instatea/enclave
+	name = "Silician Instatea"
+	desc = "Pre-war powerdered canned tea powder, marked 'SAFE FOR CONSUMPTION', with an Enclave seal on the top."
+	icon_state = "instatea"
+	list_reagents = list(/datum/reagent/toxin/teapowder = 100)
+
 /obj/item/reagent_containers/food/drinks/soda_cans/cream
 	name = "canned cream"
 	desc = "It's a can of cream. Made from milk. What else did you think you'd find in there?"
@@ -466,11 +472,23 @@
 	icon_state = "instachoc"
 	list_reagents = list(/datum/reagent/consumable/coco = 98, /datum/reagent/radium = 2)
 
+/obj/item/reagent_containers/food/drinks/bottle/instacocoa/enclave
+	name = "Silician Instacocoa"
+	desc = "Pre-war powerdered canned dried chocolate mix, marked 'SAFE FOR CONSUMPTION', with an Enclave seal on the top."
+	icon_state = "instachoc"
+	list_reagents = list(/datum/reagent/consumable/coco = 100)
+
 /obj/item/reagent_containers/food/drinks/bottle/instacoffee
 	name = "Silician Instacoffee"
 	desc = "Pre-war powerdered canned coffee."
 	icon_state = "instacoffee"
 	list_reagents = list(/datum/reagent/toxin/coffeepowder = 98, /datum/reagent/radium = 2)
+
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee/enclave
+	name = "Silician Instacoffee"
+	desc = "Pre-war powerdered canned coffee, marked 'SAFE FOR CONSUMPTION', with an Enclave seal on the top."
+	icon_state = "instacoffee"
+	list_reagents = list(/datum/reagent/toxin/coffeepowder = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/vim
 	name = "Vim"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Subtyped the canned coffee, tea, and cocoa, because I noticed the can of instant coffee in the enclave bunker had radium in it when I made my instant coffee.

## Why It's Good For The Game

The Enclave wouldn't want their personnel eating irradiated food, it's very bad for you!

## Pre-Merge Checklist
- [ x ] You tested this on a local server.
- [ x ] This code did not runtime during testing.
- [ x ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Subtyped the instant coffee, cocoa, and tea with an Enclave variant that is radium free.
tweak: Replaced the instant coffee in the Enclave bunker kitchen with the radium free variant, added a tin each of the radium free instant tea and cocoa as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
