### PR TITLE
ncr coat thing

### DIFF
--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -698,11 +698,7 @@
 	armor = list("melee" = 30, "bullet" = 45, "laser" = 35, "energy" = 15, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 0, "wound" = 40)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 8)
 
-/obj/item/clothing/head/helmet/f13/ncr/officer/captain				//NCR Captain cap
-	name = "\improper NCR officer peaked cap"
-	desc = "A tan peaked cap with a silver pin, worn by high-ranking officers of the NCRA."
-	icon_state = "ncr_dresscap"
-	item_state = "ncr_dresscap"
+/obj/item/clothing/head/helmet/f13/ncr/officer/captain				//NCR Captain beret
 	armor = list("melee" = 35, "bullet" = 50, "laser" = 40, "energy" = 20, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 0, "wound" = 45)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 10)
 

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -483,19 +483,17 @@
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 8)
 	slowdown = 0.14
 
-/obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer/captain				//NCR Captain Armor, Frontline loadout
+/obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer/captain				//NCR Captain Armor
 	name = "\improper NCR reinforced officer mantle vest"
 	desc = "A standard issue NCR infantry vest reinforced with a groinpad and a mantle. Additional plating was added to protect the shoulders and arms. Intended for use by high ranking officers of the NCRA."
 	icon_state = "ncr_captain_armour"
 	item_state = "ncr_captain_armour"
 	armor = list("melee" = 35, "bullet" = 50, "laser" = 40, "energy" = 20, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 0, "wound" = 45)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 10)
-
-/obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer/captain/coat		//NCR Captain Armor, Backline loadout
-	name = "\improper NCR officer greatcoat"
-	desc = "A special issue NCR officer's greatcoat with heavy ballistic padding sewn-in for protection."
-	icon_state = "ncr_officer_coat"
-	item_state = "ncr_officer_coat"
+	unique_reskin = list(
+		"M1" = "ncr_captain_armour",
+		"M2" = "ncr_officer_coat",
+	)
 
 /obj/item/clothing/suit/armor/f13/combat/ncr
 	name = "\improper NCR combat armor"

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -179,6 +179,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	jobtype = /datum/job/ncr/f13captain
 	id = /obj/item/card/id/dogtag/ncrcaptain
 	uniform	= /obj/item/clothing/under/f13/ncr/ncr_officer
+	suit = /obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer/captain
 	head = /obj/item/clothing/head/helmet/f13/ncr/officer/captain
 	ears = /obj/item/radio/headset/headset_ncr/command
 	glasses = /obj/item/clothing/glasses/night/ncr
@@ -203,7 +204,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/loadout/ncrcptmelee
 	name = "Backline Support"
-	suit = /obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer/captain/coat
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/deagle/elcapitan
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m14mm = 3,
@@ -211,7 +211,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/loadout/ncrcptshotgun
 	name = "Frontliner"
-	suit = /obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer/captain
 	suit_store = /obj/item/gun/ballistic/automatic/shotgun/pancor
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/d12g = 3,


### PR DESCRIPTION
## About The Pull Request
Apparently Lamas' github stopped working or something so I'm putting this up for him. It makes the NCR captain headgear the beret rather than the dresscap for drip and makes it so you can pick if you want the coat or armor normally rather than by loadout.

![image](https://github.com/f13babylon/f13babylon/assets/76122712/3b6589f1-9d1a-4a88-8ce0-ce73b49213af)

## Why It's Good For The Game
Drip

## Pre-Merge Checklist
- [ Y ] You tested this on a local server.
- [ Y ] This code did not runtime during testing.
- [ Y ] You documented all of your changes.

## Changelog
tweak: Captain Armor can be sprite-swapped for drip
tweak: Captain Headgear is the cool beret sprite