### PR TITLE
Enclave Armor Typo and description fix.

### DIFF
--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -207,7 +207,7 @@
 
 /obj/item/clothing/head/helmet/f13/combat/mk2/enclave
 	name = "old United States Marine Corp helmet"
-	desc = "An advanced model of combat helmet worn by marines aboard the USS Democracy, second only to power armor in protection used by the USCM For various tasks and operations, it's handled the nuclear wasteland somewhat better than the rest of the armors you've seen."
+	desc = "An advanced model of combat helmet worn by Marines aboard naval ships, second only to power armor in protection used by the USCM For various tasks and operations, it's handled the nuclear wasteland somewhat better than the rest of the armors you've seen."
 	icon_state = "enclave_marine"
 	item_state = "enclave_marine"
 	armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 20, "bomb" = 25, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 25)

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -838,7 +838,7 @@
 	mutantrace_variation = NONE
 
 /obj/item/clothing/suit/armor/f13/combat/mk2/enclave	//Technically it's own armor, but for balance simplicity, it's RCA
-	name = "old United States Marine Corp Armor"
+	name = "old United States Marine Corps Armor"
 	desc = "An advanced model of combat armor worn by marines aboard the USS Democracy, second only to power armor in protection used by the USMC For various tasks and operations, it's handled the nuclear wasteland somewhat better than the rest of the armors you've seen."
 	icon_state = "enclave_marine"
 	item_state = "enclave_marine"
@@ -846,7 +846,7 @@
 	mutantrace_variation = NONE
 
 /obj/item/clothing/suit/armor/f13/usmcriot
-	name = "old United States Marine Corp riot suit"
+	name = "old United States Marine Corps riot suit"
 	desc = "A pre-war riot suit used by the USCM For various tasks and operations, it's handled the nuclear wasteland somewhat better than the rest of the armors you've seen."
 	icon_state = "usmc_riot_gear"
 	item_state = "usmc_riot_gear"


### PR DESCRIPTION
## About The Pull Request

This PR fixes some capitalization issues and the Marine Corps armor being called the Marine Corp armor, also edits the description to allude more to the Marine Armor being widespread, despite it only being found in the farharbor DLC on the USS Democracy, it's assumedly standard issue at the time of the great war.

## Why It's Good For The Game

Typos bad + accuracy

## Pre-Merge Checklist
- [ ] You documented all of your changes.


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:LynxSolstice
tweak: Fixed some typos, re-desc'd the Marine armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
