### PR TITLE
Enclave LT & NCR Captain Gunswap

### DIFF
--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -194,10 +194,10 @@
 
 /datum/outfit/loadout/lt_frontline
 	name = "Frontline Commanding Officer"
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/deagle/elcapitan
+	suit_store = /obj/item/gun/ballistic/revolver/m29/peacekeeper
 	suit = /obj/item/clothing/suit/armor/f13/usmcriot
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m14mm  = 3
+		/obj/item/ammo_box/m44box = 2,
 	)
 
 // Gunnery Sergeant

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -204,9 +204,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/outfit/loadout/ncrcptmelee
 	name = "Backline Support"
 	suit = /obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer/captain/coat
-	suit_store = /obj/item/gun/ballistic/revolver/m29/peacekeeper
+	suit_store = /obj/item/gun/ballistic/automatic/pistol/deagle/elcapitan
 	backpack_contents = list(
-		/obj/item/ammo_box/m44box = 2,
+		/obj/item/ammo_box/magazine/m14mm = 3,
 	)
 
 /datum/outfit/loadout/ncrcptshotgun

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -259,10 +259,10 @@
 	extra_damage = 23 //for a combined total of 55 damage, as good as the 14mm pistol and plasma pistol.
 	fire_delay = 4 //it should still fire slow but not too slow
 
-//Peacekeeper					 Keywords: OASIS, .44, Double action, 6 rounds cylinder, Extra Firemode
+//Peacekeeper					 Keywords: Experimental, .44, Double action, 6 rounds cylinder
 /obj/item/gun/ballistic/revolver/m29/peacekeeper
 	name = "Peacekeeper"
-	desc = "When you don't just need excessive force, but crave it. This .44 has a special hammer mechanism, allowing for measured powerful shots, or fanning for a flurry of inaccurate shots."
+	desc = "When you don't just need excessive force, but crave it. This .44 has a special hammer mechanism, allowing for consistent fanning for a flurry of inaccurate shots."
 	item_state = "m29peace"
 	icon_state = "mysterious_m29"
 	icon = 'icons/obj/guns/gunfruits2022/pistols.dmi'


### PR DESCRIPTION
## About The Pull Request
Got asked by Downpour to swap these two guns around- which I'm perfectly fine with. I also fixed the Peacekeepers description while I was at it. Enclave LT now gets the based revolver instead of the 14mm, and the Captain gets the epic Capitan instead of the rapid revolver of doom.

## Why It's Good For The Game
Slightly more fitting weapons for the big leader goons. Especially given El Capitan is implied to be a gunrunner mod in it's description.

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
🆑
tweak: Swaps Peacekeeper and El Capitan to Enclave LT and NCR Captain respectively.
fix: Fixes outdated Peacekeeper description and tags
🆑 